### PR TITLE
feat(helm-chart): split documentation from value files

### DIFF
--- a/.github/scripts/generate-helm-docs.sh
+++ b/.github/scripts/generate-helm-docs.sh
@@ -8,11 +8,15 @@
 # Dependencies:
 # Node >=16
 
+# renovate: datasource=github-tags depName=bitnami-labs/readme-generator-for-helm
+GENERATOR_VERSION="2.5.0"
+
 echo "Checking if readme generator is installed already..."
-if [[ $(npm list -g | grep -c 'readme-generator-for-helm') -eq 0 ]]; then
-  echo "Readme Generator not installed, installing now..."
+if [[ $(npm list -g | grep -c "readme-generator-for-helm@${GENERATOR_VERSION}") -eq 0 ]]; then
+  echo "Readme Generator v${GENERATOR_VERSION} not installed, installing now..."
   git clone https://github.com/bitnami-labs/readme-generator-for-helm.git
   cd ./readme-generator-for-helm || exit
+  git checkout ${GENERATOR_VERSION}
   npm ci
   cd ..
   npm install -g ./readme-generator-for-helm

--- a/.github/scripts/generate-helm-docs.sh
+++ b/.github/scripts/generate-helm-docs.sh
@@ -8,7 +8,7 @@
 # Dependencies:
 # Node >=16
 
-# renovate: datasource=github-tags depName=bitnami-labs/readme-generator-for-helm
+# renovate: datasource=github-releases depName=bitnami-labs/readme-generator-for-helm
 GENERATOR_VERSION="2.5.0"
 
 echo "Checking if readme generator is installed already..."

--- a/.github/scripts/generate-helm-docs.sh
+++ b/.github/scripts/generate-helm-docs.sh
@@ -21,6 +21,7 @@ else
 fi
 
 echo "Generating readme now..."
-readme-generator --values=./helm/chart/values.yaml --readme=./helm/chart/README.md
+cat ./helm/chart/values.yaml ./helm/chart/doc.yaml > ./helm/chart/rendered.yaml
+readme-generator --values=./helm/chart/rendered.yaml --readme=./helm/chart/README.md
 
 # Please be aware, the readme file needs to exist and needs to have a Parameters section, as only this section will be re-generated

--- a/.github/workflows/validate-helm-docs.yml
+++ b/.github/workflows/validate-helm-docs.yml
@@ -42,7 +42,7 @@ jobs:
             echo "The Helm values have changes that are not reflected in the readme. Please use ./.github/scripts/generate-helm-docs.sh to re-generate the docs."
             echo ""
             echo "=========== Diff ==========="
-            diff ./README-old.md ./README.md
+            diff -u ./README-old.md ./README.md
             exit 1
           else
             echo ""

--- a/.github/workflows/validate-helm-docs.yml
+++ b/.github/workflows/validate-helm-docs.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           cd ./helm/chart/
           cp ./README.md ./README-old.md
-          readme-generator --values=./values.yaml --readme=./README.md
+          cat ./values.yaml ./doc.yaml > ./rendered.yaml
+          readme-generator --values=./rendered.yaml --readme=./README.md
           if ! cmp --quiet ./README-old.md ./README.md; then
             echo "The Helm values have changes that are not reflected in the readme. Please use ./.github/scripts/generate-helm-docs.sh to re-generate the docs."
             echo ""

--- a/helm/.gitignore
+++ b/helm/.gitignore
@@ -1,4 +1,5 @@
 *.tgz
+chart/rendered.yaml
 chart/templates/rendered.yaml
 chart/templates/crds.yaml
 chart/crds/*.yaml

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -19,5 +19,3 @@ checks
 | ---------------------------- | ---------------------------------------------------- | -------- |
 | `deployment.imagePullPolicy` | Sets the image pull policy for kubernetes deployment | `Always` |
 
-
-<!-- markdownlint-enable MD012 -->

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -8,10 +8,16 @@ checks
 
 ### OpenTelemetry
 
-| Name                         | Description                                          | Value                 |
-| ---------------------------- | ---------------------------------------------------- | --------------------- |
-| `otelCollector.url`          | Sets the URL for the open telemetry collector        | `otel-collector:4317` |
-| `deployment.imagePullPolicy` | Sets the image pull policy for kubernetes deployment | `Always`              |
+| Name                | Description                                   | Value                 |
+| ------------------- | --------------------------------------------- | --------------------- |
+| `otelCollector.url` | Sets the URL for the open telemetry collector | `otel-collector:4317` |
+
+
+### General
+
+| Name                         | Description                                          | Value    |
+| ---------------------------- | ---------------------------------------------------- | -------- |
+| `deployment.imagePullPolicy` | Sets the image pull policy for kubernetes deployment | `Always` |
 
 
 <!-- markdownlint-enable MD012 -->

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -12,7 +12,6 @@ checks
 | ------------------- | --------------------------------------------- | --------------------- |
 | `otelCollector.url` | Sets the URL for the open telemetry collector | `otel-collector:4317` |
 
-
 ### General
 
 | Name                         | Description                                          | Value    |

--- a/helm/chart/doc.yaml
+++ b/helm/chart/doc.yaml
@@ -1,0 +1,6 @@
+## @section OpenTelemetry
+## @param otelCollector.url Sets the URL for the open telemetry collector
+
+## @section General
+## @param deployment.imagePullPolicy Sets the image pull policy for kubernetes deployment
+

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,8 +1,5 @@
-## @section OpenTelemetry
 otelCollector:
-  ## @param otelCollector.url Sets the URL for the open telemetry collector
   url: "otel-collector:4317"
 
 deployment:
-  ## @param deployment.imagePullPolicy Sets the image pull policy for kubernetes deployment
   imagePullPolicy: Always

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,8 @@
       "fileMatch": [
         "(^|\\/)Makefile$",
         "(^|\\/)Dockerfile",
-        "(^|\\/).*\\.ya?ml$"
+        "(^|\\/).*\\.ya?ml$",
+        "(^|\\/).*\\.sh$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*?_VERSION ?(\\??=|\\: ?) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"


### PR DESCRIPTION
Part of #840 

## This PR

- pins the version of the doc generator tool
- separate documentation from value.yaml (see #880)
- prints a more user-friendly diff when the README.md file is not up-to-date