### PR TITLE
docs: fix build status readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Keptn Lifecycle Toolkit
 
-![build](https://img.shields.io/github/workflow/status/keptn/lifecycle-toolkit/CI)
 ![build](https://img.shields.io/github/actions/workflow/status/keptn/lifecycle-toolkit/CI.yaml?branch=main)
 ![Codecov](https://img.shields.io/codecov/c/github/keptn/lifecycle-toolkit?token=KPGfrBb2sA)
 ![goversion](https://img.shields.io/github/go-mod/go-version/keptn/lifecycle-toolkit?filename=operator%2Fgo.mod)


### PR DESCRIPTION
### This PR
- fixes the build status badge at the top of the KLT readme according to https://github.com/badges/shields/issues/8671