### PR TITLE
ci: pass locally built functions runner image to test setups

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -7,6 +7,10 @@ inputs:
    k3d-version:
      required: true
      description: "Version of k3d that should be used"
+   functions_runtime_tag:
+     description: "Tag for the functions runner image"
+     required: true
+
 runs:
   using: "composite"
   steps:
@@ -54,6 +58,7 @@ runs:
     shell: bash
     run: |
       sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
+      sed -i 's/ghcr.io\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.functions_runtime_tag }}/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -172,16 +172,22 @@ jobs:
   integration_tests:
     name: Integration Tests
     needs: [ prepare_ci_run, build_image ]
+    with:
+      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/integration-test.yml
 
   e2e_tests:
     name: End to End Tests
     needs: [ prepare_ci_run, build_image ]
+    with:
+      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/e2e-test.yml
 
   performance_tests:
     name: Performance Tests
     needs: [ prepare_ci_run, build_image, component_tests, integration_tests, e2e_tests, test ]
+    with:
+      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/performance-test.yml
 
   upload_images:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,11 @@
 name: E2E-Test
 on:
   workflow_call:
+    inputs:
+      functions_runtime_tag:
+        description: "Tag for the functions runner image"
+        type: "string"
+        required: true
 env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
@@ -29,6 +34,7 @@ jobs:
         with:
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
           k3d-version: ${{ env.K3D_VERSION }}
+          functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
 
       - name: Run E2E Tests ${{ matrix.config.name }}
         working-directory: ${{ matrix.config.folder }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,11 @@
 name: Integration-Test
 on:
   workflow_call:
+    inputs:
+      functions_runtime_tag:
+        description: "Tag for the functions runner image"
+        type: "string"
+        required: true
 env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
@@ -23,6 +28,7 @@ jobs:
         with:
           cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
           k3d-version: ${{ env.K3D_VERSION }}
+          functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
 
       - name: Download KUTTL
         run: |

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -1,6 +1,11 @@
 name: Performance Tests
 on:
   workflow_call:
+    inputs:
+      functions_runtime_tag:
+        description: "Tag for the functions runner image"
+        type: "string"
+        required: true
 env:
   GO_VERSION: "~1.19"
   CERT_MANAGER_VERSION: "v1.10.0"
@@ -22,6 +27,7 @@ jobs:
       with:
         cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
         k3d-version: ${{ env.K3D_VERSION }}
+        functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
 
     - name: Execute Performance Tests
       working-directory: operator


### PR DESCRIPTION
This PR should fix the failing integration tests on the release-please branches due to the missing functions runner image
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>