### PR TITLE
fix: security pipeline issues

### DIFF
--- a/.github/.kubescape/exceptions.json
+++ b/.github/.kubescape/exceptions.json
@@ -1,64 +1,84 @@
 [
-    {
-      "name": "ignore-cluster-role-can-get-secrets",
-      "policyType": "postureExceptionPolicy",
-      "actions": [
-        "alertOnly"
-      ],
-      "resources": [
-        {
-          "designatorType": "Attributes",
-          "attributes": {
-            "kind": "ServiceAccount",
-            "name": "klc-controller-manager"
-          }
+  {
+    "name": "ignore-cluster-role-can-get-secrets",
+    "policyType": "postureExceptionPolicy",
+    "actions": [
+      "alertOnly"
+    ],
+    "resources": [
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "ServiceAccount",
+          "name": "klc-controller-manager"
         }
-      ],
-      "posturePolicies": [
-          {
-              "controlID": "C-0015" 
-          }
-      ]
-    },
-    {
-      "name": "ignore-auto-mounting-of-service-account-tokens",
-      "policyType": "postureExceptionPolicy",
-      "actions": [
-        "alertOnly"
-      ],
-      "resources": [
-        {
-          "designatorType": "Attributes",
-          "attributes": {
-            "kind": ".*"
-          }
+      }
+    ],
+    "posturePolicies": [
+      {
+        "controlID": "C-0015"
+      }
+    ]
+  },
+  {
+    "name": "ignore-auto-mounting-of-service-account-tokens",
+    "policyType": "postureExceptionPolicy",
+    "actions": [
+      "alertOnly"
+    ],
+    "resources": [
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": ".*"
         }
-      ],
-      "posturePolicies": [
-          {
-              "controlID": "C-0034" 
-          }
-      ]
-    },
-    {
-      "name": "ignore-access-container-service-account",
-      "policyType": "postureExceptionPolicy",
-      "actions": [
-        "alertOnly"
-      ],
-      "resources": [
-        {
-          "designatorType": "Attributes",
-          "attributes": {
-            "kind": ".*"
-          }
+      }
+    ],
+    "posturePolicies": [
+      {
+        "controlID": "C-0034"
+      }
+    ]
+  },
+  {
+    "name": "ignore-access-container-service-account",
+    "policyType": "postureExceptionPolicy",
+    "actions": [
+      "alertOnly"
+    ],
+    "resources": [
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": ".*"
         }
-      ],
-      "posturePolicies": [
-          {
-              "controlID": "C-0053" 
-          }
-      ]
-    }
-  ]
+      }
+    ],
+    "posturePolicies": [
+      {
+        "controlID": "C-0053"
+      }
+    ]
+  },
+  {
+    "name": "ignore-validating-webhook-alert",
+    "policyType": "postureExceptionPolicy",
+    "actions": [
+      "alertOnly"
+    ],
+    "resources": [
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": ".*"
+        }
+      }
+    ],
+    "posturePolicies": [
+      {
+        "controlID": "C-0036"
+      }
+    ]
+  }
+]
 

--- a/.github/kics-config.yml
+++ b/.github/kics-config.yml
@@ -2,12 +2,17 @@ exclude-queries:
   # query IDs can be found here: https://docs.kics.io/latest/queries/all-queries/
   # The queries below are excluded because they are not relevant or not needed for this project
   - 48471392-d4d0-47c0-b135-cdec95eb3eef # Service Account Token Automount Not Disabled
+  - 48a5beba-e4c0-4584-a2aa-e6894e4cf424 # Pod or Container Without ResourceQuota
+  - b7bca5c4-1dab-4c2c-8cbe-3050b9d59b14 # RBAC Roles with Read Secrets Permissions
+  - 4a20ebac-1060-4c81-95d1-1f7f620e983b # Pod or Container Without LimitRange
+  - 056ac60e-fe07-4acc-9b34-8e1d51716ab9 # ServiceAccount Allows Access Secrets
+  - aee3c7d2-a811-4201-90c7-11c028be9a46 # Container Requests Not Equal To It's Limits
+
 exclude-results:
   # Similarity IDs can be found in the JSON result file of kics
   - 76f0ba03bcaf9f6e0ff8660beaebff55f74f1d89e38b6831c2b7b468a3dc764b  # RBAC Roles with Read Secrets Permissions
   - f88463cc96ec0165f0c1d83c279ff2658b8a8bd8adb2aaaf79f64a230df88504  # RBAC Roles with Read Secrets Permissions
   - c4886e7b8193614214e9626539430632e8d90cb58499932a82c924266c05d118  # RBAC Roles with Read Secrets Permissions
-  - 00d587d8e63760f6a5d45ede024de5c793cb9e018ba78e4d9e50b8d671f79ba4  # Readiness Probe not configured for kube-rbac-proxy
 
 no-color: false
 no-progress: true

--- a/.github/kics-config.yml
+++ b/.github/kics-config.yml
@@ -7,6 +7,7 @@ exclude-queries:
   - 4a20ebac-1060-4c81-95d1-1f7f620e983b # Pod or Container Without LimitRange
   - 056ac60e-fe07-4acc-9b34-8e1d51716ab9 # ServiceAccount Allows Access Secrets
   - aee3c7d2-a811-4201-90c7-11c028be9a46 # Container Requests Not Equal To It's Limits
+  - 8b36775e-183d-4d46-b0f7-96a6f34a723f # Missing AppArmor Profile
 
 exclude-results:
   # Similarity IDs can be found in the JSON result file of kics

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -25,7 +25,7 @@ jobs:
             curl -sL \
               -H 'Accept: application/vnd.github.v3+json' \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "api.github.com/repos/${{ github.repository }}/actions/workflows/CI.yaml/runs?branch=main" | \
+              "api.github.com/repos/${{ github.repository }}/actions/workflows/CI.yaml/runs?branch=fix/678/sec_scan" | \
             jq '[.workflow_runs[] | select(
               (.head_commit != null) and ( .conclusion == "success" ) 
             )][0] | .id')

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -21,7 +21,7 @@ jobs:
     name: "Prepare Security Scans"
     runs-on: ubuntu-22.04
     steps:
-      - name: Determine Target Branch for Integration Tests
+      - name: Determine Target Branch
         id: determine_branch
         run: |
           if [[ "${{ github.event.inputs.branch }}" != "" ]]; then

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -8,7 +8,7 @@ on:
       branch:
         description: 'Take CI build artifacts from branch (e.g., master, release-x.y.z)'
         required: true
-        default: 'master'
+        default: 'main'
 defaults:
   run:
     shell: bash

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -1,9 +1,14 @@
 name: "Security Scans"
 on:
-  workflow_dispatch:
   schedule:
-    - cron: '0 3 * * 1' # run tests at 1 AM (UTC), every monday (1)
+    - cron: '0 3 * * 1' # run tests at 1 AM (UTC), every monday (1) # run integration tests only when triggered manually
 
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Take CI build artifacts from branch (e.g., master, release-x.y.z)'
+        required: true
+        default: 'master'
 defaults:
   run:
     shell: bash
@@ -16,16 +21,29 @@ jobs:
     name: "Prepare Security Scans"
     runs-on: ubuntu-22.04
     steps:
+      - name: Determine Target Branch for Integration Tests
+        id: determine_branch
+        run: |
+          if [[ "${{ github.event.inputs.branch }}" != "" ]]; then
+            # branch was manually set by user -> probably a workflow_dispatch action
+            BRANCH=${{ github.event.inputs.branch }}
+            echo "Using $BRANCH as target branch for integration tests"
+          else
+            BRANCH='main'
+          fi
+          echo "BRANCH=$(echo ${BRANCH})" >> $GITHUB_OUTPUT
+
       - name: Find latest successful run ID
         id: last_run_id
         env:
+          BRANCH: ${{ steps.determine_branch.outputs.BRANCH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RUN_ID=$(\
             curl -sL \
               -H 'Accept: application/vnd.github.v3+json' \
               -H "Authorization: token $GITHUB_TOKEN" \
-              "api.github.com/repos/${{ github.repository }}/actions/workflows/CI.yaml/runs?branch=fix/678/sec_scan" | \
+              "api.github.com/repos/${{ github.repository }}/actions/workflows/CI.yaml/runs?branch=$BRANCH" | \
             jq '[.workflow_runs[] | select(
               (.head_commit != null) and ( .conclusion == "success" ) 
             )][0] | .id')
@@ -48,17 +66,15 @@ jobs:
         with:
           name: manifests
           path: |
-            ./dist/keptn-lifecycle-operator-manifest/
-            ./dist/scheduler-manifest/
+            ./dist/*-manifest/
+            ./dist/*-manifest-test/
 
       - name: Upload images
         uses: actions/upload-artifact@v3
         with:
           name: images
           path: |
-            ./dist/functions-runtime-image.tar/
-            ./dist/keptn-lifecycle-operator-image.tar/
-            ./dist/scheduler-image.tar/
+            ./dist/*-image.tar/
             
   security-scans:
     name: "Security Scans"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -1,8 +1,7 @@
 name: "Security Scans"
 on:
   schedule:
-    - cron: '0 3 * * 1' # run tests at 1 AM (UTC), every monday (1) # run integration tests only when triggered manually
-
+    - cron: '0 3 * * 1' # run tests at 1 AM (UTC), every monday (1)
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -27,7 +27,7 @@ jobs:
           if [[ "${{ github.event.inputs.branch }}" != "" ]]; then
             # branch was manually set by user -> probably a workflow_dispatch action
             BRANCH=${{ github.event.inputs.branch }}
-            echo "Using $BRANCH as target branch for integration tests"
+            echo "Using $BRANCH as target branch"
           else
             BRANCH='main'
           fi

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -170,6 +170,7 @@ jobs:
           - "functions-runtime"
           - "keptn-lifecycle-operator"
           - "scheduler"
+          - "klt-cert-manager"
     steps:
       - name: Download images
         id: download_images
@@ -194,6 +195,7 @@ jobs:
         artifact:
           - "operator"
           - "scheduler"
+          - "klt-cert-manager"
 
     steps:
       - name: Set up Go 1.x

--- a/examples/sample-app/base/manifest.yaml
+++ b/examples/sample-app/base/manifest.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
       - name: init-myservice
-        image: busybox:1.28
+        image: busybox:1.32.1
         command: ['sh', '-c', 'sleep 30']
       containers:
       - name: server

--- a/examples/support/observability/assets/podtatohead-deployment-evaluation/manifest.yaml
+++ b/examples/support/observability/assets/podtatohead-deployment-evaluation/manifest.yaml
@@ -29,7 +29,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
       - name: init-myservice
-        image: busybox:1.28
+        image: busybox:1.32.1
         command: ['sh', '-c', 'sleep 30']
       containers:
       - name: server

--- a/functions-runtime/Dockerfile
+++ b/functions-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-1.29.1 AS production
+FROM denoland/deno:alpine-1.30.0 as production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/functions-runtime/Dockerfile
+++ b/functions-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine-1.30.0 as production
+FROM denoland/deno:alpine-1.30.0 AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
+++ b/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
@@ -31,6 +31,8 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - "ALL"

--- a/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
+++ b/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
@@ -27,7 +27,10 @@ spec:
       containers:
         - name: kube-rbac-proxy
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
             capabilities:
               drop:
                 - "ALL"

--- a/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
+++ b/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
@@ -13,42 +13,52 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - amd64
-                    - arm64
-                    - ppc64le
-                    - s390x
-                - key: kubernetes.io/os
-                  operator: In
-                  values:
-                    - linux
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - ppc64le
+                      - s390x
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       containers:
-      - name: kube-rbac-proxy
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=0"
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-          name: https
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
+        - name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=0"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 15
+            periodSeconds: 20
+        - name: manager
+          args:
+            - "--health-probe-bind-address=:8081"
+            - "--metrics-bind-address=127.0.0.1:8080"

--- a/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
+++ b/klt-cert-manager/config/default/manager_auth_proxy_patch.yaml
@@ -56,12 +56,12 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 8443
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             periodSeconds: 20
           readinessProbe:
             tcpSocket:
               port: 8443
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             periodSeconds: 20
         - name: manager
           args:

--- a/klt-cert-manager/config/manager/manager.yaml
+++ b/klt-cert-manager/config/manager/manager.yaml
@@ -42,6 +42,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - "ALL"

--- a/klt-cert-manager/config/manager/manager.yaml
+++ b/klt-cert-manager/config/manager/manager.yaml
@@ -39,6 +39,8 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         securityContext:
+          seccompProfile:
+            type: RuntimeDefault
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/klt-cert-manager/config/manager/manager.yaml
+++ b/klt-cert-manager/config/manager/manager.yaml
@@ -26,8 +26,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-           type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -45,6 +43,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          runAsUser: 65532
+          runAsGroup: 65532
         livenessProbe:
           httpGet:
             path: /healthz

--- a/operator/config/default/base/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/base/manager_auth_proxy_patch.yaml
@@ -23,12 +23,12 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 8443
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             periodSeconds: 20
           readinessProbe:
             tcpSocket:
               port: 8443
-            initialDelaySeconds: 15
+            initialDelaySeconds: 5
             periodSeconds: 20
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
           args:

--- a/operator/config/default/base/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/base/manager_auth_proxy_patch.yaml
@@ -9,36 +9,46 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-rbac-proxy
-        securityContext:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 65532
-          seccompProfile:
-            type: RuntimeDefault
-          capabilities:
-            drop:
-              - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=0"
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-          name: https
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - name: manager
-        args:
-        - "--health-probe-bind-address=:8081"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - name: kube-rbac-proxy
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=0"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+        - name: manager
+          args:
+            - "--health-probe-bind-address=:8081"
+            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--leader-elect"

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -63,6 +63,12 @@ spec:
           - name: keptn-metrics
             containerPort: 9999
             protocol: TCP
+          - name: custom-metrics
+            containerPort: 6443
+            protocol: TCP
+          - name: metrics
+            containerPort: 2222
+            protocol: TCP
         imagePullPolicy: Always
         env:
           - name: POD_NAMESPACE

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -85,8 +85,8 @@ spec:
           privileged: false
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 1001
-          runAsGroup: 1001
+          runAsUser: 65532
+          runAsGroup: 65532
           capabilities:
             drop:
               - "ALL"

--- a/operator/config/rbac/auth_proxy_service.yaml
+++ b/operator/config/rbac/auth_proxy_service.yaml
@@ -14,13 +14,13 @@ spec:
   - name: metrics
     port: 2222
     protocol: TCP
-    targetPort: 2222
+    targetPort: metrics
   - name: custom-metrics
-    targetPort: 6443
+    targetPort: custom-metrics
     port: 443
   - name: keptn-metrics
     protocol: TCP
     port: 9999
-    targetPort: 9999
+    targetPort: keptn-metrics
   selector:
     control-plane: controller-manager

--- a/operator/test/e2e/operator_test.go
+++ b/operator/test/e2e/operator_test.go
@@ -50,7 +50,7 @@ var _ = Describe("[E2E] KeptnOperator", Ordered, func() {
 					Containers: []apiv1.Container{
 						{
 							Name:  "mybusy",
-							Image: "busybox:1.28",
+							Image: "busybox:1.32.1",
 						},
 					},
 				},

--- a/test/integration/podtato-head-application-v1alpha1/00-install.yaml
+++ b/test/integration/podtato-head-application-v1alpha1/00-install.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
       containers:
         - name: server

--- a/test/integration/podtato-head-application/00-install.yaml
+++ b/test/integration/podtato-head-application/00-install.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
       containers:
         - name: server

--- a/test/integration/restartable-app/00-install.yaml
+++ b/test/integration/restartable-app/00-install.yaml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
       containers:
         - name: server

--- a/test/integration/simple-deployment-annotated/00-install.yaml
+++ b/test/integration/simple-deployment-annotated/00-install.yaml
@@ -41,6 +41,6 @@ spec:
           command: ['sh', '-c', 'echo The app is running! && sleep infinity']
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
 

--- a/test/integration/simple-deployment/00-install.yaml
+++ b/test/integration/simple-deployment/00-install.yaml
@@ -41,6 +41,6 @@ spec:
           command: ['sh', '-c', 'echo The app is running! && sleep infinity']
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
 

--- a/test/integration/simple-statefulset-annotated/00-install.yaml
+++ b/test/integration/simple-statefulset-annotated/00-install.yaml
@@ -40,6 +40,6 @@ spec:
           command: ['sh', '-c', 'echo The app is running! && sleep infinity']
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
 

--- a/test/integration/simple-statefulset-annotated/02-install.yaml
+++ b/test/integration/simple-statefulset-annotated/02-install.yaml
@@ -28,6 +28,6 @@ spec:
           command: ['sh', '-c', 'echo The app is running! && sleep infinity']
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
 

--- a/test/integration/workload-instance-failing-pre-task/00-install.yaml
+++ b/test/integration/workload-instance-failing-pre-task/00-install.yaml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
       containers:
         - name: server

--- a/test/integration/workload-instance-missing-evaluation/00-install.yaml
+++ b/test/integration/workload-instance-missing-evaluation/00-install.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 5
       initContainers:
         - name: init-myservice
-          image: busybox:1.28
+          image: busybox:1.32.1
           command: ['sh', '-c', 'sleep 30']
       containers:
         - name: server


### PR DESCRIPTION
closes #687 
closes #678 
closes #628 
closes #699 
closes #717

 Adds cert manager to the security pipeline

 Modify security pipeline to run from branch images if triggered manually
 
Also addresses agreed changes from [this run ](https://github.com/keptn/lifecycle-toolkit/actions/runs/4015989214/jobs/6898435561)


- [x] Fix **Service Does Not Target Pod**
- [x] Fix R**oot Container Not Mounted Read-only** when applicable (Cert-mgn) ignore for operator
- [x] Ignore ns quota **Pod or Container Without ResourceQuota**, 
- [x] Ignore ns quota  **Pod or Container Without LimitRange**
- [x] Investigate and let the team know what **AppArmor** is (looks like introduced in beta in v1.4) Missing AppArmor Profile
- [x] Fix ready-health probes in kube-rbac-proxy, if it has the probes **Liveness Probe Is Not Defined  **&&** Readiness Probe Is Not Defined**
- [x] Separate issue - digest as part of img  **Image Without Digest** (see https://github.com/keptn/lifecycle-toolkit/issues/720)
- [x] Create a ticket to add imgpullpolicy as Helm flag **Image Pull Policy Of The Container Is Not Set To Always** ( see https://github.com/keptn/lifecycle-toolkit/issues/721)
- [x] Disable limit=request (**Container Requests Not Equal To It's Limits)**
- [x] Ignore secret read  **ServiceAccount Allows Access Secrets**  
- [x] Ignore secret read **RBAC Roles with Read Secrets Permissions**
- [x] Fix the user id manually - high enough - look into Keptn/Keptn **Container Running With Low UID**

Run with all fixes available [here](https://github.com/keptn/lifecycle-toolkit/actions/runs/4051860582/jobs/6970640603)