### PR TITLE
ci: Use local images for testing

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -36,13 +36,11 @@ runs:
     shell: bash
     run: |
       cd ~/download/artifacts
-      k3d image import scheduler-image.tar/scheduler-image.tar -c test-cluster
-      k3d image import keptn-lifecycle-operator-image.tar/keptn-lifecycle-operator-image.tar -c test-cluster
-      #for image in $(ls | grep image.tar);
-      #do
-      #  echo "Importing image: $image"
-      #  k3d image import $image/$image -c test-cluster
-      #done
+      for image in $(ls | grep image.tar);
+      do
+        echo "Importing image: $image"
+        k3d image import $image/$image -c test-cluster
+      done
   
   - name: Install cert-manager
     shell: bash
@@ -58,6 +56,7 @@ runs:
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5
+      docker exec k3d-test-cluster-server-0 sh -c "ctr image list -q | grep localhost"
       kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
       kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -8,10 +8,6 @@ inputs:
      required: true
      description: "Version of k3d that should be used"
      default: "v5.4.6"
-   release-registry:
-     required: true
-     description: "Registry URL for local registry"
-     default: "localhost:5000"
 runs:
   using: "composite"
   steps:
@@ -58,8 +54,9 @@ runs:
     shell: bash
     run: |
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
-      #kubectl apply -f ~/download/artifacts/scheduler-manifest-test
+      kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5
       kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
-      #kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
+      kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
+      kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -35,13 +35,12 @@ runs:
   - name: Import images in k3d
     shell: bash
     run: |
-      k3d image import ~/download/artifacts/keptn-lifecycle-operator-image.tar/keptn-lifecycle-operator-image.tar ~/download/artifacts/scheduler-image.tar/scheduler-image.tar -c test-cluster --verbose
-      #cd ~/download/artifacts
-      #for image in $(ls | grep image.tar);
-      #do
-      #  echo "Importing image: $image"
-      #  k3d image import $image/$image -c test-cluster --verbose
-      #done
+      cd ~/download/artifacts
+      for image in $(ls | grep image.tar);
+      do
+        echo "Importing image: $image"
+        k3d image import $image/$image -c test-cluster -t
+      done
   
   - name: Install cert-manager
     shell: bash

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -53,6 +53,7 @@ runs:
   - name: Install lifecycle-toolkit
     shell: bash
     run: |
+      sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -36,11 +36,13 @@ runs:
     shell: bash
     run: |
       cd ~/download/artifacts
-      for image in $(ls | grep image.tar);
-      do
-        echo "Importing image: $image"
-        k3d image import $image/$image -c test-cluster -t -k
-      done
+      k3d image import scheduler-image.tar/scheduler-image.tar -c test-cluster
+      k3d image import keptn-lifecycle-operator-image.tar/keptn-lifecycle-operator-image.tar -c test-cluster
+      #for image in $(ls | grep image.tar);
+      #do
+      #  echo "Importing image: $image"
+      #  k3d image import $image/$image -c test-cluster
+      #done
   
   - name: Install cert-manager
     shell: bash
@@ -58,6 +60,5 @@ runs:
       sleep 5
       kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
       kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
-      curl -s localhost:5000/v2/_catalog | jq
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -39,7 +39,7 @@ runs:
       for image in $(ls | grep image.tar);
       do
         echo "Importing image: $image"
-        k3d image import $image/$image -c test-cluster -t
+        k3d image import $image/$image -c test-cluster -t -k
       done
   
   - name: Install cert-manager
@@ -57,7 +57,7 @@ runs:
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5
       kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
-      #kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
+      kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
       curl -s localhost:5000/v2/_catalog | jq
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -22,7 +22,7 @@ runs:
     with:
       path: ~/download/artifacts
 
-  - name: "Create single k3d Cluster with imported Registry"
+  - name: "Create single k3d Cluster"
     uses: AbsaOSS/k3d-action@v2
     with:
       cluster-name: test-cluster
@@ -35,12 +35,13 @@ runs:
   - name: Import images in k3d
     shell: bash
     run: |
-      cd ~/download/artifacts
-      for image in $(ls | grep image.tar);
-      do
-        echo "Importing image: $image"
-        k3d image import $image/$image -c test-cluster --verbose
-      done
+      k3d image import ~/download/artifacts/keptn-lifecycle-operator-image.tar/keptn-lifecycle-operator-image.tar ~/download/artifacts/scheduler-image.tar/scheduler-image.tar
+      #cd ~/download/artifacts
+      #for image in $(ls | grep image.tar);
+      #do
+      #  echo "Importing image: $image"
+      #  k3d image import $image/$image -c test-cluster --verbose
+      #done
   
   - name: Install cert-manager
     shell: bash

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -4,6 +4,14 @@ inputs:
    cert-manager-version:
      required: true
      description: "Version of cert-manager that should be deployed"
+   k3d-version:
+     required: true
+     description: "Version of k3d that should be used"
+     default: "v5.4.6"
+   release-registry:
+     required: true
+     description: "Registry URL for local registry"
+     default: "localhost:5000"
 runs:
   using: "composite"
   steps:
@@ -19,8 +27,24 @@ runs:
     with:
       path: ~/download/artifacts
 
-  - name: Create k8s Kind Cluster
-    uses: helm/kind-action@v1.3.0
+  - name: "Create single k3d Cluster with imported Registry"
+    uses: AbsaOSS/k3d-action@v2
+    with:
+      cluster-name: test-cluster
+      args: >-
+        --agents 1
+        --no-lb
+        --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+
+  - name: Import images in k3d
+    shell: bash
+    run: |
+      cd ~/download/artifacts
+      for image in $(ls | grep image.tar);
+      do
+        echo "Importing image: $image"
+        k3d image import $image/$image -c test-cluster
+      done
   
   - name: Install cert-manager
     shell: bash
@@ -33,7 +57,9 @@ runs:
   - name: Install lifecycle-toolkit
     shell: bash
     run: |
-      kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest
-      kubectl apply -f ~/download/artifacts/scheduler-manifest
-      kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
+      kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
+      #kubectl apply -f ~/download/artifacts/scheduler-manifest-test
+      sleep 5
+      kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
+      #kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -56,7 +56,7 @@ runs:
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5
-      docker exec k3d-test-cluster-server-0 sh -c "ctr image list -q | grep localhost"
+      docker exec k3d-test-cluster-server-0 sh -c "ctr image list | grep localhost"
       kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
       kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -57,6 +57,7 @@ runs:
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5
       kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
-      kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
+      #kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
+      curl -s localhost:5000/v2/_catalog | jq
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -53,7 +53,7 @@ runs:
   - name: Install lifecycle-toolkit
     shell: bash
     run: |
-      sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test
+      sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -39,7 +39,7 @@ runs:
       for image in $(ls | grep image.tar);
       do
         echo "Importing image: $image"
-        k3d image import $image/$image -c test-cluster
+        k3d image import $image/$image -c test-cluster --verbose
       done
   
   - name: Install cert-manager

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -56,9 +56,5 @@ runs:
       sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
-      sleep 5
-      docker exec k3d-test-cluster-server-0 sh -c "ctr image list | grep localhost"
-      kubectl describe pod --selector control-plane=controller-manager -n keptn-lifecycle-toolkit-system
-      kubectl describe pod --selector component=scheduler -n keptn-lifecycle-toolkit-system
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -53,7 +53,7 @@ runs:
   - name: Install lifecycle-toolkit
     shell: bash
     run: |
-      sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/keptn-lifecycle-operator-manifest-test
+      sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       sleep 5

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -7,7 +7,6 @@ inputs:
    k3d-version:
      required: true
      description: "Version of k3d that should be used"
-     default: "v5.4.6"
 runs:
   using: "composite"
   steps:
@@ -27,6 +26,7 @@ runs:
     uses: AbsaOSS/k3d-action@v2
     with:
       cluster-name: test-cluster
+      k3d-version: ${{ inputs.k3d-version }}
       args: >-
         --agents 1
         --no-lb

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -35,7 +35,7 @@ runs:
   - name: Import images in k3d
     shell: bash
     run: |
-      k3d image import ~/download/artifacts/keptn-lifecycle-operator-image.tar/keptn-lifecycle-operator-image.tar ~/download/artifacts/scheduler-image.tar/scheduler-image.tar
+      k3d image import ~/download/artifacts/keptn-lifecycle-operator-image.tar/keptn-lifecycle-operator-image.tar ~/download/artifacts/scheduler-image.tar/scheduler-image.tar -c test-cluster --verbose
       #cd ~/download/artifacts
       #for image in $(ls | grep image.tar);
       #do

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,7 @@ env:
   CONTROLLER_TOOLS_VERSION: "v0.9.2"
   ENVTEST_K8S_VERSION: "1.24.2"
   SCHEDULER_COMPATIBLE_K8S_VERSION: "v0.24.3"
-
+  K3D_VERSION: "v5.4.1"
 defaults:
   run:
     shell: bash
@@ -172,16 +172,22 @@ jobs:
     name: Integration Tests
     needs: [ prepare_ci_run, build_image ]
     uses: ./.github/workflows/integration-test.yml
+    with:
+      k3d-version: ${{ env.K3D_VERSION }}
 
   e2e_tests:
     name: End to End Tests
     needs: [ prepare_ci_run, build_image ]
     uses: ./.github/workflows/e2e-test.yml
+    with:
+      k3d-version: ${{ env.K3D_VERSION }}
 
   performance_tests:
     name: Performance Tests
     needs: [ prepare_ci_run, build_image ]
     uses: ./.github/workflows/performance-test.yml
+    with:
+      k3d-version: ${{ env.K3D_VERSION }}
 
   upload_images:
     name: Upload images to ghcr registry

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -99,7 +99,7 @@ jobs:
       DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
       BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
       GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-      RELEASE_REGISTRY: "localhost:5000/keptn" #${{ format('localhost{0}5000', ':') }}
+      RELEASE_REGISTRY: "localhost:5000/keptn"
     strategy:
       matrix:
         config:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,14 +2,14 @@ name: CI
 on:
   # always execute docker build when something is pushed to main or a maintenance branch
   push:
-#    branches:                    DISABLED FOR TESTING
-#      - 'main'                   DISABLED FOR TESTING
-#      - '[0-9]+.[1-9][0-9]*.x'   DISABLED FOR TESTING
+    branches:
+      - 'main'
+      - '[0-9]+.[1-9][0-9]*.x'
   # in addition, execute for pull requests to those branches
   pull_request:
-#    branches:                    DISABLED FOR TESTING
-#      - 'main'                   DISABLED FOR TESTING
-#      - '[0-9]+.[1-9][0-9]*.x'   DISABLED FOR TESTING
+    branches:
+      - 'main'
+      - '[0-9]+.[1-9][0-9]*.x'
 env:
   GO_VERSION: "~1.19"
   CONTROLLER_TOOLS_VERSION: "v0.9.2"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,6 @@ env:
   CONTROLLER_TOOLS_VERSION: "v0.9.2"
   ENVTEST_K8S_VERSION: "1.24.2"
   SCHEDULER_COMPATIBLE_K8S_VERSION: "v0.24.3"
-  K3D_VERSION: "v5.4.1"
 defaults:
   run:
     shell: bash
@@ -172,22 +171,16 @@ jobs:
     name: Integration Tests
     needs: [ prepare_ci_run, build_image ]
     uses: ./.github/workflows/integration-test.yml
-    with:
-      k3d-version: ${{ env.K3D_VERSION }}
 
   e2e_tests:
     name: End to End Tests
     needs: [ prepare_ci_run, build_image ]
     uses: ./.github/workflows/e2e-test.yml
-    with:
-      k3d-version: ${{ env.K3D_VERSION }}
 
   performance_tests:
     name: Performance Tests
     needs: [ prepare_ci_run, build_image ]
     uses: ./.github/workflows/performance-test.yml
-    with:
-      k3d-version: ${{ env.K3D_VERSION }}
 
   upload_images:
     name: Upload images to ghcr registry

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -184,7 +184,7 @@ jobs:
 
   upload_images:
     name: Upload images to ghcr registry
-    needs: [prepare_ci_run, integration_tests, e2e_tests, performance_tests]
+    needs: [prepare_ci_run, test, component_tests, integration_tests, e2e_tests, performance_tests]
     if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,14 +2,14 @@ name: CI
 on:
   # always execute docker build when something is pushed to main or a maintenance branch
   push:
-    branches:
-      - 'main'
-      - '[0-9]+.[1-9][0-9]*.x'
+#    branches:                    DISABLED FOR TESTING
+#      - 'main'                   DISABLED FOR TESTING
+#      - '[0-9]+.[1-9][0-9]*.x'   DISABLED FOR TESTING
   # in addition, execute for pull requests to those branches
   pull_request:
-    branches:
-      - 'main'
-      - '[0-9]+.[1-9][0-9]*.x'
+#    branches:                    DISABLED FOR TESTING
+#      - 'main'                   DISABLED FOR TESTING
+#      - '[0-9]+.[1-9][0-9]*.x'   DISABLED FOR TESTING
 env:
   GO_VERSION: "~1.19"
   CONTROLLER_TOOLS_VERSION: "v0.9.2"
@@ -92,16 +92,15 @@ jobs:
           flags: ${{ matrix.config.name }}
 
   build_image:
-    name: Build and push Docker Image
+    name: Build Docker Image
     needs: prepare_ci_run
     runs-on: ubuntu-22.04
-    permissions:
-      packages: write # Needed for pushing images to the registry
     env:
       BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
       DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
       BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
       GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
+      RELEASE_REGISTRY: "localhost:5000/keptn" #${{ format('localhost{0}5000', ':') }}
     strategy:
       matrix:
         config:
@@ -117,24 +116,16 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        if: needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
-        uses: docker/login-action@v2
-        with:
-          registry: "ghcr.io"
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/setup-buildx-action@v2      
 
       - name: Build Docker Image
         uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.config.folder }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           target: production
           tags: |
-            ghcr.io/keptn/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
+            ${{ env.RELEASE_REGISTRY }}/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
           build-args: |
             GIT_HASH=${{ env.GIT_SHA }}
             RELEASE_VERSION=dev-${{ env.DATETIME }}
@@ -142,27 +133,34 @@ jobs:
             CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
             SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' }}
+          push: false
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
+          outputs: type=docker,dest=/tmp/${{ matrix.config.name }}-image.tar
+      
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.config.name }}-image.tar
+          path: /tmp/${{ matrix.config.name }}-image.tar
 
       - name: Install controller-gen
-        if: matrix.config.name == 'keptn-lifecycle-operator' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
+        if: matrix.config.name == 'keptn-lifecycle-operator'
         working-directory: ./${{ matrix.config.folder }}
         run: make controller-gen
 
       - name: Generate release.yaml
-        if: matrix.config.name != 'functions-runtime' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
+        if: matrix.config.name != 'functions-runtime'
         working-directory: ./${{ matrix.config.folder }}
         env:
           TAG: dev-${{ env.DATETIME }}
         run: make release-manifests
 
-      - name: Upload release.yaml
-        if: matrix.config.name != 'functions-runtime' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
+      - name: Upload release.yaml for tests
+        if: matrix.config.name != 'functions-runtime'
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.config.name }}-manifest
+          name: ${{ matrix.config.name }}-manifest-test
           path: ${{ matrix.config.folder }}/config/rendered/release.yaml
 
   component_tests:
@@ -173,17 +171,83 @@ jobs:
   integration_tests:
     name: Integration Tests
     needs: [ prepare_ci_run, build_image ]
-    if: needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
     uses: ./.github/workflows/integration-test.yml
 
   e2e_tests:
     name: End to End Tests
     needs: [ prepare_ci_run, build_image ]
-    if: needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
     uses: ./.github/workflows/e2e-test.yml
 
   performance_tests:
     name: Performance Tests
     needs: [ prepare_ci_run, build_image ]
-    if: needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
     uses: ./.github/workflows/performance-test.yml
+
+  upload_images:
+    name: Upload images to ghcr registry
+    needs: [prepare_ci_run, integration_tests, e2e_tests, performance_tests]
+    if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        config:
+          - name: "keptn-lifecycle-operator"
+            folder: "operator/"
+          - name: "scheduler"
+            folder: "scheduler/"
+          - name: "functions-runtime"
+            folder: "functions-runtime/"
+    permissions:
+      packages: write # Needed for pushing images to the registry
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: "ghcr.io"
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2  
+
+    - name: Build Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ matrix.config.folder }}
+        platforms: linux/amd64,linux/arm64
+        target: production
+        tags: |
+          ghcr.io/keptn/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
+        build-args: |
+          GIT_HASH=${{ env.GIT_SHA }}
+          RELEASE_VERSION=dev-${{ env.DATETIME }}
+          BUILD_TIME=${{ env.BUILD_TIME }}
+          CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
+          SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
+        builder: ${{ steps.buildx.outputs.name }}
+        push: true
+        cache-from: type=gha, scope=${{ github.workflow }}
+        cache-to: type=gha, scope=${{ github.workflow }}
+
+    - name: Install controller-gen
+      if: matrix.config.name == 'keptn-lifecycle-operator'
+      working-directory: ./${{ matrix.config.folder }}
+      run: make controller-gen
+
+    - name: Generate release.yaml
+      if: matrix.config.name != 'functions-runtime'
+      working-directory: ./${{ matrix.config.folder }}
+      env:
+        TAG: dev-${{ env.DATETIME }}
+      run: make release-manifests
+
+    - name: Upload release.yaml
+      if: matrix.config.name != 'functions-runtime'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.config.name }}-manifest
+        path: ${{ matrix.config.folder }}/config/rendered/release.yaml

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,7 +4,7 @@ on:
 env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
-  K3D_VERSION: "v5.4.1"
+  K3D_VERSION: "v5.4.6"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,6 +4,7 @@ on:
 env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
+  K3D_VERSION: "v5.4.1"
 defaults:
   run:
     shell: bash
@@ -27,6 +28,7 @@ jobs:
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Run E2E Tests ${{ matrix.config.name }}
         working-directory: ${{ matrix.config.folder }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,7 @@ env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
   KUTTL_VERSION: "0.13.0"
-  K3D_VERSION: "v5.4.1"
+  K3D_VERSION: "v5.4.6"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,6 @@ env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
   KUTTL_VERSION: "0.13.0"
-
 defaults:
   run:
     shell: bash
@@ -17,7 +16,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        
+
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,6 +5,7 @@ env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
   KUTTL_VERSION: "0.13.0"
+  K3D_VERSION: "v5.4.1"
 defaults:
   run:
     shell: bash
@@ -21,6 +22,7 @@ jobs:
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Download KUTTL
         run: |

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -5,6 +5,7 @@ env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
   USE_EXISTING_CLUSTER: "true"
+  K3D_VERSION: "v5.4.1"
 defaults:
   run:
     shell: bash
@@ -20,6 +21,7 @@ jobs:
       uses: ./.github/actions/deploy-klt-on-cluster
       with:
         cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
+        k3d-version: ${{ env.K3D_VERSION }}
 
     - name: Execute Performance Tests
       working-directory: operator

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -5,7 +5,7 @@ env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
   USE_EXISTING_CLUSTER: "true"
-  K3D_VERSION: "v5.4.1"
+  K3D_VERSION: "v5.4.6"
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## This PR

- builds the Docker images without pushing it to a registry for local testing.
- extracts those images to `.tar` archives and uploads them as artifacts
- downloads these images in testing stages, to import them into a local k3d cluster
- only pushes to the `ghcr` registry, if all tests have passed, and the push event occurs on a main/maintenance branch

This enables the pipeline to run all tests for PRs from forks.

Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>