### PR TITLE
feat(metrics-operator): allow KeptnMetrics to be placed in any namespace 

### DIFF
--- a/metrics-operator/cmd/metrics/adapter/provider/custom_metrics_test.go
+++ b/metrics-operator/cmd/metrics/adapter/provider/custom_metrics_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCustomMetrics_Delete(t *testing.T) {
 	cm := CustomMetricsCache{
-		metrics: map[string]CustomMetricValue{
+		metrics: map[metricKey]CustomMetricValue{
 			"my-namespace-my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
@@ -34,7 +34,7 @@ func TestCustomMetrics_Delete(t *testing.T) {
 
 func TestCustomMetrics_DeleteWrongKey(t *testing.T) {
 	cm := CustomMetricsCache{
-		metrics: map[string]CustomMetricValue{
+		metrics: map[metricKey]CustomMetricValue{
 			"my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
@@ -66,7 +66,7 @@ func TestCustomMetrics_DeleteFromEmptyMetrics(t *testing.T) {
 
 func TestCustomMetrics_Get(t *testing.T) {
 	cm := CustomMetricsCache{
-		metrics: map[string]CustomMetricValue{
+		metrics: map[metricKey]CustomMetricValue{
 			"default-my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
@@ -95,7 +95,7 @@ func TestCustomMetrics_Get(t *testing.T) {
 
 func TestCustomMetrics_GetValuesByLabel(t *testing.T) {
 	cm := CustomMetricsCache{
-		metrics: map[string]CustomMetricValue{
+		metrics: map[metricKey]CustomMetricValue{
 			"default-my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
@@ -136,7 +136,7 @@ func TestCustomMetrics_GetValuesByLabel(t *testing.T) {
 
 func TestCustomMetrics_List(t *testing.T) {
 	cm := CustomMetricsCache{
-		metrics: map[string]CustomMetricValue{
+		metrics: map[metricKey]CustomMetricValue{
 			"my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
@@ -173,7 +173,7 @@ func TestCustomMetrics_List(t *testing.T) {
 
 func TestCustomMetrics_ListByLabelSelector(t *testing.T) {
 	cm := CustomMetricsCache{
-		metrics: map[string]CustomMetricValue{
+		metrics: map[metricKey]CustomMetricValue{
 			"my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{

--- a/metrics-operator/cmd/metrics/adapter/provider/custom_metrics_test.go
+++ b/metrics-operator/cmd/metrics/adapter/provider/custom_metrics_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ import (
 func TestCustomMetrics_Delete(t *testing.T) {
 	cm := CustomMetricsCache{
 		metrics: map[string]CustomMetricValue{
-			"my-metric": {
+			"my-namespace-my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
 						Name: "my-metric",
@@ -23,7 +24,10 @@ func TestCustomMetrics_Delete(t *testing.T) {
 		},
 	}
 
-	cm.Delete("my-metric")
+	cm.Delete(types.NamespacedName{
+		Namespace: "my-namespace",
+		Name:      "my-metric",
+	})
 
 	require.Empty(t, cm.metrics)
 }
@@ -41,7 +45,10 @@ func TestCustomMetrics_DeleteWrongKey(t *testing.T) {
 		},
 	}
 
-	cm.Delete("something-else")
+	cm.Delete(types.NamespacedName{
+		Namespace: "",
+		Name:      "something-else",
+	})
 
 	require.Len(t, cm.metrics, 1)
 }
@@ -49,7 +56,10 @@ func TestCustomMetrics_DeleteWrongKey(t *testing.T) {
 func TestCustomMetrics_DeleteFromEmptyMetrics(t *testing.T) {
 	cm := CustomMetricsCache{}
 
-	cm.Delete("my-metric")
+	cm.Delete(types.NamespacedName{
+		Namespace: "",
+		Name:      "my-metric",
+	})
 
 	require.Empty(t, cm.metrics)
 }
@@ -57,7 +67,7 @@ func TestCustomMetrics_DeleteFromEmptyMetrics(t *testing.T) {
 func TestCustomMetrics_Get(t *testing.T) {
 	cm := CustomMetricsCache{
 		metrics: map[string]CustomMetricValue{
-			"my-metric": {
+			"default-my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
 						Name: "my-metric",
@@ -67,12 +77,18 @@ func TestCustomMetrics_Get(t *testing.T) {
 		},
 	}
 
-	val, err := cm.Get("my-metric")
+	val, err := cm.Get(types.NamespacedName{
+		Namespace: "",
+		Name:      "my-metric",
+	})
 
 	require.NoError(t, err)
 	require.NotNil(t, val)
 
-	val, err = cm.Get("nothere")
+	val, err = cm.Get(types.NamespacedName{
+		Namespace: "",
+		Name:      "nothere",
+	})
 	require.ErrorIs(t, err, ErrMetricNotFound)
 	require.Nil(t, val)
 }
@@ -80,7 +96,7 @@ func TestCustomMetrics_Get(t *testing.T) {
 func TestCustomMetrics_GetValuesByLabel(t *testing.T) {
 	cm := CustomMetricsCache{
 		metrics: map[string]CustomMetricValue{
-			"my-metric": {
+			"default-my-metric": {
 				Value: custom_metrics.MetricValue{
 					Metric: custom_metrics.MetricIdentifier{
 						Name: "my-metric",
@@ -100,7 +116,10 @@ func TestCustomMetrics_GetValuesByLabel(t *testing.T) {
 		},
 	}
 
-	val, err := cm.Get("my-metric")
+	val, err := cm.Get(types.NamespacedName{
+		Namespace: "",
+		Name:      "my-metric",
+	})
 
 	require.NoError(t, err)
 	require.NotNil(t, val)
@@ -196,7 +215,10 @@ func TestCustomMetrics_Update(t *testing.T) {
 		},
 	})
 
-	get, err := cm.Get("my-metric")
+	get, err := cm.Get(types.NamespacedName{
+		Namespace: "",
+		Name:      "my-metric",
+	})
 
 	require.Nil(t, err)
 	require.Equal(t, "my-metric", get.Value.Metric.Name)
@@ -211,7 +233,10 @@ func TestCustomMetrics_Update(t *testing.T) {
 		},
 	})
 
-	get, err = cm.Get("my-metric")
+	get, err = cm.Get(types.NamespacedName{
+		Namespace: "",
+		Name:      "my-metric",
+	})
 
 	require.Nil(t, err)
 	require.Equal(t, "my-metric", get.Value.Metric.Name)

--- a/metrics-operator/cmd/metrics/adapter/provider/provider.go
+++ b/metrics-operator/cmd/metrics/adapter/provider/provider.go
@@ -52,7 +52,7 @@ func NewProvider(ctx context.Context, client dynamic.Interface, namespace string
 			client: client,
 			scheme: scheme,
 			cache: CustomMetricsCache{
-				metrics: map[string]CustomMetricValue{},
+				metrics: map[metricKey]CustomMetricValue{},
 			},
 			logger:       ctrl.Log.WithName("provider"),
 			KltNamespace: namespace,

--- a/metrics-operator/config/rbac/role.yaml
+++ b/metrics-operator/config/rbac/role.yaml
@@ -14,6 +14,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
   - metrics.keptn.sh
   resources:
   - keptnmetrics
@@ -51,17 +57,3 @@ rules:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  name: manager-role
-  namespace: keptn-lifecycle-toolkit-system
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get

--- a/metrics-operator/controllers/metrics/controller.go
+++ b/metrics-operator/controllers/metrics/controller.go
@@ -51,7 +51,7 @@ type KeptnMetricReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 
 //role
-//+kubebuilder:rbac:groups=core,namespace=keptn-lifecycle-toolkit-system,resources=secrets,verbs=get
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Follow up PR for #849 

To support evaluations that are done in a namespace other than `keptn-lifecycle-toolkit-system` and therefore maintain feature parity with previous KLT versions, `KeptnMetrics` need to be able to live in any namespace. This PR adapts the roles required for the metrics-operator to support this, and adapts the metrics adapter accordingly