### PR TITLE
perf: requeue `KeptnMetric` and process them only when deadline is met

### DIFF
--- a/operator/controllers/metrics/keptnmetric_controller.go
+++ b/operator/controllers/metrics/keptnmetric_controller.go
@@ -77,7 +77,7 @@ func (r *KeptnMetricReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	fetchTime := metric.Status.LastUpdated.Add(time.Second * time.Duration(metric.Spec.FetchIntervalSeconds))
 	if time.Now().Before(fetchTime) {
-		diff := fetchTime.Sub(time.Now())
+		diff := time.Until(fetchTime)
 		r.Log.Info("Metric has not been updated for the configured interval. Skipping")
 		return ctrl.Result{Requeue: true, RequeueAfter: diff}, nil
 	}

--- a/operator/controllers/metrics/keptnmetric_controller.go
+++ b/operator/controllers/metrics/keptnmetric_controller.go
@@ -77,8 +77,9 @@ func (r *KeptnMetricReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	fetchTime := metric.Status.LastUpdated.Add(time.Second * time.Duration(metric.Spec.FetchIntervalSeconds))
 	if time.Now().Before(fetchTime) {
+		diff := fetchTime.Sub(time.Now())
 		r.Log.Info("Metric has not been updated for the configured interval. Skipping")
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: diff}, nil
 	}
 
 	evaluationProvider, err := r.fetchProvider(ctx, types.NamespacedName{Name: metric.Spec.Provider.Name, Namespace: metric.Namespace})


### PR DESCRIPTION
Signed-off-by: Giovanni Liva <giovanni.liva@dynatrace.com>