### PR TITLE
ci: add golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           working-directory: ${{ matrix.config.folder }}
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-          args: --config ../.golangci.yml
+          args: --config ../.golangci.yml -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,31 @@
+name: golangci-lint
+on: pull_request
+env:
+  GOLANGCI_LINT_VERSION: "v1.50.1"
+  GO_VERSION: "1.19"
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "keptn-lifecycle-operator"
+            folder: "operator/"
+          - name: "scheduler"
+            folder: "scheduler/"
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          working-directory: ${{ matrix.config.folder }}
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          args: --config ../.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,9 +2,7 @@ run:
   timeout: 5m
   go: '1.19'
 output:
-  format:
-    - colored-line-number
-    - github-actions
+  format: "colored-line-number,github-actions"
 linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+run:
+  timeout: 5m
+  go: '1.19'
+linters:
+  enable:
+    - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+#    - dogsled       # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
+#    - containedctx  # containedctx is a linter that detects struct contained context.Context field
+#    - errorlint     # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+#    - gci           # Gci controls golang package import order and makes it always deterministic.
+#    - nilnil        # Checks that there is no simultaneous return of nil error and an invalid value.
+#    - noctx         # noctx finds sending http request without context.Context

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   timeout: 5m
   go: '1.19'
-output:
-  format: "colored-line-number,github-actions"
 linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 run:
   timeout: 5m
   go: '1.19'
+output:
+  format:
+    - colored-line-number
+    - github-actions
 linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification

--- a/operator/controllers/common/activemetricsobject.go
+++ b/operator/controllers/common/activemetricsobject.go
@@ -5,7 +5,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//go:generate moq -pkg fake --skip-ensure -out ./fake/activemetricsobject_mock.go . ActiveMetricsObject
+
 // ActiveMetricsObject represents an object whose active metrics are stored
 type ActiveMetricsObject interface {
 	GetActiveMetricsAttributes() []attribute.KeyValue

--- a/operator/controllers/common/activemetricsobject.go
+++ b/operator/controllers/common/activemetricsobject.go
@@ -5,8 +5,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-
-// ActiveMetricsObject represents an object whose active metrics are stored
+//go:generate moq -pkg fake --skip-ensure -out ./fake/activemetricsobject_mock.go . ActiveMetricsObject
+//ActiveMetricsObject represents an object whose active metrics are stored
 type ActiveMetricsObject interface {
 	GetActiveMetricsAttributes() []attribute.KeyValue
 	IsEndTimeSet() bool

--- a/operator/controllers/common/activemetricsobject.go
+++ b/operator/controllers/common/activemetricsobject.go
@@ -6,7 +6,7 @@ import (
 )
 
 //go:generate moq -pkg fake --skip-ensure -out ./fake/activemetricsobject_mock.go . ActiveMetricsObject
-//ActiveMetricsObject represents an object whose active metrics are stored
+// ActiveMetricsObject represents an object whose active metrics are stored
 type ActiveMetricsObject interface {
 	GetActiveMetricsAttributes() []attribute.KeyValue
 	IsEndTimeSet() bool

--- a/operator/controllers/common/activemetricsobject.go
+++ b/operator/controllers/common/activemetricsobject.go
@@ -5,8 +5,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ActiveMetricsObject represents an object whose active metrics are stored
+//
 //go:generate moq -pkg fake --skip-ensure -out ./fake/activemetricsobject_mock.go . ActiveMetricsObject
-//ActiveMetricsObject represents an object whose active metrics are stored
 type ActiveMetricsObject interface {
 	GetActiveMetricsAttributes() []attribute.KeyValue
 	IsEndTimeSet() bool

--- a/operator/controllers/common/fake/activemetricsobject_mock.go
+++ b/operator/controllers/common/fake/activemetricsobject_mock.go
@@ -10,22 +10,22 @@ import (
 
 // ActiveMetricsObjectMock is a mock implementation of common.ActiveMetricsObject.
 //
-// 	func TestSomethingThatUsesActiveMetricsObject(t *testing.T) {
+//	func TestSomethingThatUsesActiveMetricsObject(t *testing.T) {
 //
-// 		// make and configure a mocked common.ActiveMetricsObject
-// 		mockedActiveMetricsObject := &ActiveMetricsObjectMock{
-// 			GetActiveMetricsAttributesFunc: func() []attribute.KeyValue {
-// 				panic("mock out the GetActiveMetricsAttributes method")
-// 			},
-// 			IsEndTimeSetFunc: func() bool {
-// 				panic("mock out the IsEndTimeSet method")
-// 			},
-// 		}
+//		// make and configure a mocked common.ActiveMetricsObject
+//		mockedActiveMetricsObject := &ActiveMetricsObjectMock{
+//			GetActiveMetricsAttributesFunc: func() []attribute.KeyValue {
+//				panic("mock out the GetActiveMetricsAttributes method")
+//			},
+//			IsEndTimeSetFunc: func() bool {
+//				panic("mock out the IsEndTimeSet method")
+//			},
+//		}
 //
-// 		// use mockedActiveMetricsObject in code that requires common.ActiveMetricsObject
-// 		// and then make assertions.
+//		// use mockedActiveMetricsObject in code that requires common.ActiveMetricsObject
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ActiveMetricsObjectMock struct {
 	// GetActiveMetricsAttributesFunc mocks the GetActiveMetricsAttributes method.
 	GetActiveMetricsAttributesFunc func() []attribute.KeyValue
@@ -61,7 +61,8 @@ func (mock *ActiveMetricsObjectMock) GetActiveMetricsAttributes() []attribute.Ke
 
 // GetActiveMetricsAttributesCalls gets all the calls that were made to GetActiveMetricsAttributes.
 // Check the length with:
-//     len(mockedActiveMetricsObject.GetActiveMetricsAttributesCalls())
+//
+//	len(mockedActiveMetricsObject.GetActiveMetricsAttributesCalls())
 func (mock *ActiveMetricsObjectMock) GetActiveMetricsAttributesCalls() []struct {
 } {
 	var calls []struct {
@@ -87,7 +88,8 @@ func (mock *ActiveMetricsObjectMock) IsEndTimeSet() bool {
 
 // IsEndTimeSetCalls gets all the calls that were made to IsEndTimeSet.
 // Check the length with:
-//     len(mockedActiveMetricsObject.IsEndTimeSetCalls())
+//
+//	len(mockedActiveMetricsObject.IsEndTimeSetCalls())
 func (mock *ActiveMetricsObjectMock) IsEndTimeSetCalls() []struct {
 } {
 	var calls []struct {

--- a/operator/controllers/common/fake/listitem_mock.go
+++ b/operator/controllers/common/fake/listitem_mock.go
@@ -10,19 +10,19 @@ import (
 
 // ListItemMock is a mock implementation of common.ListItem.
 //
-// 	func TestSomethingThatUsesListItem(t *testing.T) {
+//	func TestSomethingThatUsesListItem(t *testing.T) {
 //
-// 		// make and configure a mocked common.ListItem
-// 		mockedListItem := &ListItemMock{
-// 			GetItemsFunc: func() []client.Object {
-// 				panic("mock out the GetItems method")
-// 			},
-// 		}
+//		// make and configure a mocked common.ListItem
+//		mockedListItem := &ListItemMock{
+//			GetItemsFunc: func() []client.Object {
+//				panic("mock out the GetItems method")
+//			},
+//		}
 //
-// 		// use mockedListItem in code that requires common.ListItem
-// 		// and then make assertions.
+//		// use mockedListItem in code that requires common.ListItem
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ListItemMock struct {
 	// GetItemsFunc mocks the GetItems method.
 	GetItemsFunc func() []client.Object
@@ -51,7 +51,8 @@ func (mock *ListItemMock) GetItems() []client.Object {
 
 // GetItemsCalls gets all the calls that were made to GetItems.
 // Check the length with:
-//     len(mockedListItem.GetItemsCalls())
+//
+//	len(mockedListItem.GetItemsCalls())
 func (mock *ListItemMock) GetItemsCalls() []struct {
 } {
 	var calls []struct {

--- a/operator/controllers/common/fake/metricsobject_mock.go
+++ b/operator/controllers/common/fake/metricsobject_mock.go
@@ -11,40 +11,40 @@ import (
 
 // MetricsObjectMock is a mock implementation of common.MetricsObject.
 //
-// 	func TestSomethingThatUsesMetricsObject(t *testing.T) {
+//	func TestSomethingThatUsesMetricsObject(t *testing.T) {
 //
-// 		// make and configure a mocked common.MetricsObject
-// 		mockedMetricsObject := &MetricsObjectMock{
-// 			GetDurationMetricsAttributesFunc: func() []attribute.KeyValue {
-// 				panic("mock out the GetDurationMetricsAttributes method")
-// 			},
-// 			GetEndTimeFunc: func() time.Time {
-// 				panic("mock out the GetEndTime method")
-// 			},
-// 			GetMetricsAttributesFunc: func() []attribute.KeyValue {
-// 				panic("mock out the GetMetricsAttributes method")
-// 			},
-// 			GetNamespaceFunc: func() string {
-// 				panic("mock out the GetNamespace method")
-// 			},
-// 			GetParentNameFunc: func() string {
-// 				panic("mock out the GetParentName method")
-// 			},
-// 			GetPreviousVersionFunc: func() string {
-// 				panic("mock out the GetPreviousVersion method")
-// 			},
-// 			GetStartTimeFunc: func() time.Time {
-// 				panic("mock out the GetStartTime method")
-// 			},
-// 			IsEndTimeSetFunc: func() bool {
-// 				panic("mock out the IsEndTimeSet method")
-// 			},
-// 		}
+//		// make and configure a mocked common.MetricsObject
+//		mockedMetricsObject := &MetricsObjectMock{
+//			GetDurationMetricsAttributesFunc: func() []attribute.KeyValue {
+//				panic("mock out the GetDurationMetricsAttributes method")
+//			},
+//			GetEndTimeFunc: func() time.Time {
+//				panic("mock out the GetEndTime method")
+//			},
+//			GetMetricsAttributesFunc: func() []attribute.KeyValue {
+//				panic("mock out the GetMetricsAttributes method")
+//			},
+//			GetNamespaceFunc: func() string {
+//				panic("mock out the GetNamespace method")
+//			},
+//			GetParentNameFunc: func() string {
+//				panic("mock out the GetParentName method")
+//			},
+//			GetPreviousVersionFunc: func() string {
+//				panic("mock out the GetPreviousVersion method")
+//			},
+//			GetStartTimeFunc: func() time.Time {
+//				panic("mock out the GetStartTime method")
+//			},
+//			IsEndTimeSetFunc: func() bool {
+//				panic("mock out the IsEndTimeSet method")
+//			},
+//		}
 //
-// 		// use mockedMetricsObject in code that requires common.MetricsObject
-// 		// and then make assertions.
+//		// use mockedMetricsObject in code that requires common.MetricsObject
+//		// and then make assertions.
 //
-// 	}
+//	}
 type MetricsObjectMock struct {
 	// GetDurationMetricsAttributesFunc mocks the GetDurationMetricsAttributes method.
 	GetDurationMetricsAttributesFunc func() []attribute.KeyValue
@@ -122,7 +122,8 @@ func (mock *MetricsObjectMock) GetDurationMetricsAttributes() []attribute.KeyVal
 
 // GetDurationMetricsAttributesCalls gets all the calls that were made to GetDurationMetricsAttributes.
 // Check the length with:
-//     len(mockedMetricsObject.GetDurationMetricsAttributesCalls())
+//
+//	len(mockedMetricsObject.GetDurationMetricsAttributesCalls())
 func (mock *MetricsObjectMock) GetDurationMetricsAttributesCalls() []struct {
 } {
 	var calls []struct {
@@ -148,7 +149,8 @@ func (mock *MetricsObjectMock) GetEndTime() time.Time {
 
 // GetEndTimeCalls gets all the calls that were made to GetEndTime.
 // Check the length with:
-//     len(mockedMetricsObject.GetEndTimeCalls())
+//
+//	len(mockedMetricsObject.GetEndTimeCalls())
 func (mock *MetricsObjectMock) GetEndTimeCalls() []struct {
 } {
 	var calls []struct {
@@ -174,7 +176,8 @@ func (mock *MetricsObjectMock) GetMetricsAttributes() []attribute.KeyValue {
 
 // GetMetricsAttributesCalls gets all the calls that were made to GetMetricsAttributes.
 // Check the length with:
-//     len(mockedMetricsObject.GetMetricsAttributesCalls())
+//
+//	len(mockedMetricsObject.GetMetricsAttributesCalls())
 func (mock *MetricsObjectMock) GetMetricsAttributesCalls() []struct {
 } {
 	var calls []struct {
@@ -200,7 +203,8 @@ func (mock *MetricsObjectMock) GetNamespace() string {
 
 // GetNamespaceCalls gets all the calls that were made to GetNamespace.
 // Check the length with:
-//     len(mockedMetricsObject.GetNamespaceCalls())
+//
+//	len(mockedMetricsObject.GetNamespaceCalls())
 func (mock *MetricsObjectMock) GetNamespaceCalls() []struct {
 } {
 	var calls []struct {
@@ -226,7 +230,8 @@ func (mock *MetricsObjectMock) GetParentName() string {
 
 // GetParentNameCalls gets all the calls that were made to GetParentName.
 // Check the length with:
-//     len(mockedMetricsObject.GetParentNameCalls())
+//
+//	len(mockedMetricsObject.GetParentNameCalls())
 func (mock *MetricsObjectMock) GetParentNameCalls() []struct {
 } {
 	var calls []struct {
@@ -252,7 +257,8 @@ func (mock *MetricsObjectMock) GetPreviousVersion() string {
 
 // GetPreviousVersionCalls gets all the calls that were made to GetPreviousVersion.
 // Check the length with:
-//     len(mockedMetricsObject.GetPreviousVersionCalls())
+//
+//	len(mockedMetricsObject.GetPreviousVersionCalls())
 func (mock *MetricsObjectMock) GetPreviousVersionCalls() []struct {
 } {
 	var calls []struct {
@@ -278,7 +284,8 @@ func (mock *MetricsObjectMock) GetStartTime() time.Time {
 
 // GetStartTimeCalls gets all the calls that were made to GetStartTime.
 // Check the length with:
-//     len(mockedMetricsObject.GetStartTimeCalls())
+//
+//	len(mockedMetricsObject.GetStartTimeCalls())
 func (mock *MetricsObjectMock) GetStartTimeCalls() []struct {
 } {
 	var calls []struct {
@@ -304,7 +311,8 @@ func (mock *MetricsObjectMock) IsEndTimeSet() bool {
 
 // IsEndTimeSetCalls gets all the calls that were made to IsEndTimeSet.
 // Check the length with:
-//     len(mockedMetricsObject.IsEndTimeSetCalls())
+//
+//	len(mockedMetricsObject.IsEndTimeSetCalls())
 func (mock *MetricsObjectMock) IsEndTimeSetCalls() []struct {
 } {
 	var calls []struct {

--- a/operator/controllers/common/fake/phaseitem_mock.go
+++ b/operator/controllers/common/fake/phaseitem_mock.go
@@ -15,100 +15,100 @@ import (
 
 // PhaseItemMock is a mock implementation of common.PhaseItem.
 //
-// 	func TestSomethingThatUsesPhaseItem(t *testing.T) {
+//	func TestSomethingThatUsesPhaseItem(t *testing.T) {
 //
-// 		// make and configure a mocked common.PhaseItem
-// 		mockedPhaseItem := &PhaseItemMock{
-// 			CancelRemainingPhasesFunc: func(phase apicommon.KeptnPhaseType)  {
-// 				panic("mock out the CancelRemainingPhases method")
-// 			},
-// 			CompleteFunc: func()  {
-// 				panic("mock out the Complete method")
-// 			},
-// 			GenerateEvaluationFunc: func(traceContextCarrier propagation.MapCarrier, evaluationDefinition string, checkType apicommon.CheckType) klcv1alpha1.KeptnEvaluation {
-// 				panic("mock out the GenerateEvaluation method")
-// 			},
-// 			GenerateTaskFunc: func(traceContextCarrier propagation.MapCarrier, taskDefinition string, checkType apicommon.CheckType) klcv1alpha1.KeptnTask {
-// 				panic("mock out the GenerateTask method")
-// 			},
-// 			GetAppNameFunc: func() string {
-// 				panic("mock out the GetAppName method")
-// 			},
-// 			GetCurrentPhaseFunc: func() string {
-// 				panic("mock out the GetCurrentPhase method")
-// 			},
-// 			GetEndTimeFunc: func() time.Time {
-// 				panic("mock out the GetEndTime method")
-// 			},
-// 			GetNamespaceFunc: func() string {
-// 				panic("mock out the GetNamespace method")
-// 			},
-// 			GetParentNameFunc: func() string {
-// 				panic("mock out the GetParentName method")
-// 			},
-// 			GetPostDeploymentEvaluationTaskStatusFunc: func() []klcv1alpha1.EvaluationStatus {
-// 				panic("mock out the GetPostDeploymentEvaluationTaskStatus method")
-// 			},
-// 			GetPostDeploymentEvaluationsFunc: func() []string {
-// 				panic("mock out the GetPostDeploymentEvaluations method")
-// 			},
-// 			GetPostDeploymentTaskStatusFunc: func() []klcv1alpha1.TaskStatus {
-// 				panic("mock out the GetPostDeploymentTaskStatus method")
-// 			},
-// 			GetPostDeploymentTasksFunc: func() []string {
-// 				panic("mock out the GetPostDeploymentTasks method")
-// 			},
-// 			GetPreDeploymentEvaluationTaskStatusFunc: func() []klcv1alpha1.EvaluationStatus {
-// 				panic("mock out the GetPreDeploymentEvaluationTaskStatus method")
-// 			},
-// 			GetPreDeploymentEvaluationsFunc: func() []string {
-// 				panic("mock out the GetPreDeploymentEvaluations method")
-// 			},
-// 			GetPreDeploymentTaskStatusFunc: func() []klcv1alpha1.TaskStatus {
-// 				panic("mock out the GetPreDeploymentTaskStatus method")
-// 			},
-// 			GetPreDeploymentTasksFunc: func() []string {
-// 				panic("mock out the GetPreDeploymentTasks method")
-// 			},
-// 			GetPreviousVersionFunc: func() string {
-// 				panic("mock out the GetPreviousVersion method")
-// 			},
-// 			GetSpanAttributesFunc: func() []attribute.KeyValue {
-// 				panic("mock out the GetSpanAttributes method")
-// 			},
-// 			GetSpanKeyFunc: func(phase string) string {
-// 				panic("mock out the GetSpanKey method")
-// 			},
-// 			GetSpanNameFunc: func(phase string) string {
-// 				panic("mock out the GetSpanName method")
-// 			},
-// 			GetStartTimeFunc: func() time.Time {
-// 				panic("mock out the GetStartTime method")
-// 			},
-// 			GetStateFunc: func() apicommon.KeptnState {
-// 				panic("mock out the GetState method")
-// 			},
-// 			GetVersionFunc: func() string {
-// 				panic("mock out the GetVersion method")
-// 			},
-// 			IsEndTimeSetFunc: func() bool {
-// 				panic("mock out the IsEndTimeSet method")
-// 			},
-// 			SetCurrentPhaseFunc: func(s string)  {
-// 				panic("mock out the SetCurrentPhase method")
-// 			},
-// 			SetSpanAttributesFunc: func(span trace.Span)  {
-// 				panic("mock out the SetSpanAttributes method")
-// 			},
-// 			SetStateFunc: func(keptnState apicommon.KeptnState)  {
-// 				panic("mock out the SetState method")
-// 			},
-// 		}
+//		// make and configure a mocked common.PhaseItem
+//		mockedPhaseItem := &PhaseItemMock{
+//			CancelRemainingPhasesFunc: func(phase apicommon.KeptnPhaseType)  {
+//				panic("mock out the CancelRemainingPhases method")
+//			},
+//			CompleteFunc: func()  {
+//				panic("mock out the Complete method")
+//			},
+//			GenerateEvaluationFunc: func(traceContextCarrier propagation.MapCarrier, evaluationDefinition string, checkType apicommon.CheckType) klcv1alpha1.KeptnEvaluation {
+//				panic("mock out the GenerateEvaluation method")
+//			},
+//			GenerateTaskFunc: func(traceContextCarrier propagation.MapCarrier, taskDefinition string, checkType apicommon.CheckType) klcv1alpha1.KeptnTask {
+//				panic("mock out the GenerateTask method")
+//			},
+//			GetAppNameFunc: func() string {
+//				panic("mock out the GetAppName method")
+//			},
+//			GetCurrentPhaseFunc: func() string {
+//				panic("mock out the GetCurrentPhase method")
+//			},
+//			GetEndTimeFunc: func() time.Time {
+//				panic("mock out the GetEndTime method")
+//			},
+//			GetNamespaceFunc: func() string {
+//				panic("mock out the GetNamespace method")
+//			},
+//			GetParentNameFunc: func() string {
+//				panic("mock out the GetParentName method")
+//			},
+//			GetPostDeploymentEvaluationTaskStatusFunc: func() []klcv1alpha1.EvaluationStatus {
+//				panic("mock out the GetPostDeploymentEvaluationTaskStatus method")
+//			},
+//			GetPostDeploymentEvaluationsFunc: func() []string {
+//				panic("mock out the GetPostDeploymentEvaluations method")
+//			},
+//			GetPostDeploymentTaskStatusFunc: func() []klcv1alpha1.TaskStatus {
+//				panic("mock out the GetPostDeploymentTaskStatus method")
+//			},
+//			GetPostDeploymentTasksFunc: func() []string {
+//				panic("mock out the GetPostDeploymentTasks method")
+//			},
+//			GetPreDeploymentEvaluationTaskStatusFunc: func() []klcv1alpha1.EvaluationStatus {
+//				panic("mock out the GetPreDeploymentEvaluationTaskStatus method")
+//			},
+//			GetPreDeploymentEvaluationsFunc: func() []string {
+//				panic("mock out the GetPreDeploymentEvaluations method")
+//			},
+//			GetPreDeploymentTaskStatusFunc: func() []klcv1alpha1.TaskStatus {
+//				panic("mock out the GetPreDeploymentTaskStatus method")
+//			},
+//			GetPreDeploymentTasksFunc: func() []string {
+//				panic("mock out the GetPreDeploymentTasks method")
+//			},
+//			GetPreviousVersionFunc: func() string {
+//				panic("mock out the GetPreviousVersion method")
+//			},
+//			GetSpanAttributesFunc: func() []attribute.KeyValue {
+//				panic("mock out the GetSpanAttributes method")
+//			},
+//			GetSpanKeyFunc: func(phase string) string {
+//				panic("mock out the GetSpanKey method")
+//			},
+//			GetSpanNameFunc: func(phase string) string {
+//				panic("mock out the GetSpanName method")
+//			},
+//			GetStartTimeFunc: func() time.Time {
+//				panic("mock out the GetStartTime method")
+//			},
+//			GetStateFunc: func() apicommon.KeptnState {
+//				panic("mock out the GetState method")
+//			},
+//			GetVersionFunc: func() string {
+//				panic("mock out the GetVersion method")
+//			},
+//			IsEndTimeSetFunc: func() bool {
+//				panic("mock out the IsEndTimeSet method")
+//			},
+//			SetCurrentPhaseFunc: func(s string)  {
+//				panic("mock out the SetCurrentPhase method")
+//			},
+//			SetSpanAttributesFunc: func(span trace.Span)  {
+//				panic("mock out the SetSpanAttributes method")
+//			},
+//			SetStateFunc: func(keptnState apicommon.KeptnState)  {
+//				panic("mock out the SetState method")
+//			},
+//		}
 //
-// 		// use mockedPhaseItem in code that requires common.PhaseItem
-// 		// and then make assertions.
+//		// use mockedPhaseItem in code that requires common.PhaseItem
+//		// and then make assertions.
 //
-// 	}
+//	}
 type PhaseItemMock struct {
 	// CancelRemainingPhasesFunc mocks the CancelRemainingPhases method.
 	CancelRemainingPhasesFunc func(phase apicommon.KeptnPhaseType)
@@ -353,7 +353,8 @@ func (mock *PhaseItemMock) CancelRemainingPhases(phase apicommon.KeptnPhaseType)
 
 // CancelRemainingPhasesCalls gets all the calls that were made to CancelRemainingPhases.
 // Check the length with:
-//     len(mockedPhaseItem.CancelRemainingPhasesCalls())
+//
+//	len(mockedPhaseItem.CancelRemainingPhasesCalls())
 func (mock *PhaseItemMock) CancelRemainingPhasesCalls() []struct {
 	Phase apicommon.KeptnPhaseType
 } {
@@ -381,7 +382,8 @@ func (mock *PhaseItemMock) Complete() {
 
 // CompleteCalls gets all the calls that were made to Complete.
 // Check the length with:
-//     len(mockedPhaseItem.CompleteCalls())
+//
+//	len(mockedPhaseItem.CompleteCalls())
 func (mock *PhaseItemMock) CompleteCalls() []struct {
 } {
 	var calls []struct {
@@ -414,7 +416,8 @@ func (mock *PhaseItemMock) GenerateEvaluation(traceContextCarrier propagation.Ma
 
 // GenerateEvaluationCalls gets all the calls that were made to GenerateEvaluation.
 // Check the length with:
-//     len(mockedPhaseItem.GenerateEvaluationCalls())
+//
+//	len(mockedPhaseItem.GenerateEvaluationCalls())
 func (mock *PhaseItemMock) GenerateEvaluationCalls() []struct {
 	TraceContextCarrier  propagation.MapCarrier
 	EvaluationDefinition string
@@ -453,7 +456,8 @@ func (mock *PhaseItemMock) GenerateTask(traceContextCarrier propagation.MapCarri
 
 // GenerateTaskCalls gets all the calls that were made to GenerateTask.
 // Check the length with:
-//     len(mockedPhaseItem.GenerateTaskCalls())
+//
+//	len(mockedPhaseItem.GenerateTaskCalls())
 func (mock *PhaseItemMock) GenerateTaskCalls() []struct {
 	TraceContextCarrier propagation.MapCarrier
 	TaskDefinition      string
@@ -485,7 +489,8 @@ func (mock *PhaseItemMock) GetAppName() string {
 
 // GetAppNameCalls gets all the calls that were made to GetAppName.
 // Check the length with:
-//     len(mockedPhaseItem.GetAppNameCalls())
+//
+//	len(mockedPhaseItem.GetAppNameCalls())
 func (mock *PhaseItemMock) GetAppNameCalls() []struct {
 } {
 	var calls []struct {
@@ -511,7 +516,8 @@ func (mock *PhaseItemMock) GetCurrentPhase() string {
 
 // GetCurrentPhaseCalls gets all the calls that were made to GetCurrentPhase.
 // Check the length with:
-//     len(mockedPhaseItem.GetCurrentPhaseCalls())
+//
+//	len(mockedPhaseItem.GetCurrentPhaseCalls())
 func (mock *PhaseItemMock) GetCurrentPhaseCalls() []struct {
 } {
 	var calls []struct {
@@ -537,7 +543,8 @@ func (mock *PhaseItemMock) GetEndTime() time.Time {
 
 // GetEndTimeCalls gets all the calls that were made to GetEndTime.
 // Check the length with:
-//     len(mockedPhaseItem.GetEndTimeCalls())
+//
+//	len(mockedPhaseItem.GetEndTimeCalls())
 func (mock *PhaseItemMock) GetEndTimeCalls() []struct {
 } {
 	var calls []struct {
@@ -563,7 +570,8 @@ func (mock *PhaseItemMock) GetNamespace() string {
 
 // GetNamespaceCalls gets all the calls that were made to GetNamespace.
 // Check the length with:
-//     len(mockedPhaseItem.GetNamespaceCalls())
+//
+//	len(mockedPhaseItem.GetNamespaceCalls())
 func (mock *PhaseItemMock) GetNamespaceCalls() []struct {
 } {
 	var calls []struct {
@@ -589,7 +597,8 @@ func (mock *PhaseItemMock) GetParentName() string {
 
 // GetParentNameCalls gets all the calls that were made to GetParentName.
 // Check the length with:
-//     len(mockedPhaseItem.GetParentNameCalls())
+//
+//	len(mockedPhaseItem.GetParentNameCalls())
 func (mock *PhaseItemMock) GetParentNameCalls() []struct {
 } {
 	var calls []struct {
@@ -615,7 +624,8 @@ func (mock *PhaseItemMock) GetPostDeploymentEvaluationTaskStatus() []klcv1alpha1
 
 // GetPostDeploymentEvaluationTaskStatusCalls gets all the calls that were made to GetPostDeploymentEvaluationTaskStatus.
 // Check the length with:
-//     len(mockedPhaseItem.GetPostDeploymentEvaluationTaskStatusCalls())
+//
+//	len(mockedPhaseItem.GetPostDeploymentEvaluationTaskStatusCalls())
 func (mock *PhaseItemMock) GetPostDeploymentEvaluationTaskStatusCalls() []struct {
 } {
 	var calls []struct {
@@ -641,7 +651,8 @@ func (mock *PhaseItemMock) GetPostDeploymentEvaluations() []string {
 
 // GetPostDeploymentEvaluationsCalls gets all the calls that were made to GetPostDeploymentEvaluations.
 // Check the length with:
-//     len(mockedPhaseItem.GetPostDeploymentEvaluationsCalls())
+//
+//	len(mockedPhaseItem.GetPostDeploymentEvaluationsCalls())
 func (mock *PhaseItemMock) GetPostDeploymentEvaluationsCalls() []struct {
 } {
 	var calls []struct {
@@ -667,7 +678,8 @@ func (mock *PhaseItemMock) GetPostDeploymentTaskStatus() []klcv1alpha1.TaskStatu
 
 // GetPostDeploymentTaskStatusCalls gets all the calls that were made to GetPostDeploymentTaskStatus.
 // Check the length with:
-//     len(mockedPhaseItem.GetPostDeploymentTaskStatusCalls())
+//
+//	len(mockedPhaseItem.GetPostDeploymentTaskStatusCalls())
 func (mock *PhaseItemMock) GetPostDeploymentTaskStatusCalls() []struct {
 } {
 	var calls []struct {
@@ -693,7 +705,8 @@ func (mock *PhaseItemMock) GetPostDeploymentTasks() []string {
 
 // GetPostDeploymentTasksCalls gets all the calls that were made to GetPostDeploymentTasks.
 // Check the length with:
-//     len(mockedPhaseItem.GetPostDeploymentTasksCalls())
+//
+//	len(mockedPhaseItem.GetPostDeploymentTasksCalls())
 func (mock *PhaseItemMock) GetPostDeploymentTasksCalls() []struct {
 } {
 	var calls []struct {
@@ -719,7 +732,8 @@ func (mock *PhaseItemMock) GetPreDeploymentEvaluationTaskStatus() []klcv1alpha1.
 
 // GetPreDeploymentEvaluationTaskStatusCalls gets all the calls that were made to GetPreDeploymentEvaluationTaskStatus.
 // Check the length with:
-//     len(mockedPhaseItem.GetPreDeploymentEvaluationTaskStatusCalls())
+//
+//	len(mockedPhaseItem.GetPreDeploymentEvaluationTaskStatusCalls())
 func (mock *PhaseItemMock) GetPreDeploymentEvaluationTaskStatusCalls() []struct {
 } {
 	var calls []struct {
@@ -745,7 +759,8 @@ func (mock *PhaseItemMock) GetPreDeploymentEvaluations() []string {
 
 // GetPreDeploymentEvaluationsCalls gets all the calls that were made to GetPreDeploymentEvaluations.
 // Check the length with:
-//     len(mockedPhaseItem.GetPreDeploymentEvaluationsCalls())
+//
+//	len(mockedPhaseItem.GetPreDeploymentEvaluationsCalls())
 func (mock *PhaseItemMock) GetPreDeploymentEvaluationsCalls() []struct {
 } {
 	var calls []struct {
@@ -771,7 +786,8 @@ func (mock *PhaseItemMock) GetPreDeploymentTaskStatus() []klcv1alpha1.TaskStatus
 
 // GetPreDeploymentTaskStatusCalls gets all the calls that were made to GetPreDeploymentTaskStatus.
 // Check the length with:
-//     len(mockedPhaseItem.GetPreDeploymentTaskStatusCalls())
+//
+//	len(mockedPhaseItem.GetPreDeploymentTaskStatusCalls())
 func (mock *PhaseItemMock) GetPreDeploymentTaskStatusCalls() []struct {
 } {
 	var calls []struct {
@@ -797,7 +813,8 @@ func (mock *PhaseItemMock) GetPreDeploymentTasks() []string {
 
 // GetPreDeploymentTasksCalls gets all the calls that were made to GetPreDeploymentTasks.
 // Check the length with:
-//     len(mockedPhaseItem.GetPreDeploymentTasksCalls())
+//
+//	len(mockedPhaseItem.GetPreDeploymentTasksCalls())
 func (mock *PhaseItemMock) GetPreDeploymentTasksCalls() []struct {
 } {
 	var calls []struct {
@@ -823,7 +840,8 @@ func (mock *PhaseItemMock) GetPreviousVersion() string {
 
 // GetPreviousVersionCalls gets all the calls that were made to GetPreviousVersion.
 // Check the length with:
-//     len(mockedPhaseItem.GetPreviousVersionCalls())
+//
+//	len(mockedPhaseItem.GetPreviousVersionCalls())
 func (mock *PhaseItemMock) GetPreviousVersionCalls() []struct {
 } {
 	var calls []struct {
@@ -849,7 +867,8 @@ func (mock *PhaseItemMock) GetSpanAttributes() []attribute.KeyValue {
 
 // GetSpanAttributesCalls gets all the calls that were made to GetSpanAttributes.
 // Check the length with:
-//     len(mockedPhaseItem.GetSpanAttributesCalls())
+//
+//	len(mockedPhaseItem.GetSpanAttributesCalls())
 func (mock *PhaseItemMock) GetSpanAttributesCalls() []struct {
 } {
 	var calls []struct {
@@ -878,7 +897,8 @@ func (mock *PhaseItemMock) GetSpanKey(phase string) string {
 
 // GetSpanKeyCalls gets all the calls that were made to GetSpanKey.
 // Check the length with:
-//     len(mockedPhaseItem.GetSpanKeyCalls())
+//
+//	len(mockedPhaseItem.GetSpanKeyCalls())
 func (mock *PhaseItemMock) GetSpanKeyCalls() []struct {
 	Phase string
 } {
@@ -909,7 +929,8 @@ func (mock *PhaseItemMock) GetSpanName(phase string) string {
 
 // GetSpanNameCalls gets all the calls that were made to GetSpanName.
 // Check the length with:
-//     len(mockedPhaseItem.GetSpanNameCalls())
+//
+//	len(mockedPhaseItem.GetSpanNameCalls())
 func (mock *PhaseItemMock) GetSpanNameCalls() []struct {
 	Phase string
 } {
@@ -937,7 +958,8 @@ func (mock *PhaseItemMock) GetStartTime() time.Time {
 
 // GetStartTimeCalls gets all the calls that were made to GetStartTime.
 // Check the length with:
-//     len(mockedPhaseItem.GetStartTimeCalls())
+//
+//	len(mockedPhaseItem.GetStartTimeCalls())
 func (mock *PhaseItemMock) GetStartTimeCalls() []struct {
 } {
 	var calls []struct {
@@ -963,7 +985,8 @@ func (mock *PhaseItemMock) GetState() apicommon.KeptnState {
 
 // GetStateCalls gets all the calls that were made to GetState.
 // Check the length with:
-//     len(mockedPhaseItem.GetStateCalls())
+//
+//	len(mockedPhaseItem.GetStateCalls())
 func (mock *PhaseItemMock) GetStateCalls() []struct {
 } {
 	var calls []struct {
@@ -989,7 +1012,8 @@ func (mock *PhaseItemMock) GetVersion() string {
 
 // GetVersionCalls gets all the calls that were made to GetVersion.
 // Check the length with:
-//     len(mockedPhaseItem.GetVersionCalls())
+//
+//	len(mockedPhaseItem.GetVersionCalls())
 func (mock *PhaseItemMock) GetVersionCalls() []struct {
 } {
 	var calls []struct {
@@ -1015,7 +1039,8 @@ func (mock *PhaseItemMock) IsEndTimeSet() bool {
 
 // IsEndTimeSetCalls gets all the calls that were made to IsEndTimeSet.
 // Check the length with:
-//     len(mockedPhaseItem.IsEndTimeSetCalls())
+//
+//	len(mockedPhaseItem.IsEndTimeSetCalls())
 func (mock *PhaseItemMock) IsEndTimeSetCalls() []struct {
 } {
 	var calls []struct {
@@ -1044,7 +1069,8 @@ func (mock *PhaseItemMock) SetCurrentPhase(s string) {
 
 // SetCurrentPhaseCalls gets all the calls that were made to SetCurrentPhase.
 // Check the length with:
-//     len(mockedPhaseItem.SetCurrentPhaseCalls())
+//
+//	len(mockedPhaseItem.SetCurrentPhaseCalls())
 func (mock *PhaseItemMock) SetCurrentPhaseCalls() []struct {
 	S string
 } {
@@ -1075,7 +1101,8 @@ func (mock *PhaseItemMock) SetSpanAttributes(span trace.Span) {
 
 // SetSpanAttributesCalls gets all the calls that were made to SetSpanAttributes.
 // Check the length with:
-//     len(mockedPhaseItem.SetSpanAttributesCalls())
+//
+//	len(mockedPhaseItem.SetSpanAttributesCalls())
 func (mock *PhaseItemMock) SetSpanAttributesCalls() []struct {
 	Span trace.Span
 } {
@@ -1106,7 +1133,8 @@ func (mock *PhaseItemMock) SetState(keptnState apicommon.KeptnState) {
 
 // SetStateCalls gets all the calls that were made to SetState.
 // Check the length with:
-//     len(mockedPhaseItem.SetStateCalls())
+//
+//	len(mockedPhaseItem.SetStateCalls())
 func (mock *PhaseItemMock) SetStateCalls() []struct {
 	KeptnState apicommon.KeptnState
 } {

--- a/operator/controllers/common/metrics_test.go
+++ b/operator/controllers/common/metrics_test.go
@@ -80,7 +80,7 @@ func TestMetrics_GetDeploymentDuration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			_ = lifecyclev1alpha1.AddToScheme(scheme.Scheme)
 			client := fake.NewClientBuilder().WithLists(tt.clientObjects).Build()
 			res, err := GetDeploymentDuration(context.TODO(), client, tt.list)
 			require.ErrorIs(t, err, tt.err)
@@ -176,7 +176,7 @@ func TestMetrics_GetActiveInstances(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			_ = lifecyclev1alpha1.AddToScheme(scheme.Scheme)
 			client := fake.NewClientBuilder().WithLists(tt.clientObjects).Build()
 			res, err := GetActiveInstances(context.TODO(), client, tt.list)
 			require.ErrorIs(t, err, tt.err)
@@ -383,7 +383,7 @@ func TestMetrics_GetDeploymentInterval(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			_ = lifecyclev1alpha1.AddToScheme(scheme.Scheme)
 			client := fake.NewClientBuilder().WithObjects(tt.clientObject).WithLists(tt.clientObjects).Build()
 			res, err := GetDeploymentInterval(context.TODO(), client, tt.list, tt.previous)
 			require.ErrorIs(t, err, tt.err)

--- a/operator/controllers/common/metrics_test.go
+++ b/operator/controllers/common/metrics_test.go
@@ -80,7 +80,8 @@ func TestMetrics_GetDeploymentDuration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			err := lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			require.Nil(t, err)
 			client := fake.NewClientBuilder().WithLists(tt.clientObjects).Build()
 			res, err := GetDeploymentDuration(context.TODO(), client, tt.list)
 			require.ErrorIs(t, err, tt.err)
@@ -176,7 +177,8 @@ func TestMetrics_GetActiveInstances(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			err := lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			require.Nil(t, err)
 			client := fake.NewClientBuilder().WithLists(tt.clientObjects).Build()
 			res, err := GetActiveInstances(context.TODO(), client, tt.list)
 			require.ErrorIs(t, err, tt.err)

--- a/operator/controllers/common/metrics_test.go
+++ b/operator/controllers/common/metrics_test.go
@@ -385,7 +385,8 @@ func TestMetrics_GetDeploymentInterval(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			err := lifecyclev1alpha1.AddToScheme(scheme.Scheme)
+			require.Nil(t, err)
 			client := fake.NewClientBuilder().WithObjects(tt.clientObject).WithLists(tt.clientObjects).Build()
 			res, err := GetDeploymentInterval(context.TODO(), client, tt.list, tt.previous)
 			require.ErrorIs(t, err, tt.err)

--- a/operator/controllers/common/metricsobject.go
+++ b/operator/controllers/common/metricsobject.go
@@ -7,8 +7,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// MetricsObject represents an object whose metrics are stored
+//
 //go:generate moq -pkg fake --skip-ensure -out ./fake/metricsobject_mock.go . MetricsObject
-//MetricsObject represents an object whose metrics are stored
 type MetricsObject interface {
 	GetDurationMetricsAttributes() []attribute.KeyValue
 	GetMetricsAttributes() []attribute.KeyValue

--- a/operator/controllers/common/phasehandler_test.go
+++ b/operator/controllers/common/phasehandler_test.go
@@ -337,7 +337,7 @@ func TestPhaseHandler_GetEvaluationFailureReasons(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v1alpha1.AddToScheme(scheme.Scheme)
+			_ = v1alpha1.AddToScheme(scheme.Scheme)
 			client := fake.NewClientBuilder().WithObjects(tt.clientObject).Build()
 			tt.handler.Client = client
 			result, err := tt.handler.GetEvaluationFailureReasons(context.TODO(), tt.phase, tt.object)
@@ -460,7 +460,7 @@ func TestPhaseHandler_GetTaskFailureReasons(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v1alpha1.AddToScheme(scheme.Scheme)
+			_ = v1alpha1.AddToScheme(scheme.Scheme)
 			client := fake.NewClientBuilder().WithObjects(tt.clientObject).Build()
 			tt.handler.Client = client
 			result, err := tt.handler.GetTaskFailureReasons(context.TODO(), tt.phase, tt.object)

--- a/operator/controllers/common/phasehandler_test.go
+++ b/operator/controllers/common/phasehandler_test.go
@@ -337,7 +337,8 @@ func TestPhaseHandler_GetEvaluationFailureReasons(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = v1alpha1.AddToScheme(scheme.Scheme)
+			err := v1alpha1.AddToScheme(scheme.Scheme)
+			require.Nil(t, err)
 			client := fake.NewClientBuilder().WithObjects(tt.clientObject).Build()
 			tt.handler.Client = client
 			result, err := tt.handler.GetEvaluationFailureReasons(context.TODO(), tt.phase, tt.object)
@@ -460,7 +461,8 @@ func TestPhaseHandler_GetTaskFailureReasons(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = v1alpha1.AddToScheme(scheme.Scheme)
+			err := v1alpha1.AddToScheme(scheme.Scheme)
+			require.Nil(t, err)
 			client := fake.NewClientBuilder().WithObjects(tt.clientObject).Build()
 			tt.handler.Client = client
 			result, err := tt.handler.GetTaskFailureReasons(context.TODO(), tt.phase, tt.object)

--- a/operator/controllers/common/phaseitem.go
+++ b/operator/controllers/common/phaseitem.go
@@ -12,8 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// PhaseItem represents an object which has reconcile phases
+//
 //go:generate moq -pkg fake --skip-ensure -out ./fake/phaseitem_mock.go . PhaseItem
-//PhaseItem represents an object which has reconcile phases
 type PhaseItem interface {
 	GetState() apicommon.KeptnState
 	SetState(apicommon.KeptnState)

--- a/operator/controllers/common/phaseitem_test.go
+++ b/operator/controllers/common/phaseitem_test.go
@@ -37,13 +37,11 @@ func TestPhaseItem(t *testing.T) {
 			return common.StatePending
 		},
 		SetStateFunc: func(keptnState common.KeptnState) {
-			return
 		},
 		GetCurrentPhaseFunc: func() string {
 			return "phase"
 		},
 		SetCurrentPhaseFunc: func(s string) {
-			return
 		},
 		GetVersionFunc: func() string {
 			return "version"
@@ -58,7 +56,6 @@ func TestPhaseItem(t *testing.T) {
 			return "name"
 		},
 		CompleteFunc: func() {
-			return
 		},
 		IsEndTimeSetFunc: func() bool {
 			return true
@@ -112,10 +109,8 @@ func TestPhaseItem(t *testing.T) {
 			return v1alpha1.KeptnEvaluation{}
 		},
 		SetSpanAttributesFunc: func(span trace.Span) {
-			return
 		},
 		CancelRemainingPhasesFunc: func(phase common.KeptnPhaseType) {
-			return
 		},
 	}
 

--- a/operator/controllers/keptnapp/controller_test.go
+++ b/operator/controllers/keptnapp/controller_test.go
@@ -89,9 +89,9 @@ func TestKeptnAppReconciler_reconcile(t *testing.T) {
 
 	//setting up fakeclient CRD data
 
-	utils.AddApp(r.Client, "myapp")
-	utils.AddApp(r.Client, "myfinishedapp")
-	utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StateSucceeded})
+	_ = utils.AddApp(r.Client, "myapp")
+	_ = utils.AddApp(r.Client, "myfinishedapp")
+	_ = utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StateSucceeded})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/operator/controllers/keptnapp/controller_test.go
+++ b/operator/controllers/keptnapp/controller_test.go
@@ -7,6 +7,7 @@ import (
 	utils "github.com/keptn/lifecycle-toolkit/operator/controllers/common"
 	"github.com/keptn/lifecycle-toolkit/operator/controllers/common/fake"
 	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -89,9 +90,12 @@ func TestKeptnAppReconciler_reconcile(t *testing.T) {
 
 	//setting up fakeclient CRD data
 
-	_ = utils.AddApp(r.Client, "myapp")
-	_ = utils.AddApp(r.Client, "myfinishedapp")
-	_ = utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StateSucceeded})
+	err := utils.AddApp(r.Client, "myapp")
+	require.Nil(t, err)
+	err = utils.AddApp(r.Client, "myfinishedapp")
+	require.Nil(t, err)
+	err = utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StateSucceeded})
+	require.Nil(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/operator/controllers/keptnappversion/controller_test.go
+++ b/operator/controllers/keptnappversion/controller_test.go
@@ -8,6 +8,8 @@ import (
 	utils "github.com/keptn/lifecycle-toolkit/operator/controllers/common"
 	"github.com/keptn/lifecycle-toolkit/operator/controllers/common/fake"
 	"github.com/magiconair/properties/assert"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -19,6 +21,9 @@ import (
 	"strings"
 	"testing"
 )
+
+type contextID string
+const CONTEXTID contextID = "start"
 
 // this test checks if the chain of reconcile events is correct
 func TestKeptnAppVersionReconciler_reconcile(t *testing.T) {
@@ -78,14 +83,14 @@ func TestKeptnAppVersionReconciler_reconcile(t *testing.T) {
 
 	//setting up fakeclient CRD data
 
-	utils.AddAppVersion(r.Client, "default", "myappversion", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StatePending})
-	utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, createFinishedAppVersionStatus())
+	_ = utils.AddAppVersion(r.Client, "default", "myappversion", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StatePending})
+	_ = utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, createFinishedAppVersionStatus())
 
 	traces := 0
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			_, err := r.Reconcile(context.WithValue(context.TODO(), "start", tt.req.Name), tt.req)
+			_, err := r.Reconcile(context.WithValue(context.TODO(), CONTEXTID, tt.req.Name), tt.req)
 			if !reflect.DeepEqual(err, tt.wantErr) {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -97,11 +102,12 @@ func TestKeptnAppVersionReconciler_reconcile(t *testing.T) {
 					assert.Equal(t, strings.Contains(event, tt.req.Namespace), true, "wrong namespace")
 					assert.Equal(t, strings.Contains(event, e), true, fmt.Sprintf("no %s found in %s", e, event))
 				}
+
 			}
 			if tt.startTrace {
 				//A different trace for each app-version
 				assert.Equal(t, tracer.StartCalls()[traces].SpanName, "reconcile_app_version")
-				assert.Equal(t, tracer.StartCalls()[traces].Ctx.Value("start"), tt.req.Name)
+				assert.Equal(t, tracer.StartCalls()[traces].Ctx.Value(CONTEXTID), tt.req.Name)
 				traces++
 			}
 		})
@@ -180,10 +186,10 @@ func TestKeptnApVersionReconciler_setupSpansContexts(t *testing.T) {
 	}{
 		{name: "Current trace ctx should be != than app trace context",
 			args: args{
-				ctx:        context.WithValue(context.TODO(), "start", 1),
+				ctx:        context.WithValue(context.TODO(), CONTEXTID, 1),
 				appVersion: &lfcv1alpha1.KeptnAppVersion{},
 			},
-			baseCtx: context.WithValue(context.TODO(), "start", 1),
+			baseCtx: context.WithValue(context.TODO(), CONTEXTID, 1),
 			appCtx:  context.TODO(),
 		},
 	}

--- a/operator/controllers/keptnappversion/controller_test.go
+++ b/operator/controllers/keptnappversion/controller_test.go
@@ -8,6 +8,7 @@ import (
 	utils "github.com/keptn/lifecycle-toolkit/operator/controllers/common"
 	"github.com/keptn/lifecycle-toolkit/operator/controllers/common/fake"
 	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -82,8 +83,10 @@ func TestKeptnAppVersionReconciler_reconcile(t *testing.T) {
 
 	//setting up fakeclient CRD data
 
-	_ = utils.AddAppVersion(r.Client, "default", "myappversion", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StatePending})
-	_ = utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, createFinishedAppVersionStatus())
+	err := utils.AddAppVersion(r.Client, "default", "myappversion", "1.0.0", nil, lfcv1alpha1.KeptnAppVersionStatus{Status: keptncommon.StatePending})
+	require.Nil(t, err)
+	err = utils.AddAppVersion(r.Client, "default", "myfinishedapp", "1.0.0", nil, createFinishedAppVersionStatus())
+	require.Nil(t, err)
 
 	traces := 0
 	for _, tt := range tests {

--- a/operator/controllers/keptnappversion/controller_test.go
+++ b/operator/controllers/keptnappversion/controller_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 type contextID string
+
 const CONTEXTID contextID = "start"
 
 // this test checks if the chain of reconcile events is correct

--- a/operator/controllers/keptnappversion/controller_test.go
+++ b/operator/controllers/keptnappversion/controller_test.go
@@ -8,8 +8,6 @@ import (
 	utils "github.com/keptn/lifecycle-toolkit/operator/controllers/common"
 	"github.com/keptn/lifecycle-toolkit/operator/controllers/common/fake"
 	"github.com/magiconair/properties/assert"
-	"go.opentelemetry.io/otel/metric/instrument"
-	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/operator/controllers/keptnevaluation/controller.go
+++ b/operator/controllers/keptnevaluation/controller.go
@@ -101,7 +101,7 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err := controllercommon.ErrRetryCountExceeded
 		span.SetStatus(codes.Error, err.Error())
 		evaluation.Status.OverallStatus = common.StateFailed
-		r.updateFinishedEvaluationMetrics(ctx, evaluation, span)
+		_ = r.updateFinishedEvaluationMetrics(ctx, evaluation, span)
 		return ctrl.Result{}, nil
 	}
 
@@ -237,7 +237,7 @@ func (r *KeptnEvaluationReconciler) queryEvaluation(objective klcv1alpha1.Object
 	queryTime := time.Now().UTC()
 	r.Log.Info("Running query: /api/v1/query?query=" + objective.Query + "&time=" + queryTime.String())
 
-	client, err := promapi.NewClient(promapi.Config{Address: provider.Spec.TargetServer, Client: &http.Client{}})
+	client, _ := promapi.NewClient(promapi.Config{Address: provider.Spec.TargetServer, Client: &http.Client{}})
 	api := prometheus.NewAPI(client)
 	result, w, err := api.Query(
 		context.Background(),

--- a/operator/controllers/keptnevaluation/controller.go
+++ b/operator/controllers/keptnevaluation/controller.go
@@ -101,7 +101,10 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err := controllercommon.ErrRetryCountExceeded
 		span.SetStatus(codes.Error, err.Error())
 		evaluation.Status.OverallStatus = common.StateFailed
-		_ = r.updateFinishedEvaluationMetrics(ctx, evaluation, span)
+		err2 := r.updateFinishedEvaluationMetrics(ctx, evaluation, span)
+		if err2 != nil {
+			r.Log.Error(err2, "failed to update finished evaluation metrics")
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -237,7 +240,11 @@ func (r *KeptnEvaluationReconciler) queryEvaluation(objective klcv1alpha1.Object
 	queryTime := time.Now().UTC()
 	r.Log.Info("Running query: /api/v1/query?query=" + objective.Query + "&time=" + queryTime.String())
 
-	client, _ := promapi.NewClient(promapi.Config{Address: provider.Spec.TargetServer, Client: &http.Client{}})
+	client, err := promapi.NewClient(promapi.Config{Address: provider.Spec.TargetServer, Client: &http.Client{}})
+	if err != nil {
+		query.Message = err.Error()
+		return query
+	}
 	api := prometheus.NewAPI(client)
 	result, w, err := api.Query(
 		context.Background(),

--- a/operator/controllers/keptnworkloadinstance/controller.go
+++ b/operator/controllers/keptnworkloadinstance/controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/go-logr/logr"
 	version "github.com/hashicorp/go-version"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -256,18 +255,6 @@ func (r *KeptnWorkloadInstanceReconciler) SetupWithManager(mgr ctrl.Manager) err
 		// predicate disabling the auto reconciliation after updating the object status
 		For(&klcv1alpha1.KeptnWorkloadInstance{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
-}
-
-func (r *KeptnWorkloadInstanceReconciler) getAppVersion(ctx context.Context, appName types.NamespacedName) (*klcv1alpha1.KeptnAppVersion, error) {
-	app := &klcv1alpha1.KeptnApp{}
-	err := r.Get(ctx, appName, app)
-	if err != nil {
-		return nil, err
-	}
-
-	appVersion := &klcv1alpha1.KeptnAppVersion{}
-	err = r.Get(ctx, controllercommon.GetAppVersionName(appName.Namespace, appName.Name, app.Spec.Version), appVersion)
-	return appVersion, err
 }
 
 func (r *KeptnWorkloadInstanceReconciler) getAppVersionForWorkloadInstance(ctx context.Context, wli *klcv1alpha1.KeptnWorkloadInstance) (bool, klcv1alpha1.KeptnAppVersion, error) {

--- a/operator/controllers/keptnworkloadinstance/controller_test.go
+++ b/operator/controllers/keptnworkloadinstance/controller_test.go
@@ -549,9 +549,9 @@ func TestKeptnWorkloadInstanceReconciler_Reconcile(t *testing.T) {
 		},
 	}
 
-	utils.AddWorkloadInstance(r.Client, "some-wi", testNamespace)
-	utils.AddApp(r.Client, "some-app")
-	utils.AddAppVersion(
+	_ = utils.AddWorkloadInstance(r.Client, "some-wi", testNamespace)
+	_ = utils.AddApp(r.Client, "some-app")
+	_ = utils.AddAppVersion(
 		r.Client,
 		testNamespace,
 		"some-app",

--- a/operator/controllers/keptnworkloadinstance/controller_test.go
+++ b/operator/controllers/keptnworkloadinstance/controller_test.go
@@ -549,9 +549,11 @@ func TestKeptnWorkloadInstanceReconciler_Reconcile(t *testing.T) {
 		},
 	}
 
-	_ = utils.AddWorkloadInstance(r.Client, "some-wi", testNamespace)
-	_ = utils.AddApp(r.Client, "some-app")
-	_ = utils.AddAppVersion(
+	err := utils.AddWorkloadInstance(r.Client, "some-wi", testNamespace)
+	require.Nil(t, err)
+	err = utils.AddApp(r.Client, "some-app")
+	require.Nil(t, err)
+	err = utils.AddAppVersion(
 		r.Client,
 		testNamespace,
 		"some-app",
@@ -579,6 +581,7 @@ func TestKeptnWorkloadInstanceReconciler_Reconcile(t *testing.T) {
 			EndTime:                            metav1.Time{},
 		},
 	)
+	require.Nil(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/operator/test/component/DEVELOPER.md
+++ b/operator/test/component/DEVELOPER.md
@@ -54,7 +54,7 @@ var _ = Describe("KeptnAppController", func() {
             Context("with one App", func() {
                 BeforeEach(func() {  
                 //create it using the client eg. Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
-                    instance = createInstanceInCluster(name, namespace, version, instance)
+                    instance = createInstanceInCluster(name, namespace, version)
                 })
                 AfterEach(func() {
                     // Remember to clean up the cluster after each test

--- a/operator/test/component/appcontroller_test.go
+++ b/operator/test/component/appcontroller_test.go
@@ -102,7 +102,7 @@ var _ = Describe("KeptnAppController", Ordered, func() {
 
 func deleteAppInCluster(instance *klcv1alpha1.KeptnApp) {
 	By("Cleaning Up KeptnApp CRD ")
-	k8sClient.Delete(ctx, instance)
+	_ = k8sClient.Delete(ctx, instance)
 }
 
 func assertResourceUpdated(instance *klcv1alpha1.KeptnApp) *klcv1alpha1.KeptnAppVersion {

--- a/operator/test/component/appcontroller_test.go
+++ b/operator/test/component/appcontroller_test.go
@@ -76,7 +76,7 @@ var _ = Describe("KeptnAppController", Ordered, func() {
 		)
 
 		BeforeEach(func() {
-			instance = createInstanceInCluster(name, namespace, version, instance)
+			instance = createInstanceInCluster(name, namespace, version)
 			fmt.Println("created ", instance.Name)
 		})
 
@@ -153,7 +153,7 @@ func assertAppSpan(instance *klcv1alpha1.KeptnApp, spanRecorder *sdktest.SpanRec
 	Expect(spans[2].Attributes()).To(ContainElement(common.AppVersion.String(instance.Spec.Version)))
 }
 
-func createInstanceInCluster(name string, namespace string, version string, instance *klcv1alpha1.KeptnApp) *klcv1alpha1.KeptnApp {
+func createInstanceInCluster(name string, namespace string, version string) *klcv1alpha1.KeptnApp {
 	instance = &klcv1alpha1.KeptnApp{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/operator/test/component/appcontroller_test.go
+++ b/operator/test/component/appcontroller_test.go
@@ -102,7 +102,8 @@ var _ = Describe("KeptnAppController", Ordered, func() {
 
 func deleteAppInCluster(instance *klcv1alpha1.KeptnApp) {
 	By("Cleaning Up KeptnApp CRD ")
-	_ = k8sClient.Delete(ctx, instance)
+	err := k8sClient.Delete(ctx, instance)
+	logErrorIfPresent(err)
 }
 
 func assertResourceUpdated(instance *klcv1alpha1.KeptnApp) *klcv1alpha1.KeptnAppVersion {

--- a/operator/test/component/appcontroller_test.go
+++ b/operator/test/component/appcontroller_test.go
@@ -154,7 +154,7 @@ func assertAppSpan(instance *klcv1alpha1.KeptnApp, spanRecorder *sdktest.SpanRec
 }
 
 func createInstanceInCluster(name string, namespace string, version string) *klcv1alpha1.KeptnApp {
-	instance = &klcv1alpha1.KeptnApp{
+	instance := &klcv1alpha1.KeptnApp{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/operator/test/component/load_test.go
+++ b/operator/test/component/load_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	otelsdk "go.opentelemetry.io/otel/sdk/trace"
 	sdktest "go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"io/ioutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"os"
@@ -110,7 +109,7 @@ func generateMetricReport(metric Metric) {
 
 	filePath := path.Join(dir, "load-report."+time.Now().Format(time.RFC3339)+".json")
 	report := []byte(fmt.Sprintf("Overall AppVersions created %d/%d \n Creation times: %+v ", metric.succeededAppVersionCount, LOAD, metric.creationTime))
-	if err := ioutil.WriteFile(filePath, report, 0644); err != nil {
+	if err := os.WriteFile(filePath, report, 0644); err != nil {
 		GinkgoLogr.Error(err, "error writing to ", filePath)
 	}
 

--- a/operator/test/component/suite_test.go
+++ b/operator/test/component/suite_test.go
@@ -139,9 +139,15 @@ func ignoreAlreadyExists(err error) error {
 
 func setupManager(rec []keptncontroller.Controller) {
 	for _, r := range rec {
-		_ = r.SetupWithManager(k8sManager)
+		err := r.SetupWithManager(k8sManager)
+		Expect(err).To(BeNil())
 	}
+}
 
+func logErrorIfPresent(err error) {
+	if err != nil {
+		GinkgoLogr.Error(err, "Something went wrong while cleaning up the test environment")
+	}
 }
 
 func resetSpanRecords(tp *otelsdk.TracerProvider, spanRecorder *sdktest.SpanRecorder) {

--- a/operator/test/component/suite_test.go
+++ b/operator/test/component/suite_test.go
@@ -139,7 +139,7 @@ func ignoreAlreadyExists(err error) error {
 
 func setupManager(rec []keptncontroller.Controller) {
 	for _, r := range rec {
-		r.SetupWithManager(k8sManager)
+		_ = r.SetupWithManager(k8sManager)
 	}
 
 }

--- a/operator/test/component/taskcontroller_test.go
+++ b/operator/test/component/taskcontroller_test.go
@@ -105,8 +105,10 @@ var _ = Describe("KeptnTaskController", Ordered, func() {
 				}, "10s").Should(Succeed())
 			})
 			AfterEach(func() {
-				_ = k8sClient.Delete(context.TODO(), taskDefinition)
-				_ = k8sClient.Delete(context.TODO(), task)
+				err := k8sClient.Delete(context.TODO(), taskDefinition)
+				logErrorIfPresent(err)
+				err = k8sClient.Delete(context.TODO(), task)
+				logErrorIfPresent(err)
 			})
 		})
 	})

--- a/operator/test/component/taskcontroller_test.go
+++ b/operator/test/component/taskcontroller_test.go
@@ -105,8 +105,8 @@ var _ = Describe("KeptnTaskController", Ordered, func() {
 				}, "10s").Should(Succeed())
 			})
 			AfterEach(func() {
-				k8sClient.Delete(context.TODO(), taskDefinition)
-				k8sClient.Delete(context.TODO(), task)
+				_ = k8sClient.Delete(context.TODO(), taskDefinition)
+				_ = k8sClient.Delete(context.TODO(), task)
 			})
 		})
 	})

--- a/operator/test/component/workloadinstancecontroller_test.go
+++ b/operator/test/component/workloadinstancecontroller_test.go
@@ -389,8 +389,10 @@ var _ = Describe("KeptnWorkloadInstanceController", Ordered, func() {
 			})
 			AfterEach(func() {
 				// Remember to clean up the cluster after each test
-				_ = k8sClient.Delete(ctx, appVersion)
-				_ = k8sClient.Delete(ctx, wi)
+				err := k8sClient.Delete(ctx, appVersion)
+				logErrorIfPresent(err)
+				err = k8sClient.Delete(ctx, wi)
+				logErrorIfPresent(err)
 				// Reset span recorder after each spec
 				resetSpanRecords(tracer, spanRecorder)
 			})

--- a/operator/test/component/workloadinstancecontroller_test.go
+++ b/operator/test/component/workloadinstancecontroller_test.go
@@ -389,8 +389,8 @@ var _ = Describe("KeptnWorkloadInstanceController", Ordered, func() {
 			})
 			AfterEach(func() {
 				// Remember to clean up the cluster after each test
-				k8sClient.Delete(ctx, appVersion)
-				k8sClient.Delete(ctx, wi)
+				_ = k8sClient.Delete(ctx, appVersion)
+				_ = k8sClient.Delete(ctx, wi)
 				// Reset span recorder after each spec
 				resetSpanRecords(tracer, spanRecorder)
 			})

--- a/operator/webhooks/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutating_webhook.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"net/http"
 	"reflect"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/go-logr/logr"
 	klcv1alpha1 "github.com/keptn/lifecycle-toolkit/operator/api/v1alpha1"
@@ -89,7 +90,7 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 
 	if !podIsAnnotated {
 		logger.Info("Pod is not annotated, check for parent annotations...")
-		podIsAnnotated, err = a.copyAnnotationsIfParentAnnotated(ctx, &req, pod)
+		podIsAnnotated, _ = a.copyAnnotationsIfParentAnnotated(ctx, &req, pod)
 	}
 
 	if podIsAnnotated {

--- a/operator/webhooks/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutating_webhook.go
@@ -90,7 +90,11 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 
 	if !podIsAnnotated {
 		logger.Info("Pod is not annotated, check for parent annotations...")
-		podIsAnnotated, _ = a.copyAnnotationsIfParentAnnotated(ctx, &req, pod)
+		podIsAnnotated, err = a.copyAnnotationsIfParentAnnotated(ctx, &req, pod)
+		if err != nil {
+			span.SetStatus(codes.Error, "Invalid annotations")
+			return admission.Errored(http.StatusBadRequest, err)
+		}
 	}
 
 	if podIsAnnotated {

--- a/operator/webhooks/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutating_webhook.go
@@ -44,6 +44,8 @@ type PodMutatingWebhook struct {
 	Log      logr.Logger
 }
 
+const InvalidAnnotationMessage = "Invalid annotations"
+
 var ErrTooLongAnnotations = fmt.Errorf("too long annotations, maximum length for app and workload is 25 characters, for version 12 characters")
 
 // Handle inspects incoming Pods and injects the Keptn scheduler if they contain the Keptn lifecycle annotations.
@@ -84,7 +86,7 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 	logger.Info("Checked if pod is annotated.")
 
 	if err != nil {
-		span.SetStatus(codes.Error, "Invalid annotations")
+		span.SetStatus(codes.Error, InvalidAnnotationMessage)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -92,7 +94,7 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 		logger.Info("Pod is not annotated, check for parent annotations...")
 		podIsAnnotated, err = a.copyAnnotationsIfParentAnnotated(ctx, &req, pod)
 		if err != nil {
-			span.SetStatus(codes.Error, "Invalid annotations")
+			span.SetStatus(codes.Error, InvalidAnnotationMessage)
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
@@ -104,7 +106,7 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 
 		isAppAnnotationPresent, err := a.isAppAnnotationPresent(pod)
 		if err != nil {
-			span.SetStatus(codes.Error, "Invalid annotations")
+			span.SetStatus(codes.Error, InvalidAnnotationMessage)
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		if !isAppAnnotationPresent {

--- a/scheduler/pkg/klcpermit/workflow_manager.go
+++ b/scheduler/pkg/klcpermit/workflow_manager.go
@@ -3,16 +3,17 @@ package klcpermit
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
+	"strings"
+
 	"github.com/keptn/lifecycle-toolkit/scheduler/pkg/tracing"
 	"go.opentelemetry.io/otel/codes"
-	"hash/fnv"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
-	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -76,7 +77,7 @@ func (sMgr *WorkloadManager) Permit(ctx context.Context, pod *corev1.Pod) Status
 		return WorkloadInstanceNotFound
 	}
 
-	ctx, span := sMgr.getSpan(ctx, crd, pod)
+	_, span := sMgr.getSpan(ctx, crd, pod)
 
 	//check CRD status
 	phase, found, err := unstructured.NestedString(crd.UnstructuredContent(), "status", "preDeploymentEvaluationStatus")

--- a/scheduler/test/e2e/fake/v1alpha1/groupversion_info.go
+++ b/scheduler/test/e2e/fake/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the lifecycle v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=lifecycle.keptn.sh
+// +kubebuilder:object:generate=true
+// +groupName=lifecycle.keptn.sh
 package v1alpha1
 
 import (

--- a/scheduler/test/e2e/scheduler_test.go
+++ b/scheduler/test/e2e/scheduler_test.go
@@ -43,7 +43,7 @@ var _ = Describe("[E2E] KeptnScheduler", Ordered, func() {
 		)
 		BeforeEach(func() {
 			DeferCleanup(func() {
-				k8sClient.Delete(ctx, pod)
+				_ = k8sClient.Delete(ctx, pod)
 			})
 
 			//create a test Pod
@@ -108,7 +108,7 @@ var _ = Describe("[E2E] KeptnScheduler", Ordered, func() {
 		)
 		BeforeEach(func() {
 			DeferCleanup(func() {
-				k8sClient.Delete(ctx, pod)
+				_ = k8sClient.Delete(ctx, pod)
 			})
 
 			//create a test Pod

--- a/scheduler/test/e2e/scheduler_test.go
+++ b/scheduler/test/e2e/scheduler_test.go
@@ -43,7 +43,8 @@ var _ = Describe("[E2E] KeptnScheduler", Ordered, func() {
 		)
 		BeforeEach(func() {
 			DeferCleanup(func() {
-				_ = k8sClient.Delete(ctx, pod)
+				err := k8sClient.Delete(ctx, pod)
+				logErrorIfPresent(err)
 			})
 
 			//create a test Pod
@@ -108,7 +109,8 @@ var _ = Describe("[E2E] KeptnScheduler", Ordered, func() {
 		)
 		BeforeEach(func() {
 			DeferCleanup(func() {
-				_ = k8sClient.Delete(ctx, pod)
+				err := k8sClient.Delete(ctx, pod)
+				logErrorIfPresent(err)
 			})
 
 			//create a test Pod

--- a/scheduler/test/e2e/suite_test.go
+++ b/scheduler/test/e2e/suite_test.go
@@ -53,6 +53,12 @@ func TestE2EScheduler(t *testing.T) {
 	RunSpecs(t, "Scheduler Suite")
 }
 
+func logErrorIfPresent(err error) {
+	if err != nil {
+		GinkgoLogr.Error(err, "Something went wrong while cleaning up the test environment")
+	}
+}
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx, cancel = context.WithCancel(context.TODO())


### PR DESCRIPTION
## This PR

- introduces a new workflow for checking the code with golangci-lint
- the following linters are being used
  - errcheck (default)
  - gosimple (default)
  - govet (default)
  - ineffassign (default)
  - staticcheck (default)
  - typecheck (default)
  - unused (default)
  - gofmt

## Fixes

- #391 

## Follow up tasks

- implement + refactor currently commented out linters

Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>