### PR TITLE
docs: set up directory for CRD Reference

### DIFF
--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -1,0 +1,18 @@
+---
+title: CRD Reference pages
+description: Reference information about the KLT CRDs
+weight: 100
+hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
+---
+
+This section provides comprehensive reference information
+about the [Customized Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRDs)
+that are defined for the Keptn Lifecycle Toolkit.
+See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+for more information about how resources are used
+to configure Kubernetes pods.
+
+**NOTE: This section is under development.
+Information that is published here has been reviewed for technical accuracy
+but the format and content is still evolving.
+We welcome your input!**

--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -6,11 +6,8 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 ---
 
 This section provides comprehensive reference information
-about the [Customized Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRDs)
+about the [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRDs)
 that are defined for the Keptn Lifecycle Toolkit.
-See [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-for more information about how resources are used
-to configure Kubernetes pods.
 
 **NOTE: This section is under development.
 Information that is published here has been reviewed for technical accuracy

--- a/docs/content/en/docs/crd-ref/crd-template.md
+++ b/docs/content/en/docs/crd-ref/crd-template.md
@@ -2,7 +2,7 @@
 title: <crd-name>
 description: <one-line description of CRD>
 weight: <assign weight to create alphabetical order>
-hidden: true
+hide: true
 ---
 
 Copy this template to create a new CRD reference page.

--- a/docs/content/en/docs/crd-ref/crd-template.md
+++ b/docs/content/en/docs/crd-ref/crd-template.md
@@ -18,7 +18,12 @@ Copy this template to create a new CRD reference page.
 
 ## Parameters
 
+<Detailed description of each field/parameter>
+
 ## Usage
+
+<How this CRD is "activated".  For example, which event uses this CRD>
+<Instructions and guidelines for when and how to customize a CRD>
 
 ## Examples
 

--- a/docs/content/en/docs/crd-template.md
+++ b/docs/content/en/docs/crd-template.md
@@ -1,0 +1,31 @@
+---
+title: <crd-name>
+description: <one-line description of CRD>
+weight: <assign weight to create alphabetical order>
+hidden: true
+---
+
+Copy this template to create a new CRD reference page.
+
+1. Replace the variable text in metadata with information for this page
+1. Delete the `hidden: true` line
+1. Delete these instructions from your file
+1. Populate the page with appropriate content
+
+## Synopsis
+```
+```
+
+## Parameters
+
+## Usage
+
+## Examples
+
+## Files
+
+## Differences between versions
+
+## See also
+
+


### PR DESCRIPTION
Signed-off-by: Meg McRoberts <meg.mcroberts@dynatrace.com>

This sets up the directory and a template file for the CRD Reference pages

This is for use in Phase 1 of https://github.com/keptn/lifecycle-toolkit/issues/778 , to allow us to develop content.  This is almost certainly not how this material will ultimately be published but will provide us with valuable learning to help us determine the structure we want and implement the appropriate tooling.