### PR TITLE
ci: trigger release pipeline also for maintenance branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - '[0-9]+.[0-9]*.x'
+      - '[0-9]+.[0-9]+.x'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '[0-9]+.[0-9]*.x'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## This PR

- adds a trigger in the release pipeline to also run for maintenance branches

Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>