### PR TITLE
chore: upgrade examples and tests to v1alpha2

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -35,7 +35,6 @@ runs:
         --agents 1
         --no-lb
         --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-        --image "rancher/k3s:v1.24.8-k3s1"
 
   - name: Import images in k3d
     shell: bash

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -35,6 +35,7 @@ runs:
         --agents 1
         --no-lb
         --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+        --image "rancher/k3s:v1.24.8-k3s1"
 
   - name: Import images in k3d
     shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,16 +39,3 @@ jobs:
       - name: Run E2E Tests ${{ matrix.config.name }}
         working-directory: ${{ matrix.config.folder }}
         run: make e2e-test
-
-      - name: Generate logs
-        working-directory: ${{ matrix.config.folder }}
-        if: always()
-        run: |
-          kubectl logs -n cert-manager deployments/cert-manager-webhook > cert-manager-logs.txt
-
-      - name: Upload logs as artifact
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: cert-manager-logs
-          path: ${{ matrix.config.folder }}/cert-manager-logs.txt

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Upload logs as artifact
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: cert-manager-logs
           path: ${{ matrix.config.folder }}/cert-manager-logs.txt

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -39,3 +39,15 @@ jobs:
       - name: Run E2E Tests ${{ matrix.config.name }}
         working-directory: ${{ matrix.config.folder }}
         run: make e2e-test
+
+      - name: Generate logs
+        working-directory: ${{ matrix.config.folder }}
+        if: always()
+        run: |
+          kubectl logs -n cert-manager deployments/cert-manager-webhook > cert-manager-logs.txt
+
+      - name: Upload logs as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cert-manager-logs
+          path: ${{ matrix.config.folder }}/cert-manager-logs.txt

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -39,16 +39,3 @@ jobs:
       - name: Run Integration Tests
         working-directory: .
         run: make integration-test
-
-      - name: Generate logs
-        working-directory: .
-        if: always()
-        run: |
-          kubectl logs -n keptn-lifecycle-toolkit-system deployments/klc-controller-manager > controller-logs.txt
-
-      - name: Upload logs as artifact
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: controller-logs
-          path: controller-logs.txt

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -39,3 +39,15 @@ jobs:
       - name: Run Integration Tests
         working-directory: .
         run: make integration-test
+
+      - name: Generate logs
+        working-directory: .
+        if: always()
+        run: |
+          kubectl logs -n keptn-lifecycle-toolkit-system deployments/klc-controller-manager > controller-logs.txt
+
+      - name: Upload logs as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: controller-logs
+          path: controller-logs.txt

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,6 +47,7 @@ jobs:
           kubectl logs -n keptn-lifecycle-toolkit-system deployments/klc-controller-manager > controller-logs.txt
 
       - name: Upload logs as artifact
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: controller-logs

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ An App contains information about all workloads and checks associated with an ap
 It will use the following structure for the specification of the pre/post deployment and pre/post evaluations checks that should be executed at app level:
 
 ```
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
 name: podtato-head
@@ -252,7 +252,7 @@ A task definition can be configured in three different ways:
 An inline task definition looks like the following:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: deployment-hello
@@ -269,7 +269,7 @@ A further example, is available [here](./examples/taskonly-hello-keptn/inline/ta
 To runtime can also fetch the script on the fly from a remote webserver. For this, the CRD should look like the following:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-http
@@ -285,7 +285,7 @@ Finally, `KeptnTaskDefinition` can build on top of other `KeptnTaskDefinition`s.
 This is a common use case where a general function can be re-used in multiple places with different parameters.
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: slack-notification-dev
@@ -321,7 +321,7 @@ as part of pre- and post-analysis phases of a workload or application.
 A Keptn evaluation definition looks like the following:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: my-prometheus-evaluation
@@ -344,7 +344,7 @@ pre- and post-analysis phases of a workload or application.
 A Keptn evaluation provider looks like the following:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationProvider
 metadata:
   name: prometheus

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ name: podtato-head
 namespace: podtato-kubectl
 spec:
 version: "1.3"
+revision: "1"
 workloads:
 - name: podtato-head-left-arm
 version: 0.1.0

--- a/examples/kubecon-na-22-demo/base/app-post-deploy.yaml
+++ b/examples/kubecon-na-22-demo/base/app-post-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: post-deployment-notification

--- a/examples/kubecon-na-22-demo/base/app.yaml
+++ b/examples/kubecon-na-22-demo/base/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
   name: podtato-head

--- a/examples/kubecon-na-22-demo/base/provider.yaml
+++ b/examples/kubecon-na-22-demo/base/provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationProvider
 metadata:
   name: prometheus

--- a/examples/kubecon-na-22-demo/version-1/app-pre-deploy-eval.yaml
+++ b/examples/kubecon-na-22-demo/version-1/app-pre-deploy-eval.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: app-pre-deploy-eval-1

--- a/examples/kubecon-na-22-demo/version-1/app-pre-deploy.yaml
+++ b/examples/kubecon-na-22-demo/version-1/app-pre-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-check-entry

--- a/examples/kubecon-na-22-demo/version-1/app.yaml
+++ b/examples/kubecon-na-22-demo/version-1/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
   name: podtato-head

--- a/examples/kubecon-na-22-demo/version-2/app-pre-deploy-eval.yaml
+++ b/examples/kubecon-na-22-demo/version-2/app-pre-deploy-eval.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: app-pre-deploy-eval-2

--- a/examples/kubecon-na-22-demo/version-2/app-pre-deploy.yaml
+++ b/examples/kubecon-na-22-demo/version-2/app-pre-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-check-entry

--- a/examples/kubecon-na-22-demo/version-2/app.yaml
+++ b/examples/kubecon-na-22-demo/version-2/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
   name: podtato-head

--- a/examples/kubecon-na-22-demo/version-3/app-pre-deploy-eval.yaml
+++ b/examples/kubecon-na-22-demo/version-3/app-pre-deploy-eval.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: app-pre-deploy-eval-2

--- a/examples/kubecon-na-22-demo/version-3/app-pre-deploy.yaml
+++ b/examples/kubecon-na-22-demo/version-3/app-pre-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-check-entry

--- a/examples/kubecon-na-22-demo/version-3/app.yaml
+++ b/examples/kubecon-na-22-demo/version-3/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
   name: podtato-head

--- a/examples/observability/assets/podtatohead-deployment-evaluation/app.yaml
+++ b/examples/observability/assets/podtatohead-deployment-evaluation/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
   name: podtato-head

--- a/examples/observability/assets/podtatohead-deployment-evaluation/check_entry.yaml
+++ b/examples/observability/assets/podtatohead-deployment-evaluation/check_entry.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: check-entry-service

--- a/examples/observability/assets/podtatohead-deployment-evaluation/keptnevaluationprovider.yaml
+++ b/examples/observability/assets/podtatohead-deployment-evaluation/keptnevaluationprovider.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationProvider
 metadata:
   name: prometheus

--- a/examples/observability/assets/podtatohead-deployment-evaluation/post-deployment-tasks.yaml
+++ b/examples/observability/assets/podtatohead-deployment-evaluation/post-deployment-tasks.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: post-deployment-hello

--- a/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition1.yaml
+++ b/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition1.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: my-prometheus-definition1

--- a/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition2.yaml
+++ b/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition2.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: my-prometheus-definition2

--- a/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition3.yaml
+++ b/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition3.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: my-prometheus-definition2

--- a/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition4.yaml
+++ b/examples/observability/assets/podtatohead-evaluationdefinitions/keptnevaluationdefinition4.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: my-prometheus-definition1

--- a/examples/podtatohead-deployment/app.yaml
+++ b/examples/podtatohead-deployment/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnApp
 metadata:
   name: podtato-head

--- a/examples/podtatohead-deployment/app.yaml
+++ b/examples/podtatohead-deployment/app.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: podtato-kubectl
 spec:
   version: "1.3"
+  revision: "1"
   workloads:
     - name: podtato-head-left-arm
       version: 0.2.7

--- a/examples/podtatohead-deployment/check_entry.yaml
+++ b/examples/podtatohead-deployment/check_entry.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: check-entry-service

--- a/examples/podtatohead-deployment/post-deployment-tasks.yaml
+++ b/examples/podtatohead-deployment/post-deployment-tasks.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: post-deployment-hello

--- a/examples/single-service/pre-deployment-tasks.yaml
+++ b/examples/single-service/pre-deployment-tasks.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello

--- a/examples/taskonly-hello-keptn/http/task.yaml
+++ b/examples/taskonly-hello-keptn/http/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTask
 metadata:
   name: hello-developer-http

--- a/examples/taskonly-hello-keptn/http/taskdefinition.yaml
+++ b/examples/taskonly-hello-keptn/http/taskdefinition.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-http

--- a/examples/taskonly-hello-keptn/inline/task.yaml
+++ b/examples/taskonly-hello-keptn/inline/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTask
 metadata:
   name: hello-developer-inline

--- a/examples/taskonly-hello-keptn/inline/taskdefinition.yaml
+++ b/examples/taskonly-hello-keptn/inline/taskdefinition.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-inline

--- a/examples/taskonly-hello-keptn/upstream/task.yaml
+++ b/examples/taskonly-hello-keptn/upstream/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTask
 metadata:
   name: hello-developer-upstream

--- a/examples/taskonly-hello-keptn/upstream/taskdefinition.yaml
+++ b/examples/taskonly-hello-keptn/upstream/taskdefinition.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-upstream

--- a/examples/taskonly-hello-keptn/upstream/taskdefinition_upstream.yaml
+++ b/examples/taskonly-hello-keptn/upstream/taskdefinition_upstream.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-upstream-parent

--- a/test/integration/simple-daemonset-annotated/00-install.yaml
+++ b/test/integration/simple-daemonset-annotated/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello

--- a/test/integration/simple-daemonset-annotated/01-assert.yaml
+++ b/test/integration/simple-daemonset-annotated/01-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkload
 metadata:
   name: work-work
 
 ---
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkloadInstance
 metadata:
   name: work-work-0.4

--- a/test/integration/simple-daemonset-annotated/02-assert.yaml
+++ b/test/integration/simple-daemonset-annotated/02-assert.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkloadInstance
 metadata:
   name: work-work-0.5

--- a/test/integration/simple-deployment-annotated/00-install.yaml
+++ b/test/integration/simple-deployment-annotated/00-install.yaml
@@ -1,7 +1,7 @@
 
 ---
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello

--- a/test/integration/simple-deployment-annotated/01-assert.yaml
+++ b/test/integration/simple-deployment-annotated/01-assert.yaml
@@ -1,10 +1,10 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkload
 metadata:
   name: waiter-waiter
 ---
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkloadInstance
 metadata:
   name: waiter-waiter-0.4

--- a/test/integration/simple-deployment/00-install.yaml
+++ b/test/integration/simple-deployment/00-install.yaml
@@ -1,6 +1,6 @@
 
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello

--- a/test/integration/simple-deployment/01-assert.yaml
+++ b/test/integration/simple-deployment/01-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkload
 metadata:
   name: waiter-waiter
 
 ---
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkloadInstance
 metadata:
   name: waiter-waiter-0.4

--- a/test/integration/simple-statefulset-annotated/00-install.yaml
+++ b/test/integration/simple-statefulset-annotated/00-install.yaml
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello

--- a/test/integration/simple-statefulset-annotated/01-assert.yaml
+++ b/test/integration/simple-statefulset-annotated/01-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkload
 metadata:
   name: work-work
 
 ---
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkloadInstance
 metadata:
   name: work-work-0.4

--- a/test/integration/simple-statefulset-annotated/02-assert.yaml
+++ b/test/integration/simple-statefulset-annotated/02-assert.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: lifecycle.keptn.sh/v1alpha1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnWorkloadInstance
 metadata:
   name: work-work-0.5


### PR DESCRIPTION
### This PR
- updates the following files to lifecycle.keptn.sh/v1alpha2:
  - examples
  - integration tests (except KeptnApp API conversion test)
  - README

Part of #471 