### PR TITLE
chore: switch to registry.k8s.io in yaml files in prometheus example

### DIFF
--- a/examples/support/observability/config/prometheus/kube-state-metrics-deployment.yaml
+++ b/examples/support/observability/config/prometheus/kube-state-metrics-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.6.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         name: kube-state-metrics
         resources:
           limits:

--- a/test/load/assets/prometheus/kube-state-metrics-deployment.yaml
+++ b/test/load/assets/prometheus/kube-state-metrics-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.6.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         name: kube-state-metrics
         resources:
           limits:


### PR DESCRIPTION
The main Kubernetes container registry is now defaulted to registry.k8s.io. See: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/.
Switching to the new registry for the yaml files