### PR TITLE
chore: fix golangci-lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,6 @@ linters:
 issues:
   exclude-rules:
     - linters:
-        - gci
-      text: '//+kubebuilder'
-    - linters:
         - containedctx
         - gocyclo
         - gocognit

--- a/klt-cert-manager/controllers/keptnwebhookcontroller/config.go
+++ b/klt-cert-manager/controllers/keptnwebhookcontroller/config.go
@@ -2,8 +2,6 @@ package keptnwebhookcontroller
 
 import (
 	"time"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -18,9 +16,3 @@ const (
 	certificatesSecretEmptyErr = "certificates secret is empty"
 	couldNotUpdateCRDErr       = "could not update crd config"
 )
-
-var keptnCRD = schema.GroupVersionResource{Group: "lifecycle.keptn.sh"}
-var crdversion = schema.GroupVersion{
-	Group:   "apiextensions.k8s.io",
-	Version: "v1",
-}

--- a/klt-cert-manager/main.go
+++ b/klt-cert-manager/main.go
@@ -18,6 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// nolint:gci
 	// +kubebuilder:scaffold:imports
 )
 

--- a/klt-cert-manager/main.go
+++ b/klt-cert-manager/main.go
@@ -18,7 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -30,7 +30,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(apiv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 type envConfig struct {
@@ -93,7 +93,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/operator/apis/lifecycle/v1alpha1/keptnapp_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnapp_types.go
@@ -48,8 +48,8 @@ type KeptnWorkloadRef struct {
 	Version string `json:"version"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // KeptnApp is the Schema for the keptnapps API
 type KeptnApp struct {
@@ -60,7 +60,7 @@ type KeptnApp struct {
 	Status KeptnAppStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnAppList contains a list of KeptnApp
 type KeptnAppList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptnappversion_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnappversion_types.go
@@ -72,10 +72,10 @@ type WorkloadStatus struct {
 	Status common.KeptnState `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:path=keptnappversions,shortName=kav
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=keptnappversions,shortName=kav
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.currentPhase`
 // +kubebuilder:printcolumn:name="PreDeploymentStatus",priority=1,type=string,JSONPath=`.status.preDeploymentStatus`
@@ -93,7 +93,7 @@ type KeptnAppVersion struct {
 	Status KeptnAppVersionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnAppVersionList contains a list of KeptnAppVersion
 type KeptnAppVersionList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptnevaluation_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnevaluation_types.go
@@ -66,16 +66,16 @@ type EvaluationStatusItem struct {
 	Message string            `json:"message,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=keptnevaluations,shortName=ke
-//+kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
-//+kubebuilder:printcolumn:name="AppVersion",type=string,JSONPath=`.spec.appVersion`
-//+kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workload`
-//+kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.workloadVersion`
-//+kubebuilder:printcolumn:name="RetryCount",type=string,JSONPath=`.status.retryCount`
-//+kubebuilder:printcolumn:name="EvaluationStatus",type=string,JSONPath=`.status.evaluationStatus`
-//+kubebuilder:printcolumn:name="OverallStatus",type=string,JSONPath=`.status.overallStatus`
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=keptnevaluations,shortName=ke
+// +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
+// +kubebuilder:printcolumn:name="AppVersion",type=string,JSONPath=`.spec.appVersion`
+// +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workload`
+// +kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.workloadVersion`
+// +kubebuilder:printcolumn:name="RetryCount",type=string,JSONPath=`.status.retryCount`
+// +kubebuilder:printcolumn:name="EvaluationStatus",type=string,JSONPath=`.status.evaluationStatus`
+// +kubebuilder:printcolumn:name="OverallStatus",type=string,JSONPath=`.status.overallStatus`
 
 // KeptnEvaluation is the Schema for the keptnevaluations API
 type KeptnEvaluation struct {
@@ -86,7 +86,7 @@ type KeptnEvaluation struct {
 	Status KeptnEvaluationStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnEvaluationList contains a list of KeptnEvaluation
 type KeptnEvaluationList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptnevaluationdefinition_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnevaluationdefinition_types.go
@@ -41,9 +41,9 @@ type KeptnEvaluationDefinitionStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=keptnevaluationdefinitions,shortName=ked
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=keptnevaluationdefinitions,shortName=ked
 
 // KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions API
 type KeptnEvaluationDefinition struct {
@@ -54,7 +54,7 @@ type KeptnEvaluationDefinition struct {
 	Status KeptnEvaluationDefinitionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 type KeptnEvaluationDefinitionList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptnevaluationprovider_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnevaluationprovider_types.go
@@ -35,9 +35,9 @@ type KeptnEvaluationProviderStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=keptnevaluationproviders,shortName=kep
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=keptnevaluationproviders,shortName=kep
 
 // KeptnEvaluationProvider is the Schema for the keptnevaluationproviders API
 type KeptnEvaluationProvider struct {
@@ -48,7 +48,7 @@ type KeptnEvaluationProvider struct {
 	Status KeptnEvaluationProviderStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnEvaluationProviderList contains a list of KeptnEvaluationProvider
 type KeptnEvaluationProviderList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptntask_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptntask_types.go
@@ -72,8 +72,8 @@ type KeptnTaskStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="AppVersion",type=string,JSONPath=`.spec.appVersion`
 // +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workload`
@@ -90,7 +90,7 @@ type KeptnTask struct {
 	Status KeptnTaskStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnTaskList contains a list of KeptnTask
 type KeptnTaskList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptntaskdefinition_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptntaskdefinition_types.go
@@ -69,8 +69,8 @@ type FunctionStatus struct {
 	ConfigMap string `json:"configMap,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 type KeptnTaskDefinition struct {
@@ -81,7 +81,7 @@ type KeptnTaskDefinition struct {
 	Status KeptnTaskDefinitionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 type KeptnTaskDefinitionList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptnworkload_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnworkload_types.go
@@ -45,8 +45,8 @@ type KeptnWorkloadStatus struct {
 	CurrentVersion string `json:"currentVersion,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`
 
@@ -59,7 +59,7 @@ type KeptnWorkload struct {
 	Status KeptnWorkloadStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadList contains a list of KeptnWorkload
 type KeptnWorkloadList struct {

--- a/operator/apis/lifecycle/v1alpha1/keptnworkloadinstance_types.go
+++ b/operator/apis/lifecycle/v1alpha1/keptnworkloadinstance_types.go
@@ -81,9 +81,9 @@ type EvaluationStatus struct {
 	EndTime        metav1.Time       `json:"endTime,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workloadName`
 // +kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.version`
@@ -103,7 +103,7 @@ type KeptnWorkloadInstance struct {
 	Status KeptnWorkloadInstanceStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 type KeptnWorkloadInstanceList struct {
@@ -402,12 +402,12 @@ func (w *KeptnWorkloadInstance) CancelRemainingPhases(phase common.KeptnPhaseTyp
 	if phase == common.PhaseWorkloadPostEvaluation {
 		return
 	}
-	//cancel everything if app pre-eval tasks have failed
+	// cancel everything if app pre-eval tasks have failed
 	if phase == common.PhaseAppPreEvaluation {
 		w.Status.PreDeploymentStatus = common.StateCancelled
 		w.Status.PreDeploymentEvaluationStatus = common.StateCancelled
 	}
-	//cancel deployment and post-deployment tasks if workload pre-eval tasks have failed
+	// cancel deployment and post-deployment tasks if workload pre-eval tasks have failed
 	w.Status.DeploymentStatus = common.StateCancelled
 	w.Status.PostDeploymentStatus = common.StateCancelled
 	w.Status.PostDeploymentEvaluationStatus = common.StateCancelled

--- a/operator/apis/lifecycle/v1alpha2/keptnapp_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnapp_types.go
@@ -52,9 +52,9 @@ type KeptnWorkloadRef struct {
 	Version string `json:"version"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
 
 // KeptnApp is the Schema for the keptnapps API
 type KeptnApp struct {
@@ -65,7 +65,7 @@ type KeptnApp struct {
 	Status KeptnAppStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnAppList contains a list of KeptnApp
 type KeptnAppList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptnappversion_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnappversion_types.go
@@ -72,11 +72,11 @@ type WorkloadStatus struct {
 	Status common.KeptnState `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:resource:path=keptnappversions,shortName=kav
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:resource:path=keptnappversions,shortName=kav
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.currentPhase`
 // +kubebuilder:printcolumn:name="PreDeploymentStatus",priority=1,type=string,JSONPath=`.status.preDeploymentStatus`
@@ -94,7 +94,7 @@ type KeptnAppVersion struct {
 	Status KeptnAppVersionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnAppVersionList contains a list of KeptnAppVersion
 type KeptnAppVersionList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptnevaluation_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnevaluation_types.go
@@ -66,17 +66,17 @@ type EvaluationStatusItem struct {
 	Message string            `json:"message,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=keptnevaluations,shortName=ke
-//+kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
-//+kubebuilder:printcolumn:name="AppVersion",type=string,JSONPath=`.spec.appVersion`
-//+kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workload`
-//+kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.workloadVersion`
-//+kubebuilder:printcolumn:name="RetryCount",type=string,JSONPath=`.status.retryCount`
-//+kubebuilder:printcolumn:name="EvaluationStatus",type=string,JSONPath=`.status.evaluationStatus`
-//+kubebuilder:printcolumn:name="OverallStatus",type=string,JSONPath=`.status.overallStatus`
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=keptnevaluations,shortName=ke
+// +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.appName`
+// +kubebuilder:printcolumn:name="AppVersion",type=string,JSONPath=`.spec.appVersion`
+// +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workload`
+// +kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.workloadVersion`
+// +kubebuilder:printcolumn:name="RetryCount",type=string,JSONPath=`.status.retryCount`
+// +kubebuilder:printcolumn:name="EvaluationStatus",type=string,JSONPath=`.status.evaluationStatus`
+// +kubebuilder:printcolumn:name="OverallStatus",type=string,JSONPath=`.status.overallStatus`
 
 // KeptnEvaluation is the Schema for the keptnevaluations API
 type KeptnEvaluation struct {
@@ -87,7 +87,7 @@ type KeptnEvaluation struct {
 	Status KeptnEvaluationStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnEvaluationList contains a list of KeptnEvaluation
 type KeptnEvaluationList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptnevaluationdefinition_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnevaluationdefinition_types.go
@@ -41,10 +41,10 @@ type KeptnEvaluationDefinitionStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=keptnevaluationdefinitions,shortName=ked
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=keptnevaluationdefinitions,shortName=ked
 
 // KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions API
 type KeptnEvaluationDefinition struct {
@@ -55,7 +55,7 @@ type KeptnEvaluationDefinition struct {
 	Status KeptnEvaluationDefinitionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 type KeptnEvaluationDefinitionList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptnevaluationprovider_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnevaluationprovider_types.go
@@ -38,10 +38,10 @@ type KeptnEvaluationProviderStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=keptnevaluationproviders,shortName=kep
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=keptnevaluationproviders,shortName=kep
 
 // KeptnEvaluationProvider is the Schema for the keptnevaluationproviders API
 type KeptnEvaluationProvider struct {
@@ -52,7 +52,7 @@ type KeptnEvaluationProvider struct {
 	Status KeptnEvaluationProviderStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnEvaluationProviderList contains a list of KeptnEvaluationProvider
 type KeptnEvaluationProviderList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptntask_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptntask_types.go
@@ -72,9 +72,9 @@ type KeptnTaskStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="AppVersion",type=string,JSONPath=`.spec.appVersion`
 // +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workload`
@@ -91,7 +91,7 @@ type KeptnTask struct {
 	Status KeptnTaskStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnTaskList contains a list of KeptnTask
 type KeptnTaskList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptntaskdefinition_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptntaskdefinition_types.go
@@ -69,9 +69,9 @@ type FunctionStatus struct {
 	ConfigMap string `json:"configMap,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
 
 // KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 type KeptnTaskDefinition struct {
@@ -82,7 +82,7 @@ type KeptnTaskDefinition struct {
 	Status KeptnTaskDefinitionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 type KeptnTaskDefinitionList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptnworkload_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnworkload_types.go
@@ -45,9 +45,9 @@ type KeptnWorkloadStatus struct {
 	CurrentVersion string `json:"currentVersion,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`
 
@@ -60,7 +60,7 @@ type KeptnWorkload struct {
 	Status KeptnWorkloadStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadList contains a list of KeptnWorkload
 type KeptnWorkloadList struct {

--- a/operator/apis/lifecycle/v1alpha2/keptnworkloadinstance_types.go
+++ b/operator/apis/lifecycle/v1alpha2/keptnworkloadinstance_types.go
@@ -74,10 +74,10 @@ type ItemStatus struct {
 	EndTime   metav1.Time `json:"endTime,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workloadName`
 // +kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.version`
@@ -97,7 +97,7 @@ type KeptnWorkloadInstance struct {
 	Status KeptnWorkloadInstanceStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 type KeptnWorkloadInstanceList struct {

--- a/operator/apis/metrics/v1alpha1/keptnmetric_types.go
+++ b/operator/apis/metrics/v1alpha1/keptnmetric_types.go
@@ -50,11 +50,11 @@ type ProviderRef struct {
 	Name string `json:"name"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider.name`
-//+kubebuilder:printcolumn:name="Query",type=string,JSONPath=`.spec.query`
-//+kubebuilder:printcolumn:name="Value",type=string,JSONPath=`.status.value`
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider.name`
+// +kubebuilder:printcolumn:name="Query",type=string,JSONPath=`.spec.query`
+// +kubebuilder:printcolumn:name="Value",type=string,JSONPath=`.status.value`
 
 // KeptnMetric is the Schema for the keptnmetrics API
 type KeptnMetric struct {
@@ -65,7 +65,7 @@ type KeptnMetric struct {
 	Status KeptnMetricStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnMetricList contains a list of KeptnMetric
 type KeptnMetricList struct {

--- a/operator/apis/metrics/v1alpha1/keptnmetric_webhook.go
+++ b/operator/apis/metrics/v1alpha1/keptnmetric_webhook.go
@@ -36,7 +36,7 @@ func (s *KeptnMetric) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-metrics-keptn-sh-v1alpha1-keptnmetric,mutating=false,failurePolicy=fail,sideEffects=None,groups=metrics.keptn.sh,resources=keptnmetrics,verbs=create;update,versions=v1alpha1,name=vkeptnmetric.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-metrics-keptn-sh-v1alpha1-keptnmetric,mutating=false,failurePolicy=fail,sideEffects=None,groups=metrics.keptn.sh,resources=keptnmetrics,verbs=create;update,versions=v1alpha1,name=vkeptnmetric.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &KeptnMetric{}
 
@@ -60,7 +60,7 @@ func (s *KeptnMetric) ValidateDelete() error {
 }
 
 func (s *KeptnMetric) validateKeptnMetric() error {
-	var allErrs field.ErrorList //defined as a list to allow returning multiple validation errors
+	var allErrs field.ErrorList // defined as a list to allow returning multiple validation errors
 	var err *field.Error
 	if err = s.validateProvider(); err != nil {
 		allErrs = append(allErrs, err)

--- a/operator/apis/options/v1alpha1/keptnconfig_types.go
+++ b/operator/apis/options/v1alpha1/keptnconfig_types.go
@@ -42,8 +42,8 @@ type KeptnConfigStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // KeptnConfig is the Schema for the keptnconfigs API
 type KeptnConfig struct {
@@ -54,7 +54,7 @@ type KeptnConfig struct {
 	Status KeptnConfigStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnConfigList contains a list of KeptnConfig
 type KeptnConfigList struct {

--- a/operator/cmd/fake/manager_mock.go
+++ b/operator/cmd/fake/manager_mock.go
@@ -5,21 +5,20 @@ package fake
 
 import (
 	"context"
+	"net/http"
+	"sync"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sync"
-
-	"github.com/go-logr/logr"
 )
 
 // MockManager is a mock implementation of manager.IManager.

--- a/operator/controllers/common/fake/spanhandler_mock.go
+++ b/operator/controllers/common/fake/spanhandler_mock.go
@@ -5,9 +5,10 @@ package fake
 
 import (
 	"context"
+	"sync"
+
 	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sync"
 )
 
 // ISpanHandlerMock is a mock implementation of common.ISpanHandler.

--- a/operator/controllers/common/fake/tracer_mock.go
+++ b/operator/controllers/common/fake/tracer_mock.go
@@ -5,8 +5,9 @@ package fake
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/trace"
 	"sync"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ITracerMock is a mock implementation of interfaces.ITracer.

--- a/operator/controllers/common/fake/tracerfactory_mock.go
+++ b/operator/controllers/common/fake/tracerfactory_mock.go
@@ -4,8 +4,9 @@
 package fake
 
 import (
-	"go.opentelemetry.io/otel/trace"
 	"sync"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // TracerFactoryMock is a mock implementation of interfaces.TracerFactory.

--- a/operator/controllers/lifecycle/interfaces/fake/activemetricsobject_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/activemetricsobject_mock.go
@@ -4,8 +4,9 @@
 package fake
 
 import (
-	"go.opentelemetry.io/otel/attribute"
 	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // ActiveMetricsObjectMock is a mock implementation of common.ActiveMetricsObject.

--- a/operator/controllers/lifecycle/interfaces/fake/async/tracer_provider_float_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/async/tracer_provider_float_mock.go
@@ -4,9 +4,10 @@
 package fake
 
 import (
+	"sync"
+
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/asyncfloat64"
-	"sync"
 )
 
 // ITracerProviderAsyncFloat64Mock is a mock implementation of interfaces.ITracerProviderAsyncFloat64.

--- a/operator/controllers/lifecycle/interfaces/fake/async/tracer_provider_int_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/async/tracer_provider_int_mock.go
@@ -4,9 +4,10 @@
 package fake
 
 import (
+	"sync"
+
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/asyncint64"
-	"sync"
 )
 
 // ITracerProviderAsyncInt64Mock is a mock implementation of interfaces.ITracerProviderAsyncInt64.

--- a/operator/controllers/lifecycle/interfaces/fake/listitem_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/listitem_mock.go
@@ -4,8 +4,9 @@
 package fake
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ListItemMock is a mock implementation of common.ListItem.

--- a/operator/controllers/lifecycle/interfaces/fake/meter_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/meter_mock.go
@@ -5,12 +5,13 @@ package fake
 
 import (
 	"context"
+	"sync"
+
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/asyncfloat64"
 	"go.opentelemetry.io/otel/metric/instrument/asyncint64"
 	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
-	"sync"
 )
 
 // IMeterMock is a mock implementation of interfaces.IMeter.

--- a/operator/controllers/lifecycle/interfaces/fake/metricsobject_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/metricsobject_mock.go
@@ -4,9 +4,10 @@
 package fake
 
 import (
-	"go.opentelemetry.io/otel/attribute"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // MetricsObjectMock is a mock implementation of common.MetricsObject.

--- a/operator/controllers/lifecycle/interfaces/fake/phaseitem_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/phaseitem_mock.go
@@ -4,12 +4,13 @@
 package fake
 
 import (
+	"sync"
+	"time"
+
 	klcv1alpha2 "github.com/keptn/lifecycle-toolkit/operator/apis/lifecycle/v1alpha2"
 	apicommon "github.com/keptn/lifecycle-toolkit/operator/apis/lifecycle/v1alpha2/common"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"sync"
-	"time"
 )
 
 // PhaseItemMock is a mock implementation of interfaces.PhaseItem.

--- a/operator/controllers/lifecycle/interfaces/fake/spanitem_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/spanitem_mock.go
@@ -4,9 +4,10 @@
 package fake
 
 import (
+	"sync"
+
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
-	"sync"
 )
 
 // SpanItemMock is a mock implementation of common.SpanItem.

--- a/operator/controllers/lifecycle/interfaces/fake/sync/tracer_provider_float_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/sync/tracer_provider_float_mock.go
@@ -4,9 +4,10 @@
 package fake
 
 import (
+	"sync"
+
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/syncfloat64"
-	"sync"
 )
 
 // ITracerProviderSyncFloat64Mock is a mock implementation of interfaces.ITracerProviderSyncFloat64.

--- a/operator/controllers/lifecycle/interfaces/fake/sync/tracer_provider_int_mock.go
+++ b/operator/controllers/lifecycle/interfaces/fake/sync/tracer_provider_int_mock.go
@@ -4,9 +4,10 @@
 package fake
 
 import (
+	"sync"
+
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
-	"sync"
 )
 
 // ITracerProviderSyncInt64Mock is a mock implementation of interfaces.ITracerProviderSyncInt64.

--- a/operator/controllers/lifecycle/keptnapp/controller.go
+++ b/operator/controllers/lifecycle/keptnapp/controller.go
@@ -53,12 +53,12 @@ type KeptnAppReconciler struct {
 	TracerFactory controllercommon.TracerFactory
 }
 
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnapps,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnapps/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnapps/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversion,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversion/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversion/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnapps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnapps/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnapps/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversion,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversion/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversion/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/controllers/lifecycle/keptnappversion/controller.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller.go
@@ -53,10 +53,10 @@ type KeptnAppVersionReconciler struct {
 	SpanHandler   controllercommon.ISpanHandler
 }
 
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/status,verbs=get;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/controllers/lifecycle/keptnevaluation/controller.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller.go
@@ -53,15 +53,15 @@ type KeptnEvaluationReconciler struct {
 	Namespace     string
 }
 
-//clusterrole
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluations,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluations/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluations/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluationproviders,verbs=get;list;watch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluationdefinitions,verbs=get;list;watch
+// clusterrole
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluations/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluationproviders,verbs=get;list;watch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnevaluationdefinitions,verbs=get;list;watch
 
-//role
-//+kubebuilder:rbac:groups=core,namespace=keptn-lifecycle-toolkit-system,resources=secrets,verbs=get
+// role
+// +kubebuilder:rbac:groups=core,namespace=keptn-lifecycle-toolkit-system,resources=secrets,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/controllers/lifecycle/keptntask/controller.go
+++ b/operator/controllers/lifecycle/keptntask/controller.go
@@ -52,12 +52,12 @@ type KeptnTaskReconciler struct {
 	TracerFactory controllercommon.TracerFactory
 }
 
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;get;update;list;watch
-//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;list
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create;get;update;list;watch
+// +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;list
 
 func (r *KeptnTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Reconciling KeptnTask")

--- a/operator/controllers/lifecycle/keptntaskdefinition/controller.go
+++ b/operator/controllers/lifecycle/keptntaskdefinition/controller.go
@@ -39,10 +39,10 @@ type KeptnTaskDefinitionReconciler struct {
 	Recorder record.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntaskdefinitions,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntaskdefinitions/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntaskdefinitions/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;update;list;watch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntaskdefinitions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntaskdefinitions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntaskdefinitions/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;update;list;watch
 
 func (r *KeptnTaskDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Reconciling KeptnTaskDefinition")

--- a/operator/controllers/lifecycle/keptnworkload/controller.go
+++ b/operator/controllers/lifecycle/keptnworkload/controller.go
@@ -52,12 +52,12 @@ type KeptnWorkloadReconciler struct {
 	TracerFactory controllercommon.TracerFactory
 }
 
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloads,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloads/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloads/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloads,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloads/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloads/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -54,15 +54,15 @@ type KeptnWorkloadInstanceReconciler struct {
 	TracerFactory controllercommon.TracerFactory
 }
 
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;watch;patch
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
-//+kubebuilder:rbac:groups=apps,resources=replicasets;deployments;statefulsets;daemonsets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnworkloadinstances/finalizers,verbs=update
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptntasks/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;watch;patch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=replicasets;deployments;statefulsets;daemonsets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -74,7 +74,7 @@ type KeptnWorkloadInstanceReconciler struct {
 func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Searching for Keptn Workload Instance")
 
-	//retrieve workload instance
+	// retrieve workload instance
 	workloadInstance := &klcv1alpha2.KeptnWorkloadInstance{}
 	err := r.Get(ctx, req.NamespacedName, workloadInstance)
 	if errors.IsNotFound(err) {
@@ -96,7 +96,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 	appTraceContextCarrier := propagation.MapCarrier(workloadInstance.Spec.TraceId)
 	ctxAppTrace := otel.GetTextMapPropagator().Extract(context.TODO(), appTraceContextCarrier)
 
-	//Wait for pre-deployment checks of Workload
+	// Wait for pre-deployment checks of Workload
 	phase := apicommon.PhaseWorkloadPreDeployment
 	phaseHandler := controllercommon.PhaseHandler{
 		Client:      r.Client,
@@ -126,7 +126,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	//Wait for pre-evaluation checks of Workload
+	// Wait for pre-evaluation checks of Workload
 	phase = apicommon.PhaseWorkloadPreEvaluation
 	if !workloadInstance.IsPreDeploymentEvaluationSucceeded() {
 		reconcilePreEval := func(phaseCtx context.Context) (apicommon.KeptnState, error) {
@@ -138,7 +138,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	//Wait for deployment of Workload
+	// Wait for deployment of Workload
 	phase = apicommon.PhaseWorkloadDeployment
 	if !workloadInstance.IsDeploymentSucceeded() {
 		reconcileWorkloadInstance := func(phaseCtx context.Context) (apicommon.KeptnState, error) {
@@ -150,7 +150,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	//Wait for post-deployment checks of Workload
+	// Wait for post-deployment checks of Workload
 	phase = apicommon.PhaseWorkloadPostDeployment
 	if !workloadInstance.IsPostDeploymentSucceeded() {
 		reconcilePostDeployment := func(phaseCtx context.Context) (apicommon.KeptnState, error) {
@@ -162,7 +162,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	//Wait for post-evaluation checks of Workload
+	// Wait for post-evaluation checks of Workload
 	phase = apicommon.PhaseWorkloadPostEvaluation
 	if !workloadInstance.IsPostDeploymentEvaluationSucceeded() {
 		reconcilePostEval := func(phaseCtx context.Context) (apicommon.KeptnState, error) {

--- a/operator/controllers/metrics/keptnmetric_controller.go
+++ b/operator/controllers/metrics/keptnmetric_controller.go
@@ -43,14 +43,14 @@ type KeptnMetricReconciler struct {
 	Log    logr.Logger
 }
 
-//clusterrole
-//+kubebuilder:rbac:groups=metrics.keptn.sh,resources=providers,verbs=get;list;watch
-//+kubebuilder:rbac:groups=metrics.keptn.sh,resources=keptnmetrics,verbs=get;list;watch;
-//+kubebuilder:rbac:groups=metrics.keptn.sh,resources=keptnmetrics/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=metrics.keptn.sh,resources=keptnmetrics/finalizers,verbs=update
+// clusterrole
+// +kubebuilder:rbac:groups=metrics.keptn.sh,resources=providers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=metrics.keptn.sh,resources=keptnmetrics,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=metrics.keptn.sh,resources=keptnmetrics/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=metrics.keptn.sh,resources=keptnmetrics/finalizers,verbs=update
 
-//role
-//+kubebuilder:rbac:groups=core,namespace=keptn-lifecycle-toolkit-system,resources=secrets,verbs=get
+// role
+// +kubebuilder:rbac:groups=core,namespace=keptn-lifecycle-toolkit-system,resources=secrets,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/controllers/options/keptnconfig_controller.go
+++ b/operator/controllers/options/keptnconfig_controller.go
@@ -40,9 +40,9 @@ type KeptnConfigReconciler struct {
 	LastAppliedSpec *optionsv1alpha1.KeptnConfigSpec
 }
 
-//+kubebuilder:rbac:groups=options.keptn.sh,resources=keptnconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=options.keptn.sh,resources=keptnconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=options.keptn.sh,resources=keptnconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=options.keptn.sh,resources=keptnconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=options.keptn.sh,resources=keptnconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=options.keptn.sh,resources=keptnconfigs/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/operator/main.go
+++ b/operator/main.go
@@ -58,7 +58,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -73,7 +73,7 @@ func init() {
 	utilruntime.Must(lifecyclev1alpha2.AddToScheme(scheme))
 	utilruntime.Must(metricsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(optionsv1alpha1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 type envConfig struct {
@@ -316,7 +316,7 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KeptnMetric")
 		os.Exit(1)
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	controllercommon.SetUpKeptnMeters(meter, mgr.GetClient())
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -58,6 +58,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// nolint:gci
 	// +kubebuilder:scaffold:imports
 )
 

--- a/operator/test/component/suite_test.go
+++ b/operator/test/component/suite_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// nolint:gci
 	// +kubebuilder:scaffold:imports
 )
 

--- a/operator/test/component/suite_test.go
+++ b/operator/test/component/suite_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 	err = klcv1alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = metricsv1alpha1.AddToScheme(scheme.Scheme)

--- a/operator/test/e2e/suite_test.go
+++ b/operator/test/e2e/suite_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// nolint:gci
 	// +kubebuilder:scaffold:imports
 )
 

--- a/operator/test/e2e/suite_test.go
+++ b/operator/test/e2e/suite_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 	err = klcv1alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
-		time.Sleep(3 * time.Second) //wait for test to start
+		time.Sleep(3 * time.Second) // wait for test to start
 		wg.Wait()
 		fmt.Println("SUITE FINISHED")
 		err := testEnv.Stop()

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook.go
@@ -30,8 +30,8 @@ import (
 )
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.keptn.sh,admissionReviewVersions=v1,sideEffects=None
-//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
-//+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets;replicasets,verbs=get
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets;replicasets,verbs=get
 
 // PodMutatingWebhook annotates Pods
 type PodMutatingWebhook struct {

--- a/scheduler/test/e2e/fake/v1alpha1/keptnworkload_types.go
+++ b/scheduler/test/e2e/fake/v1alpha1/keptnworkload_types.go
@@ -42,8 +42,8 @@ type KeptnWorkloadStatus struct {
 	CurrentVersion string `json:"currentVersion,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`
 
@@ -56,7 +56,7 @@ type KeptnWorkload struct {
 	Status KeptnWorkloadStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadList contains a list of KeptnWorkload
 type KeptnWorkloadList struct {

--- a/scheduler/test/e2e/fake/v1alpha1/keptnworkloadinstance_types.go
+++ b/scheduler/test/e2e/fake/v1alpha1/keptnworkloadinstance_types.go
@@ -75,9 +75,9 @@ type EvaluationStatus struct {
 	EndTime        metav1.Time       `json:"endTime,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workloadName`
 // +kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.version`
@@ -97,7 +97,7 @@ type KeptnWorkloadInstance struct {
 	Status KeptnWorkloadInstanceStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 type KeptnWorkloadInstanceList struct {

--- a/scheduler/test/e2e/fake/v1alpha2/keptnworkload_types.go
+++ b/scheduler/test/e2e/fake/v1alpha2/keptnworkload_types.go
@@ -42,8 +42,8 @@ type KeptnWorkloadStatus struct {
 	CurrentVersion string `json:"currentVersion,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.spec.version`
 
@@ -56,7 +56,7 @@ type KeptnWorkload struct {
 	Status KeptnWorkloadStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadList contains a list of KeptnWorkload
 type KeptnWorkloadList struct {

--- a/scheduler/test/e2e/fake/v1alpha2/keptnworkloadinstance_types.go
+++ b/scheduler/test/e2e/fake/v1alpha2/keptnworkloadinstance_types.go
@@ -68,9 +68,9 @@ type ItemStatus struct {
 	EndTime   metav1.Time `json:"endTime,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=keptnworkloadinstances,shortName=kwi
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AppName",type=string,JSONPath=`.spec.app`
 // +kubebuilder:printcolumn:name="WorkloadName",type=string,JSONPath=`.spec.workloadName`
 // +kubebuilder:printcolumn:name="WorkloadVersion",type=string,JSONPath=`.spec.version`
@@ -90,7 +90,7 @@ type KeptnWorkloadInstance struct {
 	Status KeptnWorkloadInstanceStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 type KeptnWorkloadInstanceList struct {

--- a/scheduler/test/e2e/suite_test.go
+++ b/scheduler/test/e2e/suite_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// nolint:gci
 	// +kubebuilder:scaffold:imports
 )
 

--- a/scheduler/test/e2e/suite_test.go
+++ b/scheduler/test/e2e/suite_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	apiServerArgs := testEnv.ControlPlane.GetAPIServer().Configure()
-	//apiServerArgs.Append("disable-admission-plugins", "TaintNodesByCondition", "Priority")
+	// apiServerArgs.Append("disable-admission-plugins", "TaintNodesByCondition", "Priority")
 	apiServerArgs.Append("runtime-config", "api/all=true")
 
 	var err error
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 	err = testv1alpha2.AddToScheme(kscheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	k8sClient, err = client.New(cfg, client.Options{Scheme: kscheme.Scheme})
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
-		time.Sleep(30 * time.Second) //wait for test to start
+		time.Sleep(30 * time.Second) // wait for test to start
 		wg.Wait()
 		fmt.Println("SUITE FINISHED")
 		err := testEnv.Stop()


### PR DESCRIPTION
### This PR
- fixes all currently open linter errors from golangci-lint
  - gci
  - unused variables
  - makes kubebuilder comment style consistent

#### Notes
Changes are nicely split into separate commits with good descriptions for easy review