### PR TITLE
chore: execute performance tests after all other tests have been executed

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -181,7 +181,7 @@ jobs:
 
   performance_tests:
     name: Performance Tests
-    needs: [ prepare_ci_run, build_image ]
+    needs: [ prepare_ci_run, build_image, component_tests, integration_tests, e2e_tests, test ]
     uses: ./.github/workflows/performance-test.yml
 
   upload_images:


### PR DESCRIPTION
This PR avoids having multiple instances of the same controller running at the same time during the component/performance tests

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>