### PR TITLE
chore: update codeowners to have default owners for docs folder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,4 @@
 *   @thisthat @thschue @bacherfl
 /.github/ @thisthat @thschue @bacherfl @mowies @philipp-hinteregger
 /scheduler/ @thisthat @thschue @bacherfl @RealAnna
-/docs @StackScribe
+/docs @thisthat @thschue @bacherfl @StackScribe


### PR DESCRIPTION
Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>