### PR TITLE
chore: add component tests as part of the coverage

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -85,172 +85,173 @@ jobs:
         working-directory: ./${{ matrix.config.folder }}
         run: make test
 
-      - name: Component Tests
-        if: matrix.config.name == 'keptn-lifecycle-operator'
-        uses: ./.github/workflows/component-test.yml
-
-      - name: Report code coverage
-        uses: codecov/codecov-action@v3
-        with:
-          flags: ${{ matrix.config.name }}
-
-  build_image:
-    name: Build Docker Image
-    needs: prepare_ci_run
-    runs-on: ubuntu-22.04
-    env:
-      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
-      BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
-      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-      RELEASE_REGISTRY: "localhost:5000/keptn"
-    strategy:
-      matrix:
-        config:
-          - name: "keptn-lifecycle-operator"
-            folder: "operator/"
-          - name: "scheduler"
-            folder: "scheduler/"
-          - name: "functions-runtime"
-            folder: "functions-runtime/"
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2      
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ matrix.config.folder }}
-          platforms: linux/amd64
-          target: production
-          tags: |
-            ${{ env.RELEASE_REGISTRY }}/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
-          build-args: |
-            GIT_HASH=${{ env.GIT_SHA }}
-            RELEASE_VERSION=dev-${{ env.DATETIME }}
-            BUILD_TIME=${{ env.BUILD_TIME }}
-            CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
-            SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
-          builder: ${{ steps.buildx.outputs.name }}
-          push: false
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
-          outputs: type=docker,dest=/tmp/${{ matrix.config.name }}-image.tar
-      
-      - name: Upload image as artifact
+#      - name: Report code coverage
+#        uses: codecov/codecov-action@v3
+#        with:
+#          flags: ${{ matrix.config.name }}
+      - name: Upload coverage for unit tests
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.config.name }}-image.tar
-          path: /tmp/${{ matrix.config.name }}-image.tar
+          name: ${{ matrix.config.name }}-coverage.out
+          path: ${{ matrix.config.folder }}/cover.out
 
-      - name: Install controller-gen
-        if: matrix.config.name == 'keptn-lifecycle-operator'
-        working-directory: ./${{ matrix.config.folder }}
-        run: make controller-gen
-
-      - name: Generate release.yaml
-        if: matrix.config.name != 'functions-runtime'
-        working-directory: ./${{ matrix.config.folder }}
-        env:
-          TAG: dev-${{ env.DATETIME }}
-        run: make release-manifests
-
-      - name: Upload release.yaml for tests
-        if: matrix.config.name != 'functions-runtime'
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.config.name }}-manifest-test
-          path: ${{ matrix.config.folder }}/config/rendered/release.yaml
+#  build_image:
+#    name: Build Docker Image
+#    needs: prepare_ci_run
+#    runs-on: ubuntu-22.04
+#    env:
+#      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
+#      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
+#      BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
+#      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
+#      RELEASE_REGISTRY: "localhost:5000/keptn"
+#    strategy:
+#      matrix:
+#        config:
+#          - name: "keptn-lifecycle-operator"
+#            folder: "operator/"
+#          - name: "scheduler"
+#            folder: "scheduler/"
+#          - name: "functions-runtime"
+#            folder: "functions-runtime/"
+#    steps:
+#      - name: Check out code
+#        uses: actions/checkout@v3
+#
+#      - name: Set up Docker Buildx
+#        id: buildx
+#        uses: docker/setup-buildx-action@v2
+#
+#      - name: Build Docker Image
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: ${{ matrix.config.folder }}
+#          platforms: linux/amd64
+#          target: production
+#          tags: |
+#            ${{ env.RELEASE_REGISTRY }}/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
+#          build-args: |
+#            GIT_HASH=${{ env.GIT_SHA }}
+#            RELEASE_VERSION=dev-${{ env.DATETIME }}
+#            BUILD_TIME=${{ env.BUILD_TIME }}
+#            CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
+#            SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
+#          builder: ${{ steps.buildx.outputs.name }}
+#          push: false
+#          cache-from: type=gha, scope=${{ github.workflow }}
+#          cache-to: type=gha, scope=${{ github.workflow }}
+#          outputs: type=docker,dest=/tmp/${{ matrix.config.name }}-image.tar
+#
+#      - name: Upload image as artifact
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ${{ matrix.config.name }}-image.tar
+#          path: /tmp/${{ matrix.config.name }}-image.tar
+#
+#      - name: Install controller-gen
+#        if: matrix.config.name == 'keptn-lifecycle-operator'
+#        working-directory: ./${{ matrix.config.folder }}
+#        run: make controller-gen
+#
+#      - name: Generate release.yaml
+#        if: matrix.config.name != 'functions-runtime'
+#        working-directory: ./${{ matrix.config.folder }}
+#        env:
+#          TAG: dev-${{ env.DATETIME }}
+#        run: make release-manifests
+#
+#      - name: Upload release.yaml for tests
+#        if: matrix.config.name != 'functions-runtime'
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: ${{ matrix.config.name }}-manifest-test
+#          path: ${{ matrix.config.folder }}/config/rendered/release.yaml
 
   component_tests:
     name: Component Tests
     needs: prepare_ci_run
     uses: ./.github/workflows/component-test.yml
 
-  integration_tests:
-    name: Integration Tests
-    needs: [ prepare_ci_run, build_image ]
-    uses: ./.github/workflows/integration-test.yml
-
-  e2e_tests:
-    name: End to End Tests
-    needs: [ prepare_ci_run, build_image ]
-    uses: ./.github/workflows/e2e-test.yml
-
-  performance_tests:
-    name: Performance Tests
-    needs: [ prepare_ci_run, build_image ]
-    uses: ./.github/workflows/performance-test.yml
-
-  upload_images:
-    name: Upload images to ghcr registry
-    needs: [prepare_ci_run, test, component_tests, integration_tests, e2e_tests, performance_tests]
-    if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        config:
-          - name: "keptn-lifecycle-operator"
-            folder: "operator/"
-          - name: "scheduler"
-            folder: "scheduler/"
-          - name: "functions-runtime"
-            folder: "functions-runtime/"
-    permissions:
-      packages: write # Needed for pushing images to the registry
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
-      with:
-        registry: "ghcr.io"
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2  
-
-    - name: Build Docker Image
-      uses: docker/build-push-action@v3
-      with:
-        context: ${{ matrix.config.folder }}
-        platforms: linux/amd64,linux/arm64
-        target: production
-        tags: |
-          ghcr.io/keptn/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
-        build-args: |
-          GIT_HASH=${{ env.GIT_SHA }}
-          RELEASE_VERSION=dev-${{ env.DATETIME }}
-          BUILD_TIME=${{ env.BUILD_TIME }}
-          CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
-          SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
-        builder: ${{ steps.buildx.outputs.name }}
-        push: true
-        cache-from: type=gha, scope=${{ github.workflow }}
-        cache-to: type=gha, scope=${{ github.workflow }}
-
-    - name: Install controller-gen
-      if: matrix.config.name == 'keptn-lifecycle-operator'
-      working-directory: ./${{ matrix.config.folder }}
-      run: make controller-gen
-
-    - name: Generate release.yaml
-      if: matrix.config.name != 'functions-runtime'
-      working-directory: ./${{ matrix.config.folder }}
-      env:
-        TAG: dev-${{ env.DATETIME }}
-      run: make release-manifests
-
-    - name: Upload release.yaml
-      if: matrix.config.name != 'functions-runtime'
-      uses: actions/upload-artifact@v3
-      with:
-        name: ${{ matrix.config.name }}-manifest
-        path: ${{ matrix.config.folder }}/config/rendered/release.yaml
+#  integration_tests:
+#    name: Integration Tests
+#    needs: [ prepare_ci_run, build_image ]
+#    uses: ./.github/workflows/integration-test.yml
+#
+#  e2e_tests:
+#    name: End to End Tests
+#    needs: [ prepare_ci_run, build_image ]
+#    uses: ./.github/workflows/e2e-test.yml
+#
+#  performance_tests:
+#    name: Performance Tests
+#    needs: [ prepare_ci_run, build_image ]
+#    uses: ./.github/workflows/performance-test.yml
+#
+#  upload_images:
+#    name: Upload images to ghcr registry
+#    needs: [prepare_ci_run, test, component_tests, integration_tests, e2e_tests, performance_tests]
+#    if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
+#    runs-on: ubuntu-22.04
+#    strategy:
+#      matrix:
+#        config:
+#          - name: "keptn-lifecycle-operator"
+#            folder: "operator/"
+#          - name: "scheduler"
+#            folder: "scheduler/"
+#          - name: "functions-runtime"
+#            folder: "functions-runtime/"
+#    permissions:
+#      packages: write # Needed for pushing images to the registry
+#    steps:
+#    - name: Check out code
+#      uses: actions/checkout@v3
+#
+#    - name: Login to GitHub Container Registry
+#      uses: docker/login-action@v2
+#      with:
+#        registry: "ghcr.io"
+#        username: ${{ github.actor }}
+#        password: ${{ secrets.GITHUB_TOKEN }}
+#
+#    - name: Set up Docker Buildx
+#      id: buildx
+#      uses: docker/setup-buildx-action@v2
+#
+#    - name: Build Docker Image
+#      uses: docker/build-push-action@v3
+#      with:
+#        context: ${{ matrix.config.folder }}
+#        platforms: linux/amd64,linux/arm64
+#        target: production
+#        tags: |
+#          ghcr.io/keptn/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
+#        build-args: |
+#          GIT_HASH=${{ env.GIT_SHA }}
+#          RELEASE_VERSION=dev-${{ env.DATETIME }}
+#          BUILD_TIME=${{ env.BUILD_TIME }}
+#          CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
+#          SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
+#        builder: ${{ steps.buildx.outputs.name }}
+#        push: true
+#        cache-from: type=gha, scope=${{ github.workflow }}
+#        cache-to: type=gha, scope=${{ github.workflow }}
+#
+#    - name: Install controller-gen
+#      if: matrix.config.name == 'keptn-lifecycle-operator'
+#      working-directory: ./${{ matrix.config.folder }}
+#      run: make controller-gen
+#
+#    - name: Generate release.yaml
+#      if: matrix.config.name != 'functions-runtime'
+#      working-directory: ./${{ matrix.config.folder }}
+#      env:
+#        TAG: dev-${{ env.DATETIME }}
+#      run: make release-manifests
+#
+#    - name: Upload release.yaml
+#      if: matrix.config.name != 'functions-runtime'
+#      uses: actions/upload-artifact@v3
+#      with:
+#        name: ${{ matrix.config.name }}-manifest
+#        path: ${{ matrix.config.folder }}/config/rendered/release.yaml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,77 +91,77 @@ jobs:
           flags: ${{ matrix.config.name }}
 
 
-#  build_image:
-#    name: Build Docker Image
-#    needs: prepare_ci_run
-#    runs-on: ubuntu-22.04
-#    env:
-#      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
-#      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
-#      BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
-#      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
-#      RELEASE_REGISTRY: "localhost:5000/keptn"
-#    strategy:
-#      matrix:
-#        config:
-#          - name: "keptn-lifecycle-operator"
-#            folder: "operator/"
-#          - name: "scheduler"
-#            folder: "scheduler/"
-#          - name: "functions-runtime"
-#            folder: "functions-runtime/"
-#    steps:
-#      - name: Check out code
-#        uses: actions/checkout@v3
-#
-#      - name: Set up Docker Buildx
-#        id: buildx
-#        uses: docker/setup-buildx-action@v2
-#
-#      - name: Build Docker Image
-#        uses: docker/build-push-action@v3
-#        with:
-#          context: ${{ matrix.config.folder }}
-#          platforms: linux/amd64
-#          target: production
-#          tags: |
-#            ${{ env.RELEASE_REGISTRY }}/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
-#          build-args: |
-#            GIT_HASH=${{ env.GIT_SHA }}
-#            RELEASE_VERSION=dev-${{ env.DATETIME }}
-#            BUILD_TIME=${{ env.BUILD_TIME }}
-#            CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
-#            SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
-#          builder: ${{ steps.buildx.outputs.name }}
-#          push: false
-#          cache-from: type=gha, scope=${{ github.workflow }}
-#          cache-to: type=gha, scope=${{ github.workflow }}
-#          outputs: type=docker,dest=/tmp/${{ matrix.config.name }}-image.tar
-#
-#      - name: Upload image as artifact
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ${{ matrix.config.name }}-image.tar
-#          path: /tmp/${{ matrix.config.name }}-image.tar
-#
-#      - name: Install controller-gen
-#        if: matrix.config.name == 'keptn-lifecycle-operator'
-#        working-directory: ./${{ matrix.config.folder }}
-#        run: make controller-gen
-#
-#      - name: Generate release.yaml
-#        if: matrix.config.name != 'functions-runtime'
-#        working-directory: ./${{ matrix.config.folder }}
-#        env:
-#          TAG: dev-${{ env.DATETIME }}
-#        run: make release-manifests
-#
-#      - name: Upload release.yaml for tests
-#        if: matrix.config.name != 'functions-runtime'
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: ${{ matrix.config.name }}-manifest-test
-#          path: ${{ matrix.config.folder }}/config/rendered/release.yaml
+  build_image:
+    name: Build Docker Image
+    needs: prepare_ci_run
+    runs-on: ubuntu-22.04
+    env:
+      BRANCH: ${{ needs.prepare_ci_run.outputs.BRANCH }}
+      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
+      BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
+      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
+      RELEASE_REGISTRY: "localhost:5000/keptn"
+    strategy:
+      matrix:
+        config:
+          - name: "keptn-lifecycle-operator"
+            folder: "operator/"
+          - name: "scheduler"
+            folder: "scheduler/"
+          - name: "functions-runtime"
+            folder: "functions-runtime/"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ matrix.config.folder }}
+          platforms: linux/amd64
+          target: production
+          tags: |
+            ${{ env.RELEASE_REGISTRY }}/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
+          build-args: |
+            GIT_HASH=${{ env.GIT_SHA }}
+            RELEASE_VERSION=dev-${{ env.DATETIME }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
+            CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
+            SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
+          builder: ${{ steps.buildx.outputs.name }}
+          push: false
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}
+          outputs: type=docker,dest=/tmp/${{ matrix.config.name }}-image.tar
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.config.name }}-image.tar
+          path: /tmp/${{ matrix.config.name }}-image.tar
+
+      - name: Install controller-gen
+        if: matrix.config.name == 'keptn-lifecycle-operator'
+        working-directory: ./${{ matrix.config.folder }}
+        run: make controller-gen
+
+      - name: Generate release.yaml
+        if: matrix.config.name != 'functions-runtime'
+        working-directory: ./${{ matrix.config.folder }}
+        env:
+          TAG: dev-${{ env.DATETIME }}
+        run: make release-manifests
+
+      - name: Upload release.yaml for tests
+        if: matrix.config.name != 'functions-runtime'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.config.name }}-manifest-test
+          path: ${{ matrix.config.folder }}/config/rendered/release.yaml
 
   component_tests:
     name: Component Tests
@@ -169,86 +169,86 @@ jobs:
     uses: ./.github/workflows/component-test.yml
 
 
-#  integration_tests:
-#    name: Integration Tests
-#    needs: [ prepare_ci_run, build_image ]
-#    uses: ./.github/workflows/integration-test.yml
-#
-#  e2e_tests:
-#    name: End to End Tests
-#    needs: [ prepare_ci_run, build_image ]
-#    uses: ./.github/workflows/e2e-test.yml
-#
-#  performance_tests:
-#    name: Performance Tests
-#    needs: [ prepare_ci_run, build_image ]
-#    uses: ./.github/workflows/performance-test.yml
-#
-#  upload_images:
-#    name: Upload images to ghcr registry
-#    needs: [prepare_ci_run, test, component_tests, integration_tests, e2e_tests, performance_tests]
-#    if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
-#    runs-on: ubuntu-22.04
-#    strategy:
-#      matrix:
-#        config:
-#          - name: "keptn-lifecycle-operator"
-#            folder: "operator/"
-#          - name: "scheduler"
-#            folder: "scheduler/"
-#          - name: "functions-runtime"
-#            folder: "functions-runtime/"
-#    permissions:
-#      packages: write # Needed for pushing images to the registry
-#    steps:
-#    - name: Check out code
-#      uses: actions/checkout@v3
-#
-#    - name: Login to GitHub Container Registry
-#      uses: docker/login-action@v2
-#      with:
-#        registry: "ghcr.io"
-#        username: ${{ github.actor }}
-#        password: ${{ secrets.GITHUB_TOKEN }}
-#
-#    - name: Set up Docker Buildx
-#      id: buildx
-#      uses: docker/setup-buildx-action@v2
-#
-#    - name: Build Docker Image
-#      uses: docker/build-push-action@v3
-#      with:
-#        context: ${{ matrix.config.folder }}
-#        platforms: linux/amd64,linux/arm64
-#        target: production
-#        tags: |
-#          ghcr.io/keptn/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
-#        build-args: |
-#          GIT_HASH=${{ env.GIT_SHA }}
-#          RELEASE_VERSION=dev-${{ env.DATETIME }}
-#          BUILD_TIME=${{ env.BUILD_TIME }}
-#          CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
-#          SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
-#        builder: ${{ steps.buildx.outputs.name }}
-#        push: true
-#        cache-from: type=gha, scope=${{ github.workflow }}
-#        cache-to: type=gha, scope=${{ github.workflow }}
-#
-#    - name: Install controller-gen
-#      if: matrix.config.name == 'keptn-lifecycle-operator'
-#      working-directory: ./${{ matrix.config.folder }}
-#      run: make controller-gen
-#
-#    - name: Generate release.yaml
-#      if: matrix.config.name != 'functions-runtime'
-#      working-directory: ./${{ matrix.config.folder }}
-#      env:
-#        TAG: dev-${{ env.DATETIME }}
-#      run: make release-manifests
-#
-#    - name: Upload release.yaml
-#      if: matrix.config.name != 'functions-runtime'
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ${{ matrix.config.name }}-manifest
-#        path: ${{ matrix.config.folder }}/config/rendered/release.yaml
+  integration_tests:
+    name: Integration Tests
+    needs: [ prepare_ci_run, build_image ]
+    uses: ./.github/workflows/integration-test.yml
+
+  e2e_tests:
+    name: End to End Tests
+    needs: [ prepare_ci_run, build_image ]
+    uses: ./.github/workflows/e2e-test.yml
+
+  performance_tests:
+    name: Performance Tests
+    needs: [ prepare_ci_run, build_image ]
+    uses: ./.github/workflows/performance-test.yml
+
+  upload_images:
+    name: Upload images to ghcr registry
+    needs: [prepare_ci_run, test, component_tests, integration_tests, e2e_tests, performance_tests]
+    if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        config:
+          - name: "keptn-lifecycle-operator"
+            folder: "operator/"
+          - name: "scheduler"
+            folder: "scheduler/"
+          - name: "functions-runtime"
+            folder: "functions-runtime/"
+    permissions:
+      packages: write # Needed for pushing images to the registry
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: "ghcr.io"
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        context: ${{ matrix.config.folder }}
+        platforms: linux/amd64,linux/arm64
+        target: production
+        tags: |
+          ghcr.io/keptn/${{ matrix.config.name }}:dev-${{ env.DATETIME }}
+        build-args: |
+          GIT_HASH=${{ env.GIT_SHA }}
+          RELEASE_VERSION=dev-${{ env.DATETIME }}
+          BUILD_TIME=${{ env.BUILD_TIME }}
+          CONTROLLER_TOOLS_VERSION=${{ env.CONTROLLER_TOOLS_VERSION }}
+          SCHEDULER_COMPATIBLE_K8S_VERSION=${{ env.SCHEDULER_COMPATIBLE_K8S_VERSION }}
+        builder: ${{ steps.buildx.outputs.name }}
+        push: true
+        cache-from: type=gha, scope=${{ github.workflow }}
+        cache-to: type=gha, scope=${{ github.workflow }}
+
+    - name: Install controller-gen
+      if: matrix.config.name == 'keptn-lifecycle-operator'
+      working-directory: ./${{ matrix.config.folder }}
+      run: make controller-gen
+
+    - name: Generate release.yaml
+      if: matrix.config.name != 'functions-runtime'
+      working-directory: ./${{ matrix.config.folder }}
+      env:
+        TAG: dev-${{ env.DATETIME }}
+      run: make release-manifests
+
+    - name: Upload release.yaml
+      if: matrix.config.name != 'functions-runtime'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.config.name }}-manifest
+        path: ${{ matrix.config.folder }}/config/rendered/release.yaml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -81,9 +81,13 @@ jobs:
           cache: true
           cache-dependency-path: '${{ matrix.config.folder }}go.sum'
 
-      - name: Test ${{ matrix.config.name }}
+      - name: Unit Test ${{ matrix.config.name }}
         working-directory: ./${{ matrix.config.folder }}
         run: make test
+
+      - name: Component Tests
+        if: matrix.config.name == 'keptn-lifecycle-operator'
+        uses: ./.github/workflows/component-test.yml
 
       - name: Report code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -166,15 +166,8 @@ jobs:
   component_tests:
     name: Component Tests
     needs: prepare_ci_run
+    uses: ./.github/workflows/component-test.yml
 
-    steps:
-      - name: Run component tests
-        uses: ./.github/workflows/component-test.yml
-
-      - name: Report code coverage
-        uses: codecov/codecov-action@v3
-        with:
-          flags: component-tests
 
 #  integration_tests:
 #    name: Integration Tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -85,15 +85,11 @@ jobs:
         working-directory: ./${{ matrix.config.folder }}
         run: make test
 
-#      - name: Report code coverage
-#        uses: codecov/codecov-action@v3
-#        with:
-#          flags: ${{ matrix.config.name }}
-      - name: Upload coverage for unit tests
-        uses: actions/upload-artifact@v3
+      - name: Report code coverage
+        uses: codecov/codecov-action@v3
         with:
-          name: ${{ matrix.config.name }}-coverage.out
-          path: ${{ matrix.config.folder }}/cover.out
+          flags: ${{ matrix.config.name }}
+
 
 #  build_image:
 #    name: Build Docker Image
@@ -170,7 +166,15 @@ jobs:
   component_tests:
     name: Component Tests
     needs: prepare_ci_run
-    uses: ./.github/workflows/component-test.yml
+
+    steps:
+      - name: Run component tests
+        uses: ./.github/workflows/component-test.yml
+
+      - name: Report code coverage
+        uses: codecov/codecov-action@v3
+        with:
+          flags: component-tests
 
 #  integration_tests:
 #    name: Integration Tests

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -24,3 +24,9 @@ jobs:
     - name: Execute Component Tests
       working-directory: operator
       run: make component-test
+
+    - name: Upload coverage for component tests
+      uses: actions/upload-artifact@v3
+      with:
+        name: cover-component.out
+        path: 'operator/cover-component.out'

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -25,8 +25,7 @@ jobs:
       working-directory: operator
       run: make component-test
 
-    - name: Upload coverage for component tests
-      uses: actions/upload-artifact@v3
+    - name: Report code coverage
+      uses: codecov/codecov-action@v3
       with:
-        name: cover-component.out
-        path: 'operator/cover-component.out'
+        flags: component-tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -32,3 +32,7 @@ flags:
     paths:
       - scheduler/
     carryforward: true
+  component-tests:
+    paths:
+      - operator/
+    carryforward: true

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -91,8 +91,7 @@ test: manifests fmt vet generate envtest ## Run tests.
 
 .PHONY: component-test
 component-test: manifests generate envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/component/... -v -timeout 30m -coverprofile cover-component.out -coverpkg "github.com/keptn/lifecycle-toolkit/operator/controllers/..."
-	cat cover-component.out >> cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/component/... -v -timeout 30m -coverprofile cover.out -coverpkg "github.com/keptn/lifecycle-toolkit/operator/controllers/..."
 
 .PHONY: performance-test
 performance-test: manifests generate envtest ## Run tests.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -91,7 +91,8 @@ test: manifests fmt vet generate envtest ## Run tests.
 
 .PHONY: component-test
 component-test: manifests generate envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/component/... -v  -timeout 30m 
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/component/... -v -timeout 30m -coverprofile cover-component.out -coverpkg "github.com/keptn/lifecycle-toolkit/operator/controllers/..."
+	cat cover-component.out >> cover.out
 
 .PHONY: performance-test
 performance-test: manifests generate envtest ## Run tests.


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>

Add component tests to the coverage report: https://app.codecov.io/gh/keptn/lifecycle-toolkit/tree/chore%2Funify-coverage

We can see a bump from 57% to 68%