### PR TITLE
docs: added documentation to enable Slack notification post deployment task (#787)

### DIFF
--- a/docs/content/en/docs/tasks/implement-slack-notification/_index.md
+++ b/docs/content/en/docs/tasks/implement-slack-notification/_index.md
@@ -3,7 +3,7 @@ title: Implement Slack Notification
 description: Learn how to implement Slack notification as a post deployment task.
 icon: concepts
 layout: quickstart
-weight: 20
+weight: 24
 hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 

--- a/docs/content/en/docs/tasks/implement-slack-notification/_index.md
+++ b/docs/content/en/docs/tasks/implement-slack-notification/_index.md
@@ -1,0 +1,38 @@
+---
+title: Implement Slack Notification
+description: Learn how to implement Slack notification as a post deployment task.
+icon: concepts
+layout: quickstart
+weight: 20
+hidechildren: true # this flag hides all sub-pages in the sidebar-multicard.html
+---
+
+# Overview
+This section describes how to **prepare and enable** post-deployment tasks to send notifications to slack using webhooks.
+
+## Create Slack Webhook
+
+At first, create an incoming slack webhook. Necessary information is available in the [slack api page](https://api.slack.com/messaging/webhooks).
+Once you create the webhook, you will get a URL similar to below example.
+
+`https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX`
+
+`T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX` is the secret part of the webhook which we would need in the next step.
+
+## Create slack-secret
+
+Create a `slack-secret.yaml` definition using the following command.
+This will create a kubernetes secret named `slack-secret.yaml` in the [base](./base) directory.
+
+```bash
+kubectl create secret generic slack-secret --from-literal=SECURE_DATA='{"slack_hook":<YOUR_HOOK_SECRET>,"text":"Deployed PodTatoHead Application"}' -n podtato-kubectl -oyaml --dry-run=client > base/slack-secret.yaml
+```
+## Enable post deployment task
+
+To enable Slack notification add `post-deployment-notification` in as a postDeploymentTasks in the
+[examples/sample-app/base/app.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/app.yaml) file as shown below.
+
+```yaml
+  postDeploymentTasks:
+    - post-deployment-notification
+```

--- a/docs/content/en/docs/tasks/implement-slack-notification/_index.md
+++ b/docs/content/en/docs/tasks/implement-slack-notification/_index.md
@@ -22,7 +22,7 @@ Once you create the webhook, you will get a URL similar to below example.
 ## Create slack-secret
 
 Create a `slack-secret.yaml` definition using the following command.
-This will create a kubernetes secret named `slack-secret.yaml` in the [base](./base) directory. Before running 
+This will create a kubernetes secret named `slack-secret.yaml` in the `examples/sample-app/base` directory. Before running 
 this command change your current directory into `examples/sample-app`.
 
 ```bash

--- a/docs/content/en/docs/tasks/implement-slack-notification/_index.md
+++ b/docs/content/en/docs/tasks/implement-slack-notification/_index.md
@@ -22,7 +22,8 @@ Once you create the webhook, you will get a URL similar to below example.
 ## Create slack-secret
 
 Create a `slack-secret.yaml` definition using the following command.
-This will create a kubernetes secret named `slack-secret.yaml` in the [base](./base) directory.
+This will create a kubernetes secret named `slack-secret.yaml` in the [base](./base) directory. Before running 
+this command change your current directory into `examples/sample-app`.
 
 ```bash
 kubectl create secret generic slack-secret --from-literal=SECURE_DATA='{"slack_hook":<YOUR_HOOK_SECRET>,"text":"Deployed PodTatoHead Application"}' -n podtato-kubectl -oyaml --dry-run=client > base/slack-secret.yaml

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -4,12 +4,35 @@ This example should demonstrate the capabilities of the lifecycle toolkit as ill
 
 ![img.png](assets/big-picture.png)
 
-## Prepare Secret for Slack Notification
-As a first step, create an incoming webhook according to the instructions
-https://api.slack.com/messaging/webhooks
+## PostDeployment Slack Notification
+This section describes how to **prepare and enable** post deployment task to send notification into slack using webhook.
 
-Afterwards create a secret with the created webhook
-> kubectl create secret generic slack-notification --from-literal=SECURE_DATA='{"slack_hook":<YOUR_HOOK>,"text":"Deployed PodTatoHead Application"}' -n podtato-kubectl -oyaml --dry-run=client > base/slack-secret.yaml
+**Create Slack Webhook**
+
+In the first step, create an incoming slack webhook. Necessary information is available in the [slack api page](https://api.slack.com/messaging/webhooks).
+Once you create the webhook, you will get a URL similar to below example.
+
+`https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX` 
+
+`T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX` is the secret part of the webhook which we would need in the next step.
+
+**Create slack-secret**
+
+Create a `slack-secret.yaml` definition using the following command. 
+This will create a kubernetes secret named `slack-secret.yaml` in the [base](./base) directory.
+
+```bash
+kubectl create secret generic slack-secret --from-literal=SECURE_DATA='{"slack_hook":<YOUR_HOOK_SECRET>,"text":"Deployed PodTatoHead Application"}' -n podtato-kubectl -oyaml --dry-run=client > base/slack-secret.yaml
+```
+**Enable post deployment task**
+
+To enable Slack notification add `post-deployment-notification` in as a postDeploymentTasks in the
+[app.yaml](base/app.yaml) file as shown below.
+
+```yaml
+  postDeploymentTasks:
+    - post-deployment-notification
+```
 
 ## Deploy the Observability Part and Keptn-lifecycle-toolkit
 > make install

--- a/examples/sample-app/README.md
+++ b/examples/sample-app/README.md
@@ -5,7 +5,7 @@ This example should demonstrate the capabilities of the lifecycle toolkit as ill
 ![img.png](assets/big-picture.png)
 
 ## PostDeployment Slack Notification
-This section describes how to **prepare and enable** post deployment task to send notification into slack using webhook.
+This section describes how to **prepare and enable** post-deployment tasks to send notifications to slack using webhooks.
 
 **Create Slack Webhook**
 

--- a/examples/sample-app/base/app.yaml
+++ b/examples/sample-app/base/app.yaml
@@ -18,6 +18,5 @@ spec:
       version: 0.2.7
     - name: podtato-head-hat
       version: 0.1.0
-  postDeploymentTasks:
-    - post-deployment-notification
+
 

--- a/examples/sample-app/base/app.yaml
+++ b/examples/sample-app/base/app.yaml
@@ -18,5 +18,6 @@ spec:
       version: 0.2.7
     - name: podtato-head-hat
       version: 0.1.0
-
+  postDeploymentTasks:
+    - post-deployment-notification
 


### PR DESCRIPTION
Fixes #787 

- [x] Removed postDeploymentTasks from the [base/app.yaml](https://github.com/keptn/lifecycle-toolkit/blob/dc6f664c5a3132e7a01078c25c4c4bb059cde8bf/examples/sample-app/base/app.yaml#L6)
- [x] Added documentation to configure and enable postDeploymentTasks 
- [x] Added `implement-slack-notification` task in the docs/task page