### PR TITLE
ci: fix renovate by ignoring KLT container images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,17 +36,23 @@
       "addLabels": ["docker"]
     },
     {
+      "matchManagers": ["kustomize"],
+      "excludePackageNames": [
+        "ghcr.keptn.sh/keptn/keptn-lifecycle-operator",
+        "ghcr.keptn.sh/keptn/scheduler"
+      ]
+    },
+    {
       "matchPackageNames": ["kubernetes-sigs/kustomize"],
       "extractVersion": "^kustomize/(?<version>.*)$"
     },
     {
-      "matchPackageNames": [
+      "excludePackageNames": [
         "docker.io/thschue/keptn-lifecycle-operator",
         "docker.io/thschue/scheduler",
         "docker.io/annadreal/keptn-lifecycle-operator",
         "docker.io/annadreal/kube-scheduler"
-      ],
-      "enabled": false
+      ]
     }
   ],
   "regexManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,7 @@
   "ignoreDeps": [
     "ghcr.keptn.sh/keptn/keptn-lifecycle-operator",
     "ghcr.keptn.sh/keptn/scheduler",
+    "ghcr.keptn.sh/keptn/functions-runtime",
     "docker.io/thschue/keptn-lifecycle-operator",
     "docker.io/thschue/scheduler",
     "docker.io/annadreal/keptn-lifecycle-operator",

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,10 @@
       "enabled": false
     }
   ],
+  "ignoreDeps": [
+    "ghcr.keptn.sh/keptn/keptn-lifecycle-operator",
+    "ghcr.keptn.sh/keptn/scheduler"
+  ],
   "packageRules": [
     {
       "matchManagers": ["gomod"],

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,11 @@
   ],
   "ignoreDeps": [
     "ghcr.keptn.sh/keptn/keptn-lifecycle-operator",
-    "ghcr.keptn.sh/keptn/scheduler"
+    "ghcr.keptn.sh/keptn/scheduler",
+    "docker.io/thschue/keptn-lifecycle-operator",
+    "docker.io/thschue/scheduler",
+    "docker.io/annadreal/keptn-lifecycle-operator",
+    "docker.io/annadreal/kube-scheduler"
   ],
   "packageRules": [
     {
@@ -42,14 +46,6 @@
     {
       "matchPackageNames": ["kubernetes-sigs/kustomize"],
       "extractVersion": "^kustomize/(?<version>.*)$"
-    },
-    {
-      "excludePackageNames": [
-        "docker.io/thschue/keptn-lifecycle-operator",
-        "docker.io/thschue/scheduler",
-        "docker.io/annadreal/keptn-lifecycle-operator",
-        "docker.io/annadreal/kube-scheduler"
-      ]
     }
   ],
   "regexManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
     "**/test/**",
     "**/tests/**"
   ],
+  "hostRules": [
+    {
+      "matchHost": "ghcr.keptn.sh",
+      "enabled": false
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["gomod"],
@@ -34,13 +40,6 @@
     {
       "matchManagers": ["dockerfile"],
       "addLabels": ["docker"]
-    },
-    {
-      "matchManagers": ["kustomize"],
-      "excludePackageNames": [
-        "ghcr.keptn.sh/keptn/keptn-lifecycle-operator",
-        "ghcr.keptn.sh/keptn/scheduler"
-      ]
     },
     {
       "matchPackageNames": ["kubernetes-sigs/kustomize"],

--- a/renovate.json
+++ b/renovate.json
@@ -22,12 +22,6 @@
     "**/test/**",
     "**/tests/**"
   ],
-  "hostRules": [
-    {
-      "matchHost": "ghcr.keptn.sh",
-      "enabled": false
-    }
-  ],
   "ignoreDeps": [
     "ghcr.keptn.sh/keptn/keptn-lifecycle-operator",
     "ghcr.keptn.sh/keptn/scheduler"


### PR DESCRIPTION
### This PR
- fixes renovate in the KLT by ignoring the scheduler and operator images