### PR TITLE
ci: fix main builds by adding missing env variables

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -190,6 +190,10 @@ jobs:
     needs: [prepare_ci_run, test, component_tests, integration_tests, e2e_tests, performance_tests]
     if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true' # only run on push to main/maintenance branches
     runs-on: ubuntu-22.04
+    env:
+      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
+      BUILD_TIME: ${{ needs.prepare_ci_run.outputs.BUILD_TIME }}
+      GIT_SHA: ${{ needs.prepare_ci_run.outputs.GIT_SHA }}
     strategy:
       matrix:
         config:


### PR DESCRIPTION
### This PR
- fixes a few things on main CI builds
- some environment variables were used but not set up correctly which resulted in faulty container image tags (`dev-` instead of `dev-<some-timestamp>`)