### PR TITLE
ci: use kind instead of k3d for tests

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -15,7 +15,7 @@ inputs:
      required: false
      description: "Kubernetes that should be used"
      # renovate: datasource=github-releases depName=kubernetes/kubernetes
-     default: "v1.26.0"
+     default: "v1.25.3"
    functions_runtime_tag:
      description: "Tag for the functions runner image"
      required: true

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -2,16 +2,20 @@ name: "Deploy Keptn Lifecycle Toolkit on GH cluster"
 description: "Creates a Kind cluster and deploys Keptn Lifecycle Toolkit"
 inputs:
    cert-manager-version:
-     required: true
-     description: "Version of cert-manager that should be deployed"
-   k3d-version:
-     required: true
-     description: "Version of k3d that should be used"
-   k3s-version:
      required: false
-     description: "Version of k3s that should be used"
-     # renovate: datasource=github-releases depName=k3s-io/k3s
-     default: "rancher/k3s:v1.24.8-k3s1"
+     description: "Version of cert-manager that should be deployed"
+     # renovate: datasource=github-releases depName=cert-manager/cert-manager
+     default: "v1.10.0"
+   kind-version:
+     required: false
+     description: "Version of kind that should be used"
+     # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+     default: "v0.17.0"
+   k8s-version:
+     required: false
+     description: "Kubernetes that should be used"
+     # renovate: datasource=github-releases depName=kubernetes/kubernetes
+     default: "v1.26.0"
    functions_runtime_tag:
      description: "Tag for the functions runner image"
      required: true
@@ -31,16 +35,13 @@ runs:
     with:
       path: ~/download/artifacts
 
-  - name: "Create single k3d Cluster"
-    uses: AbsaOSS/k3d-action@v2
+  - name: "Create single kind Cluster"
+    uses: helm/kind-action@v1.5.0
     with:
-      cluster-name: test-cluster
-      k3d-version: ${{ inputs.k3d-version }}
-      args: >-
-        --agents 1
-        --no-lb
-        --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
-        --image "${{ inputs.k3s-version }}"
+      cluster_name: test-cluster
+      version: ${{ inputs.kind-version }}
+      node_image: "kindest/node:${{ inputs.k8s-version }}"
+      kubectl_version: ${{ inputs.k8s-version }}
 
   - name: Import images in k3d
     shell: bash
@@ -49,7 +50,7 @@ runs:
       for image in $(ls | grep image.tar);
       do
         echo "Importing image: $image"
-        k3d image import $image/$image -c test-cluster
+        kind load image-archive $image/$image -n test-cluster
       done
   
   - name: Install cert-manager

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -19,6 +19,10 @@ inputs:
    functions_runtime_tag:
      description: "Tag for the functions runner image"
      required: true
+   cluster-name:
+     required: false
+     description: "Name of the kind cluster"
+     default: "test-cluster"
 
 runs:
   using: "composite"
@@ -38,7 +42,7 @@ runs:
   - name: "Create single kind Cluster"
     uses: helm/kind-action@v1.5.0
     with:
-      cluster_name: test-cluster
+      cluster_name: ${{ inputs.cluster-name }}
       version: ${{ inputs.kind-version }}
       node_image: "kindest/node:${{ inputs.k8s-version }}"
       kubectl_version: ${{ inputs.k8s-version }}
@@ -50,7 +54,7 @@ runs:
       for image in $(ls | grep image.tar);
       do
         echo "Importing image: $image"
-        kind load image-archive $image/$image -n test-cluster
+        kind load image-archive $image/$image -n ${{ inputs.cluster-name }}
       done
   
   - name: Install cert-manager

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,10 +8,6 @@ on:
         required: true
 env:
   GO_VERSION: "~1.19"
-  # renovate: datasource=github-releases depName=cert-manager/cert-manager
-  CERT_MANAGER_VERSION: "v1.10.0"
-  # renovate: datasource=github-releases depName=k3d-io/k3d
-  K3D_VERSION: "v5.4.6"
 defaults:
   run:
     shell: bash
@@ -34,8 +30,6 @@ jobs:
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
-          cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
-          k3d-version: ${{ env.K3D_VERSION }}
           functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
 
       - name: Run E2E Tests ${{ matrix.config.name }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,11 +9,7 @@ on:
 env:
   GO_VERSION: "~1.19"
   # renovate: datasource=github-releases depName=cert-manager/cert-manager
-  CERT_MANAGER_VERSION: "v1.10.0"
-  # renovate: datasource=github-tags depName=kudobuilder/kuttl
   KUTTL_VERSION: "0.13.0"
-  # renovate: datasource=github-releases depName=k3d-io/k3d
-  K3D_VERSION: "v5.4.6"
 defaults:
   run:
     shell: bash
@@ -29,8 +25,6 @@ jobs:
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
-          cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
-          k3d-version: ${{ env.K3D_VERSION }}
           functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
 
       - name: Download KUTTL

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ on:
         required: true
 env:
   GO_VERSION: "~1.19"
-  # renovate: datasource=github-releases depName=cert-manager/cert-manager
+  # renovate: datasource=github-tags depName=kudobuilder/kuttl
   KUTTL_VERSION: "0.13.0"
 defaults:
   run:

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -8,11 +8,7 @@ on:
         required: true
 env:
   GO_VERSION: "~1.19"
-  # renovate: datasource=github-releases depName=cert-manager/cert-manager
-  CERT_MANAGER_VERSION: "v1.10.0"
   USE_EXISTING_CLUSTER: "true"
-  # renovate: datasource=github-releases depName=k3d-io/k3d
-  K3D_VERSION: "v5.4.6"
 defaults:
   run:
     shell: bash
@@ -27,8 +23,6 @@ jobs:
     - name: Setup cluster
       uses: ./.github/actions/deploy-klt-on-cluster
       with:
-        cert-manager-version: ${{ env.CERT_MANAGER_VERSION }}
-        k3d-version: ${{ env.K3D_VERSION }}
         functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
 
     - name: Execute Performance Tests


### PR DESCRIPTION
### This PR

- uses `kind` instead of `k3d` for testing

Signed-off-by: Philipp Hinteregger <philipp.hinteregger@dynatrace.com>