### PR TITLE
ci: run performance tests parallel to e2e and integration tests

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -7,6 +7,11 @@ inputs:
    k3d-version:
      required: true
      description: "Version of k3d that should be used"
+   k3s-version:
+     required: false
+     description: "Version of k3s that should be used"
+     # renovate: datasource=github-releases depName=k3d-io/k3d
+     default: "rancher/k3s:v1.24.8-k3s1"
    functions_runtime_tag:
      description: "Tag for the functions runner image"
      required: true
@@ -35,6 +40,7 @@ runs:
         --agents 1
         --no-lb
         --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+        --image "${{ inputs.k3s-version }}"
 
   - name: Import images in k3d
     shell: bash

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -10,7 +10,7 @@ inputs:
    k3s-version:
      required: false
      description: "Version of k3s that should be used"
-     # renovate: datasource=github-releases depName=k3d-io/k3d
+     # renovate: datasource=github-releases depName=k3s-io/k3s
      default: "rancher/k3s:v1.24.8-k3s1"
    functions_runtime_tag:
      description: "Tag for the functions runner image"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -181,7 +181,7 @@ jobs:
 
   performance_tests:
     name: Performance Tests
-    needs: [ prepare_ci_run, build_image, component_tests, integration_tests, e2e_tests, test ]
+    needs: [ prepare_ci_run, build_image ]
     with:
       functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/performance-test.yml


### PR DESCRIPTION
### This PR

- uses the k3s version `v1.24.8` to avoid [this](https://github.com/k3s-io/k3s/issues/5835) networking bug
- runs performance-tests again in parallel with the e2e- and integration-tests
- fixes #516

Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>