### PR TITLE
fix: include namespace creation in release manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,15 @@ jobs:
           cd ..
           echo "---" >> operator/config/rendered/release.yaml
           echo "---" >> scheduler/config/rendered/release.yaml
-          cat operator/config/rendered/release.yaml scheduler/config/rendered/release.yaml klt-cert-manager/config/rendered/release.yaml > manifest.yaml
+          cat >> namespace.yaml << EOF
+          ---
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: keptn-lifecycle-toolkit-system
+          ---
+          EOF
+          cat namespace.yaml operator/config/rendered/release.yaml scheduler/config/rendered/release.yaml klt-cert-manager/config/rendered/release.yaml > manifest.yaml
 
       - name: Attach release assets
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Fixes #852

Example of run that the ns file is correctly created: https://github.com/thisthat/lifecycle-controller/actions/runs/4183048159/jobs/7246906287