### PR TITLE
chore: enhance golangci-lint with code complexity and other measures

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -63,4 +63,3 @@ runs:
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w
-      kubectl describe pods -n keptn-lifecycle-toolkit-system -l component=scheduler

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -63,3 +63,4 @@ runs:
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w
       kubectl rollout status deployment klc-controller-manager -n keptn-lifecycle-toolkit-system -w
+      kubectl describe pods -n keptn-lifecycle-toolkit-system -l component=scheduler

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,11 +1,9 @@
 name: CI
 on:
-  # always execute docker build when something is pushed to main or a maintenance branch
   push:
     branches:
       - 'main'
       - '[0-9]+.[1-9][0-9]*.x'
-  # in addition, execute for pull requests to those branches
   pull_request:
     branches:
       - 'main'
@@ -69,7 +67,6 @@ jobs:
             folder: "operator/"
           - name: "scheduler"
             folder: "scheduler/"
-            # Nothing to test in functions-runtime
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -89,7 +86,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           flags: ${{ matrix.config.name }}
-
 
   build_image:
     name: Build Docker Image
@@ -167,7 +163,6 @@ jobs:
     name: Component Tests
     needs: prepare_ci_run
     uses: ./.github/workflows/component-test.yml
-
 
   integration_tests:
     name: Integration Tests

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,13 @@
 name: golangci-lint
-on: pull_request
+on:
+  push:
+    branches:
+      - 'main'
+      - '[0-9]+.[1-9][0-9]*.x'
+  pull_request:
+    branches:
+      - 'main'
+      - '[0-9]+.[1-9][0-9]*.x'
 env:
   GOLANGCI_LINT_VERSION: "v1.50.1"
   GO_VERSION: "1.19"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
+        continue-on-error: true
         with:
           working-directory: ${{ matrix.config.folder }}
           version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters-settings:
   gocyclo:
     min-complexity: 10
   gocognit:
-    min-complexity: 15
+    min-complexity: 20
   funlen:
     lines: 120
     statements: 120

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ issues:
         - containedctx
         - gocyclo
         - gocognit
+        - funlen
       path: _test\.go
 
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
     - dogsled       # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - nilnil        # Checks that there is no simultaneous return of nil error and an invalid value.
     - noctx         # noctx finds sending http request without context.Context
-    - gocyclo        # measure cyclomatic complexity
+    - gocyclo       # measure cyclomatic complexity
     - gocognit      # measure cognitive complexity
     - funlen        # limit function length
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,9 @@ linters:
     - dogsled       # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - nilnil        # Checks that there is no simultaneous return of nil error and an invalid value.
     - noctx         # noctx finds sending http request without context.Context
+    - gocyclo        # measure cyclomatic complexity
+    - gocognit      # measure cognitive complexity
+    - funlen        # limit function length
 
 issues:
   exclude-rules:
@@ -18,4 +21,14 @@ issues:
       text: '//+kubebuilder'
     - linters:
         - containedctx
+        - gocyclo
       path: _test\.go
+
+linters-settings:
+  gocyclo:
+    min-complexity: 10
+  gocognit:
+    min-complexity: 15
+  funlen:
+    lines: 120
+    statements: 120

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   timeout: 5m
   go: '1.19'
+  issue-exit-code: 0
 linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
@@ -13,6 +14,7 @@ linters:
     - gocyclo       # measure cyclomatic complexity
     - gocognit      # measure cognitive complexity
     - funlen        # limit function length
+    - dupl          # Detect code duplication
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ issues:
     - linters:
         - containedctx
         - gocyclo
+        - gocognit
       path: _test\.go
 
 linters-settings:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -83,11 +83,15 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests fmt vet generate envtest ## Run tests.
-	go test ./api/... -v
-	go test ./controllers/... -v  -coverprofile cover-pkg.out
-	go test ./webhooks/... -v  -coverprofile cover-main.out
-	cat cover-main.out cover-pkg.out > cover.out
-	rm cover-pkg.out cover-main.out
+	go test ./api/... -v -coverprofile cover-api.out
+	go test ./controllers/... -v -coverprofile cover-pkg.out
+	go test ./webhooks/... -v -coverprofile cover-main.out
+	sed -i '/mode: set/d' cover-api.out
+	sed -i '/mode: set/d' cover-pkg.out
+	sed -i '/mode: set/d' cover-main.out
+	echo "mode: set" > cover.out
+	cat cover-main.out cover-pkg.out cover-api.out >> cover.out
+	rm cover-pkg.out cover-main.out cover-api.out
 
 .PHONY: component-test
 component-test: manifests generate envtest ## Run tests.

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -86,7 +86,10 @@ test: manifests fmt vet envtest## Run tests.
 	go test ./pkg/... -coverprofile cover-pkg.out
 	go test ./cmd/scheduler -coverprofile cover-main.out
 	go test ./test/... -v -ginkgo.skip-file="e2e"
-	cat cover-main.out cover-pkg.out > cover.out
+	sed -i '/mode: set/d' cover-pkg.out
+	sed -i '/mode: set/d' cover-main.out
+	echo "mode: set" > cover.out
+	cat cover-main.out cover-pkg.out >> cover.out
 	rm cover-pkg.out cover-main.out
 
 


### PR DESCRIPTION
### This PR
- adds some more linters to golangci-lint:
  - `cyclop`: Measures and limits cyclomatic complexity
  - `gocognit`: Measures and limits cognitive complexity
  - `funlen`: Limits function line and statement length
- this change will enable us to get rid of sonarcloud since we have everything covered by golangci-lint
- adjusts makefile `test` commands to return aggregated and fully syntactically correct coverage reports


#### Notes:
- golangci-lint will fail until all errors are fixed in a follow up ticket
- for now golangci-lint will not make the pipeline go red since we cannot fix all errors right now

Closes #462

Linter issues will be fixed in #485.