### PR TITLE
chore: update observability demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to install the latest release of the Lifecycle Toolkit.
 
 The Lifecycle Toolkit uses the OpenTelemetry collector to provide a vendor-agnostic implementation of how to receive,
 process and export telemetry data. To install it, follow their [installation instructions](https://opentelemetry.io/docs/collector/getting-started/).
-We also provide some more information about this in our [observability example](./examples/observability/).
+We also provide some more information about this in our [observability example](./examples/support/observability/).
 
 ## Goals
 


### PR DESCRIPTION
Fix the broken link to the observability demo

Closes issue: https://github.com/keptn/lifecycle-toolkit/issues/665

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>