### PR TITLE
feat: add metadata to helm chart

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -33,6 +33,7 @@ jobs:
             test
             deps
           scopes: |
+            helm-chart
             scheduler
             operator
             cert-manager

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keptn-lifecycle-toolkit
 description: A Helm chart for Keptn Lifecycle Toolkit, a set of tools to enable cloud-native application lifecycle management
-icon: "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/assets/logo/keptn_lifecycle_controller_logo.png"
+icon: "https://raw.githubusercontent.com/cncf/artwork/master/projects/keptn/icon/color/keptn-icon-color.svg"
 home: https://keptn.sh
 sources:
   - "https://github.com/keptn/lifecycle-toolkit"

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -11,3 +11,9 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.5.0" # x-release-please-version
+
+sources:
+  - "https://github.com/keptn/lifecycle-toolkit"
+annotations:
+  artifacthub.io/links: |
+    - support: "https://github.com/keptn/lifecycle-toolkit/issues/new"

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -35,4 +35,3 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.5.0" # x-release-please-version
-

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: keptn-lifecycle-toolkit
 description: A Helm chart for Keptn Lifecycle Toolkit, a set of tools to enable cloud-native application lifecycle management
+icon: "https://raw.githubusercontent.com/cncf/artwork/master/projects/keptn/icon/color/keptn-icon-color.svg"
 home: https://keptn.sh
 sources:
   - "https://github.com/keptn/lifecycle-toolkit"

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keptn-lifecycle-toolkit
 description: A Helm chart for Keptn Lifecycle Toolkit, a set of tools to enable cloud-native application lifecycle management
-icon: "https://raw.githubusercontent.com/cncf/artwork/master/projects/keptn/icon/color/keptn-icon-color.svg"
+icon: "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/assets/logo/keptn_lifecycle_controller_logo.png"
 home: https://keptn.sh
 sources:
   - "https://github.com/keptn/lifecycle-toolkit"

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,9 +1,33 @@
 apiVersion: v2
 name: keptn-lifecycle-toolkit
 description: A Helm chart for Keptn Lifecycle Toolkit, a set of tools to enable cloud-native application lifecycle management
+home: https://keptn.sh
+sources:
+  - "https://github.com/keptn/lifecycle-toolkit"
+keywords:
+  - cloud-native
+  - lifecycle
+  - lifecycle-management
+  - application-lifecycle
+  - application-lifecycle-management
+  - orchestration
+  - keptn
+  - operator
+  - pre-deployment
+  - post-deployment
+  - evaluation
+annotations:
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/keptn/lifecycle-toolkit/issues/new
+    - name: community
+      url: https://slack.keptn.sh/
+  artifacthub.io/license: "Apache-2.0"
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: "Full Lifecycle"
 
+kubeVersion: ">= 1.24.0"
 type: application
-
 version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
@@ -12,8 +36,3 @@ version: 0.1.0
 # It is recommended to use it with quotes.
 appVersion: "0.5.0" # x-release-please-version
 
-sources:
-  - "https://github.com/keptn/lifecycle-toolkit"
-annotations:
-  artifacthub.io/links: |
-    - support: "https://github.com/keptn/lifecycle-toolkit/issues/new"


### PR DESCRIPTION
### This PR
- adds helm and artifacthub metadata to the KLT helm chart
- some annotations were omitted because they are too much effort and would need to be updated manually:
  - CRDs
  - CRD examples

Fixes #596