### PR TITLE
ci: docs auto update on release

### DIFF
--- a/.github/actions/update-documentation/action.yml
+++ b/.github/actions/update-documentation/action.yml
@@ -91,8 +91,8 @@ runs:
     - name: Commit changes to docs repo
       uses: EndBug/add-and-commit@v9
       with:
-        committer_name: "Keptn Sandbox Bot"
-        committer_email: "keptn-sandbox@keptn.sh"
+        author_name: "Keptn Sandbox Bot"
+        author_email: "keptn-sandbox@keptn.sh"
         commit: "--signoff"
         cwd: ${{ inputs.doc-repo-path }}
         message: "docs: update documentation for version ${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,3 +163,4 @@ jobs:
           version: ${{ needs.release-please.outputs.tag_name }}
           klt-repo: ${{ github.workspace }}
           token: ${{ secrets.KEPTN_SANDBOX_BOT_TOKEN }}
+          update-main: true


### PR DESCRIPTION
### This PR
- makes sure that upon release of KLT, also the default version in the docs get updated to the new one
- fixes commit author name and email address