### PR TITLE
feat: use scarf.sh registry for all container images

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -58,7 +58,7 @@ runs:
     shell: bash
     run: |
       sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
-      sed -i 's/ghcr.io\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.functions_runtime_tag }}/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
+      sed -i 's/ghcr.keptn.sh\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.functions_runtime_tag }}/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -58,7 +58,7 @@ runs:
     shell: bash
     run: |
       sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
-      sed -i 's/ghcr.keptn.sh\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.functions_runtime_tag }}/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
+      sed -i 's/ghcr.io\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.functions_runtime_tag }}/g' ~/download/artifacts/keptn-lifecycle-operator-manifest-test/release.yaml
       kubectl apply -f ~/download/artifacts/keptn-lifecycle-operator-manifest-test
       kubectl apply -f ~/download/artifacts/scheduler-manifest-test
       kubectl rollout status deployment keptn-scheduler -n keptn-lifecycle-toolkit-system -w

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
 
       - name: Create manifests
         env:
+          RELEASE_REGISTRY: ghcr.keptn.sh/keptn
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           cd scheduler

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -10,5 +10,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: docker.io/thschue/keptn-lifecycle-operator
+  newName: ghcr.keptn.sh/keptn/keptn-lifecycle-operator
   newTag: "202211141668444272"

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -47,7 +47,7 @@ spec:
           - name: OTEL_COLLECTOR_URL
             value: otel-collector:4317
           - name: FUNCTION_RUNNER_IMAGE
-            value: ghcr.io/keptn/functions-runtime:v0.4.1 #x-release-please-version
+            value: ghcr.keptn.sh/keptn/functions-runtime:v0.4.1 #x-release-please-version
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/scheduler/manifests/install/kustomization.yaml
+++ b/scheduler/manifests/install/kustomization.yaml
@@ -13,11 +13,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: image
-  newName: ghcr.io/keptn/scheduler
+  newName: ghcr.keptn.sh/keptn/scheduler
   newTag: "202211041667586936"
 - name: klfc-scheduler
   newName: docker.io/thschue/scheduler
   newTag: "202211021667386780"
 - name: scheduler
-  newName: docker.io/thschue/scheduler
-  newTag: "202211071667824605"
+  newName: mowies/scheduler
+  newTag: 0.5.0-next.13

--- a/scheduler/manifests/install/kustomization.yaml
+++ b/scheduler/manifests/install/kustomization.yaml
@@ -12,12 +12,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: image
-  newName: ghcr.keptn.sh/keptn/scheduler
-  newTag: "202211041667586936"
-- name: klfc-scheduler
-  newName: docker.io/thschue/scheduler
-  newTag: "202211021667386780"
 - name: scheduler
-  newName: mowies/scheduler
+  newName: ghcr.keptn.sh/keptn/scheduler
   newTag: 0.5.0-next.13


### PR DESCRIPTION
### This PR
- introduces a new container registry under our own keptn domain
- this gives keptn the option to keep track of download numbers and versions of KLT that are downloaded

THIS IS A BREAKING CHANGE

Part of #195 