### PR TITLE
docs: change port for KTL docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ build:
 	docker run --rm -it $(VOLUMES) $(IMAGE) -D -v
 
 server:
-	docker run --rm -it $(VOLUMES) -p 1314:1313 $(IMAGE) server -D
+	docker run --rm -it $(VOLUMES) -p 1314:1314 $(IMAGE) server -D -p 1314
 
 clean:
 	docker run --rm -it $(VOLUMES) $(IMAGE) --cleanDestinationDir

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ build:
 	docker run --rm -it $(VOLUMES) $(IMAGE) -D -v
 
 server:
-	docker run --rm -it $(VOLUMES) -p 1313:1313 $(IMAGE) server -D
+	docker run --rm -it $(VOLUMES) -p 1314:1313 $(IMAGE) server -D
 
 clean:
 	docker run --rm -it $(VOLUMES) $(IMAGE) --cleanDestinationDir

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@ VOLUMES := -v $(TMPDIR)/lifecycle-toolkit-docs:/src -v $(CURDIR)/content/en/docs
 # renovate: datasource=docker depName=klakegg/hugo
 HUGO_VERSION := 0.105.0-ext
 IMAGE := klakegg/hugo:$(HUGO_VERSION)
+PORT := 1314
 
 .PHONY: build server clean htmltest
 
@@ -16,7 +17,7 @@ build:
 	docker run --rm -it $(VOLUMES) $(IMAGE) -D -v
 
 server:
-	docker run --rm -it $(VOLUMES) -p 1314:1314 $(IMAGE) server -D -p 1314
+	docker run --rm -it $(VOLUMES) -p  $(PORT):$(PORT) $(IMAGE) server -D -p $(PORT)
 
 clean:
 	docker run --rm -it $(VOLUMES) $(IMAGE) --cleanDestinationDir


### PR DESCRIPTION
 KTL docs port changes so that id does not conflict with the keptn docs (#708)

- [x] default external docker port for hugo changed to 1314
- [x] Internal hugo port changed to 1314 so that the user gets the correct msg about where the server is running
- [x] hugo port made configurable using PORT variable  

![image](https://user-images.githubusercontent.com/32765701/215259847-3b679ab5-0237-4761-bb26-494c3feffbc9.png)

Example:
` make PORT=1319 server `
