### PR TITLE
ci: Improve CI pipeline performance

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
             folder: "operator/"
           - name: "scheduler"
             folder: "scheduler/"
-            # Nothing to test in functions-runtime
+            # Nothing to compile in functions-runtime
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,47 +55,6 @@ jobs:
         run:
           echo "NON_FORKED_AND_NON_ROBOT_RUN=$NON_FORKED_AND_NON_ROBOT_RUN" >> "$GITHUB_OUTPUT"
 
-  compile:
-    name: Compile
-    needs: prepare_ci_run
-    runs-on: ubuntu-22.04
-    env:
-      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
-      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-    strategy:
-      matrix:
-        config:
-          - name: "keptn-lifecycle-operator"
-            folder: "operator/"
-          - name: "scheduler"
-            folder: "scheduler/"
-            # Nothing to compile in functions-runtime
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-          cache-dependency-path: '${{ matrix.config.folder }}go.sum'
-
-      - name: Go vet
-        if: matrix.config.name != 'functions-runtime'
-        working-directory: ./${{ matrix.config.folder }}
-        run: go vet ./...
-
-      - name: Go fmt
-        if: matrix.config.name != 'functions-runtime'
-        working-directory: ./${{ matrix.config.folder }}
-        run: go fmt ./...
-
-      - name: Compile ${{ matrix.config.name }}
-        working-directory: ./${{ matrix.config.folder }}
-        run: make build
-
   test:
     name: Unit Tests
     needs: prepare_ci_run
@@ -119,6 +78,18 @@ jobs:
           cache: true
           cache-dependency-path: '${{ matrix.config.folder }}go.sum'
 
+      - name: Go vet
+        working-directory: ./${{ matrix.config.folder }}
+        run: go vet ./...
+
+      - name: Go fmt
+        working-directory: ./${{ matrix.config.folder }}
+        run: go fmt ./...
+
+      - name: Compile ${{ matrix.config.name }}
+        working-directory: ./${{ matrix.config.folder }}
+        run: make build
+
       - name: Test ${{ matrix.config.name }}
         working-directory: ./${{ matrix.config.folder }}
         run: |
@@ -126,7 +97,7 @@ jobs:
 
   build_image:
     name: Build and push Docker Image
-    needs: [ prepare_ci_run, compile, test ]
+    needs: [ prepare_ci_run, test ]
     runs-on: ubuntu-22.04
     permissions:
       packages: write # Needed for pushing images to the registry

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -78,6 +78,14 @@ jobs:
           cache: true
           cache-dependency-path: '${{ matrix.config.folder }}go.sum'
 
+      - name: Go vet
+        working-directory: ./${{ matrix.config.folder }}
+        run: go vet ./...
+
+      - name: Go fmt
+        working-directory: ./${{ matrix.config.folder }}
+        run: go fmt ./...
+
       - name: Compile ${{ matrix.config.name }}
         working-directory: ./${{ matrix.config.folder }}
         run: make build
@@ -104,14 +112,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: '${{ matrix.config.folder }}go.sum'
-
-      - name: Go vet
-        working-directory: ./${{ matrix.config.folder }}
-        run: go vet ./...
-
-      - name: Go fmt
-        working-directory: ./${{ matrix.config.folder }}
-        run: go fmt ./...
 
       - name: Test ${{ matrix.config.name }}
         working-directory: ./${{ matrix.config.folder }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,6 +55,33 @@ jobs:
         run:
           echo "NON_FORKED_AND_NON_ROBOT_RUN=$NON_FORKED_AND_NON_ROBOT_RUN" >> "$GITHUB_OUTPUT"
 
+  compile:
+    name: Compile
+    needs: prepare_ci_run
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        config:
+          - name: "keptn-lifecycle-operator"
+            folder: "operator/"
+          - name: "scheduler"
+            folder: "scheduler/"
+            # Nothing to test in functions-runtime
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+          cache-dependency-path: '${{ matrix.config.folder }}go.sum'
+
+      - name: Compile ${{ matrix.config.name }}
+        working-directory: ./${{ matrix.config.folder }}
+        run: make build
+
   test:
     name: Unit Tests
     needs: prepare_ci_run
@@ -86,10 +113,6 @@ jobs:
         working-directory: ./${{ matrix.config.folder }}
         run: go fmt ./...
 
-      - name: Compile ${{ matrix.config.name }}
-        working-directory: ./${{ matrix.config.folder }}
-        run: make build
-
       - name: Test ${{ matrix.config.name }}
         working-directory: ./${{ matrix.config.folder }}
         run: |
@@ -97,7 +120,7 @@ jobs:
 
   build_image:
     name: Build and push Docker Image
-    needs: [ prepare_ci_run, test ]
+    needs: [ prepare_ci_run, compile, test ]
     runs-on: ubuntu-22.04
     permissions:
       packages: write # Needed for pushing images to the registry

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -76,12 +76,12 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: manifests envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: generate ## Build manager binary.
 	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w -X main.gitCommit=$(HASH) -X main.buildTime=$(BUILD_TIME) -X main.buildVersion=$(TAG)' -o bin/manager main.go
 
 .PHONY: run

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -75,7 +75,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: fmt vet ## Run tests.
+test: ## Run tests.
 	go test ./... -coverprofile cover.out
 
 .PHONY: kustomize


### PR DESCRIPTION
Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>

## This PR

- improves CI pipeline performance
- removes fmt vet and generate from make test
- removes fmt and vet from make build

## Comparison

- Runtime [main](https://github.com/keptn/lifecycle-toolkit/actions/runs/3377183551) branch: 9min 11s
- Runtim [this](https://github.com/keptn/lifecycle-toolkit/actions/runs/3377371766) branch: 7min 18s