### PR TITLE
ci: add step to cache build tools in artifact upload job

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -216,6 +216,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache build tools
+        id: cache-build-tools
+        uses: actions/cache@v3
+        with:
+          path: ./${{ matrix.config.folder }}/bin
+          key: build-tools-${{ github.ref_name }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -115,6 +115,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache build tools
+        id: cache-build-tools
+        uses: actions/cache@v3
+        with:
+          path: ./${{ matrix.config.folder }}/bin
+          key: build-tools-${{ github.ref_name }}
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Cache build tools operator
+        id: cache-build-tools
+        uses: actions/cache@v3
+        with:
+          path: ./operator/bin
+          key: build-tools-${{ github.ref_name }}
+
+      - name: Cache build tools scheduler
+        id: cache-build-tools
+        uses: actions/cache@v3
+        with:
+          path: ./scheduler/bin
+          key: build-tools-${{ github.ref_name }}
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
### This PR
- adds a cache step for the build tools so that we should see less GH API rate limiting happening in our pipeline
- caching for the cert manager will be added in #687

Fixes #563