### PR TITLE
ci: let renovate pick up hugo version

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,8 @@ DOCREPO := github.com/keptn-sandbox/lifecycle-toolkit-docs
 TMPDIR := $(CURDIR)/tmp
 VOLUMES := -v $(TMPDIR)/lifecycle-toolkit-docs:/src -v $(CURDIR)/content/docs:/src/content/en/docs
 # renovate: datasource=docker depName=klakegg/hugo
-IMAGE := klakegg/hugo:0.105.0-ext
+HUGO_VERSION := 0.105.0-ext
+IMAGE := klakegg/hugo:$(HUGO_VERSION)
 
 .PHONY: build server clean htmltest
 


### PR DESCRIPTION
### This PR
- makes sure that the docs tooling hugo version is picked up by renovate using the correct syntax