### PR TITLE
ci: introduce additional linters for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
           - name: "scheduler"
             folder: "scheduler/"
     steps:
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v3
       
       - uses: actions/setup-go@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gci           # Gci controls golang package import order and makes it always deterministic.
-    - errorlint       # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - errorlint       # errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - containedctx  # containedctx is a linter that detects struct contained context.Context field
     - dogsled       # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - nilnil        # Checks that there is no simultaneous return of nil error and an invalid value.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,17 @@ linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gci           # Gci controls golang package import order and makes it always deterministic.
-#    - errorlint       # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-#    - containedctx  # containedctx is a linter that detects struct contained context.Context field
-#    - dogsled       # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
-#    - nilnil        # Checks that there is no simultaneous return of nil error and an invalid value.
-#    - noctx         # noctx finds sending http request without context.Context
+    - errorlint       # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - containedctx  # containedctx is a linter that detects struct contained context.Context field
+    - dogsled       # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
+    - nilnil        # Checks that there is no simultaneous return of nil error and an invalid value.
+    - noctx         # noctx finds sending http request without context.Context
 
 issues:
   exclude-rules:
     - linters:
         - gci
       text: '//+kubebuilder'
+    - linters:
+        - containedctx
+      path: _test\.go


### PR DESCRIPTION
## This PR

- is a follow up PR of #448 
- introduces the following linters for `golangci-lint`
  - errorlint
  - containedctx
  - dogsled
  - nilnil
  - noctx
- adds refactoring for errors of the added linters

## Related issue

- #391 

Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>