### PR TITLE
chore: adjust manifest limits

### DIFF
--- a/klt-cert-manager/config/manager/manager.yaml
+++ b/klt-cert-manager/config/manager/manager.yaml
@@ -65,8 +65,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 100m
-            memory: 32Mi
+            cpu: 25m
+            memory: 64Mi
           requests:
             cpu: 5m
             memory: 16Mi


### PR DESCRIPTION
## This PR

~~- Removes kube-rbac-proxy since it goes against our Observability first approach (see their [docs](https://book.kubebuilder.io/reference/metrics.html#protecting-the-metrics))~~
- adjust limits based on monitoring while running the performance tests
![Screenshot 2023-02-21 at 17 18 14](https://user-images.githubusercontent.com/992621/220400933-4070b7b1-8767-4a95-a880-7b84c4318205.png)
![Screenshot 2023-02-21 at 17 19 02](https://user-images.githubusercontent.com/992621/220400939-d98ed39e-cb1f-4890-821c-6efe60ddd666.png)

