### PR TITLE
feat: generate SBOMs for container images on release

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -160,11 +160,6 @@ jobs:
           name: ${{ matrix.config.name }}-manifest-test
           path: ${{ matrix.config.folder }}/config/rendered/release.yaml
 
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          output-file: ./sbom-${{ matrix.config.name }}.spdx.json
-
   component_tests:
     name: Component Tests
     needs: prepare_ci_run

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -160,6 +160,11 @@ jobs:
           name: ${{ matrix.config.name }}-manifest-test
           path: ${{ matrix.config.folder }}/config/rendered/release.yaml
 
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          output-file: ./sbom-${{ matrix.config.name }}.spdx.json
+
   component_tests:
     name: Component Tests
     needs: prepare_ci_run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,19 @@ jobs:
           COSIGN_EXPERIMENTAL: 1
         run: cosign sign ${{ env.IMAGE_TAG }}
 
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0.13.1
+        with:
+          image: ${{ env.IMAGE_TAG }}
+          artifact-name: sbom-${{ matrix.config.name }}
+          output-file: ./sbom-${{ matrix.config.name }}.spdx.json
+
+      - name: Attach SBOM to release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: ./sbom-${{ matrix.config.name }}.spdx.json
+
   release-manifests:
     if: needs.release-please.outputs.releases_created == 'true'
     needs:


### PR DESCRIPTION
### This PR
- generates SBOMs for all 3 container images upon release
- the SBOMs are attached to the newly created release in JSON format

Fixes #300