### PR TITLE
chore: fix development url in page branch

### DIFF
--- a/docs/config/production/params.yaml
+++ b/docs/config/production/params.yaml
@@ -1,5 +1,5 @@
 
 versions:
-- url: https://main-lifecycle-toolkit.keptn.sh
+- url: https://main.lifecycle.keptn.sh
   version: development
 github_branch: page


### PR DESCRIPTION
This would be fixed with the next release, but we want to be consistent, so here is the change for the testing. As the branch is already protected, we are doing this by PR.