### PR TITLE
chore: improve Makefiles usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,5 @@ markdownlint:
 
 markdownlint-fix:
 	docker run -v $(CURDIR):/workdir --rm  ghcr.io/igorshubovych/markdownlint-cli:latest  "**/*.md" --config "/workdir/docs/markdownlint-rules.yaml" --fix --ignore "/workdir/CHANGELOG.md"
+
+include docs/Makefile

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,5 @@
-VOLUMES := -v $(CURDIR):/src 
+ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+VOLUMES := -v $(ROOT_DIR):/src 
 # renovate: datasource=docker depName=klakegg/hugo
 HUGO_VERSION := 0.105.0-ext
 IMAGE := klakegg/hugo:$(HUGO_VERSION)


### PR DESCRIPTION
Allowing "make" targets of the `docs` directory to be populated into the main `makefile`. Now they can be called from both directories.