### PR TITLE
fix(operator): prevent re-execution of workload tasks that have been cancelled in a previous KLT version

### DIFF
--- a/operator/apis/lifecycle/v1alpha2/common/common.go
+++ b/operator/apis/lifecycle/v1alpha2/common/common.go
@@ -40,10 +40,13 @@ const (
 	StateUnknown     KeptnState = "Unknown"
 	StatePending     KeptnState = "Pending"
 	StateDeprecated  KeptnState = "Deprecated"
+	// StateCancelled represents state that was cancelled due to a previous step having failed.
+	// Deprecated: Use StateDeprecated instead. Should only be used in checks for backwards compatibility reasons
+	StateCancelled KeptnState = "Cancelled"
 )
 
 func (k KeptnState) IsCompleted() bool {
-	return k == StateSucceeded || k == StateFailed || k == StateDeprecated
+	return k == StateSucceeded || k == StateFailed || k == StateDeprecated || k == StateCancelled
 }
 
 func (k KeptnState) IsSucceeded() bool {
@@ -55,7 +58,7 @@ func (k KeptnState) IsFailed() bool {
 }
 
 func (k KeptnState) IsDeprecated() bool {
-	return k == StateDeprecated
+	return k == StateDeprecated || k == StateCancelled
 }
 
 func (k KeptnState) IsPending() bool {

--- a/operator/apis/lifecycle/v1alpha2/common/common_test.go
+++ b/operator/apis/lifecycle/v1alpha2/common/common_test.go
@@ -29,7 +29,7 @@ func TestKeptnState_IsCompleted(t *testing.T) {
 			Want:  true,
 		},
 		{
-			State: "Cancelled",
+			State: StateCancelled,
 			Want:  true,
 		},
 	}
@@ -93,6 +93,10 @@ func TestKeptnState_IsDeprecated(t *testing.T) {
 		},
 		{
 			State: StateDeprecated,
+			Want:  true,
+		},
+		{
+			State: StateCancelled,
 			Want:  true,
 		},
 	}

--- a/operator/apis/lifecycle/v1alpha2/common/common_test.go
+++ b/operator/apis/lifecycle/v1alpha2/common/common_test.go
@@ -28,10 +28,14 @@ func TestKeptnState_IsCompleted(t *testing.T) {
 			State: StateDeprecated,
 			Want:  true,
 		},
+		{
+			State: "Cancelled",
+			Want:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			require.Equal(t, tt.State.IsCompleted(), tt.Want)
+			require.Equal(t, tt.Want, tt.State.IsCompleted())
 		})
 	}
 }


### PR DESCRIPTION
Closes #680 
This PR prevents tasks of WorkloadInstances being attempted to be reconciled if they are in the `Cancelled` state (which had been replaced with `Deprecated` recently).

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>