### PR TITLE
feat(operator): fix ownership information for keptnworkloads

### DIFF
--- a/operator/webhooks/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutating_webhook.go
@@ -429,6 +429,9 @@ func (a *PodMutatingWebhook) generateWorkload(ctx context.Context, pod *corev1.P
 			Name:        a.getWorkloadName(pod),
 			Namespace:   namespace,
 			Annotations: traceContextCarrier,
+			OwnerReferences: []metav1.OwnerReference{
+				ownerRef,
+			},
 		},
 		Spec: klcv1alpha2.KeptnWorkloadSpec{
 			AppName:                   applicationName,
@@ -492,6 +495,7 @@ func (a *PodMutatingWebhook) getOwnerReference(resource *metav1.ObjectMeta) meta
 				reference.UID = owner.UID
 				reference.Kind = owner.Kind
 				reference.Name = owner.Name
+				reference.APIVersion = owner.APIVersion
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the way how lifecycle toolkit resources are correlated in ArgoCD. Looks like this in the end:
![image](https://user-images.githubusercontent.com/38893055/207606789-c3d7168a-1517-4153-9c6c-8bee073e58ad.png)

Signed-off-by: Thomas Schuetz <thomas.schuetz@dynatrace.com>