### PR TITLE
fix: use correct namespace variable in delete cmd

### DIFF
--- a/examples/argo/Makefile
+++ b/examples/argo/Makefile
@@ -67,7 +67,7 @@ argo-install-podtatohead:
 
 .PHONY: uninstall
 uninstall:
-	kubectl delete -n $(ARGO_VERSION) -f https://raw.githubusercontent.com/argoproj/argo-cd/v$(ARGO_VERSION)/manifests/install.yaml --ignore-not-found=true
+	kubectl delete -n $(ARGO_NAMESPACE) -f https://raw.githubusercontent.com/argoproj/argo-cd/v$(ARGO_VERSION)/manifests/install.yaml --ignore-not-found=true
 	kubectl delete namespace $(ARGO_NAMESPACE) --ignore-not-found=true
 	@echo ""
 	@echo "##########################"


### PR DESCRIPTION
### This PR
- fixes a tiny bug in the Argo example where the argo namespace gets deleted. The wrong variable was used there.