### PR TITLE
perf(operator): only check for KeptnApp pre-evaluation if KWI has not entered its first phase yet

### DIFF
--- a/operator/controllers/common/test_utils.go
+++ b/operator/controllers/common/test_utils.go
@@ -65,41 +65,6 @@ func AddAppVersion(c client.Client, namespace string, appName string, version st
 	return c.Create(context.TODO(), app)
 }
 
-func AddWorkloadInstance(c client.Client, name string, namespace string) error {
-	wi := &lfcv1alpha2.KeptnWorkloadInstance{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: lfcv1alpha2.KeptnWorkloadInstanceSpec{
-			KeptnWorkloadSpec: lfcv1alpha2.KeptnWorkloadSpec{
-				AppName: "some-app",
-				Version: "1.0.0",
-			},
-			WorkloadName:    "some-app-some-workload",
-			PreviousVersion: "",
-			TraceId:         nil,
-		},
-		Status: lfcv1alpha2.KeptnWorkloadInstanceStatus{
-			DeploymentStatus:                   apicommon.StateSucceeded,
-			PreDeploymentStatus:                apicommon.StateSucceeded,
-			PostDeploymentStatus:               apicommon.StateSucceeded,
-			PreDeploymentEvaluationStatus:      apicommon.StateSucceeded,
-			PostDeploymentEvaluationStatus:     apicommon.StateSucceeded,
-			CurrentPhase:                       apicommon.PhaseWorkloadPostEvaluation.ShortName,
-			PreDeploymentTaskStatus:            nil,
-			PostDeploymentTaskStatus:           nil,
-			PreDeploymentEvaluationTaskStatus:  nil,
-			PostDeploymentEvaluationTaskStatus: nil,
-			Status:                             apicommon.StateSucceeded,
-			StartTime:                          metav1.Time{},
-			EndTime:                            metav1.Time{},
-		},
-	}
-	return c.Create(context.TODO(), wi)
-}
-
 func InitAppMeters() apicommon.KeptnMeters {
 	provider := metric.NewMeterProvider()
 	meter := provider.Meter("keptn/task")

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -64,10 +64,6 @@ type KeptnWorkloadInstanceReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the KeptnWorkloadInstance object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -247,7 +247,7 @@ func (r *KeptnWorkloadInstanceReconciler) checkPreEvaluationStatusOfApp(ctx cont
 	// Wait for pre-evaluation checks of App
 	// Only check if we have not begun with the first phase of the workload instance, to avoid retrieving the KeptnAppVersion
 	// in each reconciliation loop
-	if workloadInstance.GetCurrentPhase() == "" {
+	if workloadInstance.GetCurrentPhase() != "" {
 		return false, nil
 	}
 	phase := apicommon.PhaseAppPreEvaluation


### PR DESCRIPTION
Related to #680 
This PR makes sure that the status of a KeptnAppVersion's evaluation is only checked as long as a KWI has not entered it's first reconciliation phase. This will reduce calls to the K8s API, and avoid sending a new KeptnAppPreEvaluationSuccess K8s event in each reconciliation loop