### PR TITLE
feat: datadog metric provider for KLT

### DIFF
--- a/metrics-operator/controllers/common/providers/common.go
+++ b/metrics-operator/controllers/common/providers/common.go
@@ -3,3 +3,4 @@ package providers
 const DynatraceProviderName = "dynatrace"
 const DynatraceDQLProviderName = "dql"
 const PrometheusProviderName = "prometheus"
+const DataDogProviderName = "datadog"

--- a/metrics-operator/controllers/common/providers/datadog/common.go
+++ b/metrics-operator/controllers/common/providers/datadog/common.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const apiKey, appKey = "DD_CLIENT_API_KEY", "DD_CLIENT_APP_KEY"
+
 var ErrSecretKeyRefNotDefined = errors.New("the SecretKeyRef property with the DataDog API Key is missing")
 
 func hasDDSecretDefined(spec metricsapi.KeptnMetricsProviderSpec) bool {
@@ -33,7 +35,6 @@ func getDDSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, 
 		return "", "", err
 	}
 
-	apiKey, appKey := "DD_CLIENT_API_KEY", "DD_CLIENT_APP_KEY"
 	apiKeyVal := ddCredsSecret.Data[apiKey]
 	appKeyVal := ddCredsSecret.Data[appKey]
 	if len(apiKeyVal) == 0 || len(appKeyVal) == 0 {

--- a/metrics-operator/controllers/common/providers/datadog/common.go
+++ b/metrics-operator/controllers/common/providers/datadog/common.go
@@ -38,7 +38,7 @@ func getDDSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, 
 	apiKeyVal := ddCredsSecret.Data[apiKey]
 	appKeyVal := ddCredsSecret.Data[appKey]
 	if len(apiKeyVal) == 0 || len(appKeyVal) == 0 {
-		return "", "", fmt.Errorf("secret does not contain %s, %s", apiKey, appKey)
+		return "", "", fmt.Errorf("secret does not contain %s or %s", apiKey, appKey)
 	}
 	return string(apiKeyVal), string(appKeyVal), nil
 }

--- a/metrics-operator/controllers/common/providers/datadog/common.go
+++ b/metrics-operator/controllers/common/providers/datadog/common.go
@@ -1,0 +1,31 @@
+package datadog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var ErrSecretKeyRefNotDefined = errors.New("the SecretKeyRef property with the DataDog API Key is missing")
+
+func getDDSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) (string, error) {
+	if !provider.HasSecretDefined() {
+		return "", ErrSecretKeyRefNotDefined
+	}
+	ddCredsSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: provider.Spec.SecretKeyRef.Name, Namespace: provider.Namespace}, ddCredsSecret); err != nil {
+		return "", err
+	}
+	fmt.Println(provider.Spec.SecretKeyRef.Key)
+
+	apiKey := ddCredsSecret.Data[provider.Spec.SecretKeyRef.Key]
+	if len(apiKey) == 0 {
+		return "", fmt.Errorf("secret contains invalid key %s", provider.Spec.SecretKeyRef.Key)
+	}
+	return string(apiKey), nil
+}

--- a/metrics-operator/controllers/common/providers/datadog/common_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/common_test.go
@@ -1,0 +1,120 @@
+package datadog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
+	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/fake"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetSecret_NoKeyDefined(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+	fakeClient := fake.NewClient()
+
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: svr.URL,
+		},
+	}
+	r1, r2, e := getDDSecret(context.TODO(), p, fakeClient)
+	require.NotNil(t, e)
+	require.ErrorIs(t, e, ErrSecretKeyRefNotDefined)
+	require.Empty(t, r1)
+	require.Empty(t, r2)
+
+}
+
+func TestGetSecret_NoSecretDefined(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "DD_CLIENT_API_KEY", "fake-api-key"
+	appKey, appKeyValue := "DD_CLIENT_APP_KEY", "fake-app-key"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "garbage",
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			apiKey: []byte(apiKeyValue),
+			appKey: []byte(appKeyValue),
+		},
+	}
+	fakeClient := fake.NewClient(apiToken)
+
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+	r1, r2, e := getDDSecret(context.TODO(), p, fakeClient)
+	require.NotNil(t, e)
+	require.True(t, strings.Contains(e.Error(), "secrets \""+secretName+"\" not found"))
+	require.Empty(t, r1)
+	require.Empty(t, r2)
+
+}
+
+func TestGetSecret_HappyPath(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "DD_CLIENT_API_KEY", "fake-api-key"
+	appKey, appKeyValue := "DD_CLIENT_APP_KEY", "fake-app-key"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			apiKey: []byte(apiKeyValue),
+			appKey: []byte(appKeyValue),
+		},
+	}
+	fakeClient := fake.NewClient(apiToken)
+
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+	r1, r2, e := getDDSecret(context.TODO(), p, fakeClient)
+	require.Nil(t, e)
+	require.Equal(t, apiKeyValue, r1)
+	require.Equal(t, appKeyValue, r2)
+
+}

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -74,6 +74,28 @@ func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metrics
 	}
 
 	points := (result.Series)[0].Pointlist
-	value := strconv.FormatFloat(*points[len(points)-1][1], 'g', 5, 64)
+	if len(points) == 0 {
+		d.Log.Info("No metric points in query result")
+		return "", nil, fmt.Errorf("no metric points in query result")
+	}
+
+	r := d.getSingleValue(points)
+	value := strconv.FormatFloat(r, 'g', 5, 64)
 	return value, b, nil
+}
+
+func (d *KeptnDataDogProvider) getSingleValue(points [][]*float64) float64 {
+	var sum float64 = 0
+	var count uint64 = 0
+	for _, point := range points {
+		if point[1] != nil {
+			sum += *point[1]
+			count++
+		}
+	}
+	if count < 1 {
+		// cannot dive by zero
+		return 0
+	}
+	return sum / float64(count)
 }

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -39,15 +39,14 @@ func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metrics
 		return "", nil, err
 	}
 
-	apiKey, err := getDDSecret(ctx, provider, d.K8sClient)
+	apiKeyVal, appKeyVal, err := getDDSecret(ctx, provider, d.K8sClient)
 	if err != nil {
 		return "", nil, err
 	}
-	appKey := "appkey" // TODO: retrieve this from kubernetes secret
 
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Dd-Api-Key", apiKey)
-	req.Header.Set("Dd-Application-Key", appKey)
+	req.Header.Set("Dd-Api-Key", apiKeyVal)
+	req.Header.Set("Dd-Application-Key", appKeyVal)
 
 	res, err := d.HttpClient.Do(req)
 	if err != nil {

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -30,9 +30,10 @@ func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metrics
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	// Assumed default metric duration as 1 day(s)
+	// Assumed default metric duration as 5 minutes
 	// Think a better way to handle this
-	fromTime := time.Now().AddDate(0, 0, -1).Unix()
+	intervalInMin := 5
+	fromTime := time.Now().Add(time.Duration(-intervalInMin) * time.Minute).Unix()
 	toTime := time.Now().Unix()
 	qURL := provider.Spec.TargetServer + "/api/v1/query?from=" + strconv.Itoa(int(fromTime)) + "&to=" + strconv.Itoa(int(toTime)) + "&query=" + url.QueryEscape(metric.Spec.Query)
 	req, err := http.NewRequestWithContext(ctx, "GET", qURL, nil)

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -8,12 +8,14 @@ import (
 	"github.com/go-logr/logr"
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
 	"io"
+	//nolint:gci
+	"net/http" //nolint:gci
 	"net/url"
 	"strconv"
 	"time"
 
 	//nolint:gci
-	"net/http" //nolint:gci
+	//nolint:gci
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -1,0 +1,80 @@
+package datadog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/go-logr/logr"
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
+	"io"
+	"net/url"
+	"strconv"
+	"time"
+
+	//nolint:gci
+	"net/http" //nolint:gci
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type KeptnDataDogProvider struct {
+	Log        logr.Logger
+	HttpClient http.Client
+	K8sClient  client.Client
+}
+
+// EvaluateQuery fetches the SLI values from datadog provider
+func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metricsapi.KeptnMetric, provider metricsapi.KeptnMetricsProvider) (string, []byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	// Assumed default metric duration as 1 day(s)
+	// Think a better way to handle this
+	fromTime := time.Now().AddDate(0, 0, -1).Unix()
+	toTime := time.Now().Unix()
+	qURL := provider.Spec.TargetServer + "/api/v1/query?from=" + strconv.Itoa(int(fromTime)) + "&to=" + strconv.Itoa(int(toTime)) + "&query=" + url.QueryEscape(metric.Spec.Query)
+	req, err := http.NewRequestWithContext(ctx, "GET", qURL, nil)
+	if err != nil {
+		d.Log.Error(err, "Error while creating request")
+		return "", nil, err
+	}
+
+	apiKey, err := getDDSecret(ctx, provider, d.K8sClient)
+	if err != nil {
+		return "", nil, err
+	}
+	appKey := "appkey" // TODO: retrieve this from kubernetes secret
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Dd-Api-Key", apiKey)
+	req.Header.Set("Dd-Application-Key", appKey)
+
+	res, err := d.HttpClient.Do(req)
+	if err != nil {
+		d.Log.Error(err, "Error while creating request")
+		return "", nil, err
+	}
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			d.Log.Error(err, "Could not close request body")
+		}
+	}()
+
+	b, _ := io.ReadAll(res.Body)
+	result := datadogV1.MetricsQueryResponse{}
+	err = json.Unmarshal(b, &result)
+	if err != nil {
+		d.Log.Error(err, "Error while parsing response")
+		return "", nil, err
+	}
+
+	if len(result.Series) == 0 {
+		d.Log.Info("No values in query result")
+		return "", nil, fmt.Errorf("no values in query result")
+	}
+
+	points := (result.Series)[0].Pointlist
+	value := strconv.FormatFloat(*points[len(points)-1][1], 'g', 5, 64)
+	return value, b, nil
+}

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -5,8 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	//nolint:gci
-	"net/http" //nolint:gci
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -14,8 +13,6 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/go-logr/logr"
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
-	//nolint:gci
-	//nolint:gci
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
-	"github.com/go-logr/logr"
-	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
 	"io"
 	//nolint:gci
 	"net/http" //nolint:gci
@@ -14,6 +11,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/go-logr/logr"
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
 	//nolint:gci
 	//nolint:gci
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -68,3 +68,53 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 	require.Equal(t, []byte(ddPayload), raw)
 	require.Equal(t, fmt.Sprintf("%.3f", 84.782), r)
 }
+func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte("garbage"))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "DD_CLIENT_API_KEY", "fake-api-key"
+	appKey, appKeyValue := "DD_CLIENT_APP_KEY", "fake-app-key"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			apiKey: []byte(apiKeyValue),
+			appKey: []byte(appKeyValue),
+		},
+	}
+	fakeClient := fake.NewClient(apiToken)
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+
+	r, raw, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.Equal(t, "", r)
+	require.Equal(t, []byte(nil), raw)
+	require.NotNil(t, e)
+}

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -1,0 +1,65 @@
+package datadog
+
+import (
+	"context"
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
+	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/fake"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const ddPayload = "{\"from_date\":1677736306000,\"group_by\":[],\"message\":\"\",\"query\":\"system.cpu.idle{*}\",\"res_type\":\"time_series\",\"series\":[{\"aggr\":null,\"display_name\":\"system.cpu.idle\",\"end\":1677821999000,\"expression\":\"system.cpu.idle{*}\",\"interval\":300,\"length\":7,\"metric\":\"system.cpu.idle\",\"pointlist\":[[1677781200000,92.37997436523438],[1677781500000,91.46615447998047],[1677781800000,92.05865631103515],[1677782100000,97.49858474731445],[1677782400000,95.95263163248698],[1677821400000,69.67094268798829],[1677821700000,84.78184509277344]],\"query_index\":0,\"scope\":\"*\",\"start\":1677781200000,\"tag_set\":[],\"unit\":[{\"family\":\"percentage\",\"name\":\"percent\",\"plural\":\"percent\",\"scale_factor\":1,\"short_name\":\"%\"},{}]}],\"status\":\"ok\",\"to_date\":1677822706000}"
+
+func TestEvaluateQuery_HappyPath(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+	secretName, secretKey, secretValue := "datadogToken", "apiKey", "fake-api-key"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			secretKey: []byte(secretValue),
+		},
+	}
+	fakeClient := fake.NewClient(apiToken)
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: secretKey,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+
+	r, raw, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.Nil(t, e)
+	require.Equal(t, []byte(ddPayload), raw)
+	require.Equal(t, fmt.Sprintf("%.3f", 84.782), r)
+}

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -3,7 +3,6 @@ package datadog
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -24,14 +24,18 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 		require.Nil(t, err)
 	}))
 	defer svr.Close()
-	secretName, secretKey, secretValue := "datadogToken", "apiKey", "fake-api-key"
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "DD_CLIENT_API_KEY", "fake-api-key"
+	appKey, appKeyValue := "DD_CLIENT_APP_KEY", "fake-app-key"
 	apiToken := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: "",
 		},
 		Data: map[string][]byte{
-			secretKey: []byte(secretValue),
+			apiKey: []byte(apiKeyValue),
+			appKey: []byte(appKeyValue),
 		},
 	}
 	fakeClient := fake.NewClient(apiToken)
@@ -46,13 +50,14 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 			Query: "system.cpu.idle{*}",
 		},
 	}
+	b := true
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
 			SecretKeyRef: v1.SecretKeySelector{
 				LocalObjectReference: v1.LocalObjectReference{
 					Name: secretName,
 				},
-				Key: secretKey,
+				Optional: &b,
 			},
 			TargetServer: svr.URL,
 		},

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -3,7 +3,6 @@ package datadog
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -3,8 +3,10 @@ package datadog
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
@@ -17,6 +19,7 @@ import (
 )
 
 const ddPayload = "{\"from_date\":1677736306000,\"group_by\":[],\"message\":\"\",\"query\":\"system.cpu.idle{*}\",\"res_type\":\"time_series\",\"series\":[{\"aggr\":null,\"display_name\":\"system.cpu.idle\",\"end\":1677821999000,\"expression\":\"system.cpu.idle{*}\",\"interval\":300,\"length\":7,\"metric\":\"system.cpu.idle\",\"pointlist\":[[1677781200000,92.37997436523438],[1677781500000,91.46615447998047],[1677781800000,92.05865631103515],[1677782100000,97.49858474731445],[1677782400000,95.95263163248698],[1677821400000,69.67094268798829],[1677821700000,84.78184509277344]],\"query_index\":0,\"scope\":\"*\",\"start\":1677781200000,\"tag_set\":[],\"unit\":[{\"family\":\"percentage\",\"name\":\"percent\",\"plural\":\"percent\",\"scale_factor\":1,\"short_name\":\"%\"},{}]}],\"status\":\"ok\",\"to_date\":1677822706000}"
+const ddEmptyPayload = "{\"from_date\":1677736306000,\"group_by\":[],\"message\":\"\",\"query\":\"system.cpu.idle{*}\",\"res_type\":\"time_series\",\"series\":[],\"status\":\"ok\",\"to_date\":1677822706000}"
 
 func TestEvaluateQuery_HappyPath(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -117,4 +120,168 @@ func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
 	require.Equal(t, "", r)
 	require.Equal(t, []byte(nil), raw)
 	require.NotNil(t, e)
+}
+func TestEvaluateQuery_MissingSecret(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	fakeClient := fake.NewClient()
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: svr.URL,
+		},
+	}
+
+	_, _, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.NotNil(t, e)
+	require.ErrorIs(t, e, ErrSecretKeyRefNotDefined)
+}
+func TestEvaluateQuery_SecretNotFound(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	fakeClient := fake.NewClient()
+	secretName := "datadogSecret"
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+
+	_, _, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.NotNil(t, e)
+	require.True(t, errors.IsNotFound(e))
+}
+func TestEvaluateQuery_RefNonExistingKey(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "I_AM_NOT_DD_CLIENT_API_KEY", "value"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			apiKey: []byte(apiKeyValue),
+		},
+	}
+	fakeClient := fake.NewClient(apiToken)
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+
+	_, _, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.NotNil(t, e)
+	require.True(t, strings.Contains(e.Error(), "secret does not contain DD_CLIENT_API_KEY or DD_CLIENT_APP_KEY"))
+}
+func TestEvaluateQuery_EmptyPayload(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddEmptyPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "DD_CLIENT_API_KEY", "fake-api-key"
+	appKey, appKeyValue := "DD_CLIENT_APP_KEY", "fake-app-key"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			apiKey: []byte(apiKeyValue),
+			appKey: []byte(appKeyValue),
+		},
+	}
+	fakeClient := fake.NewClient(apiToken)
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+
+	r, raw, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.Nil(t, raw)
+	require.Equal(t, "", r)
+	require.True(t, strings.Contains(e.Error(), "no values in query result"))
+
 }

--- a/metrics-operator/controllers/common/providers/provider.go
+++ b/metrics-operator/controllers/common/providers/provider.go
@@ -42,6 +42,7 @@ func NewProvider(provider string, log logr.Logger, k8sClient client.Client) (Kep
 		return &datadog.KeptnDataDogProvider{
 			Log:        log,
 			HttpClient: http.Client{},
+			K8sClient:  k8sClient,
 		}, nil
 	default:
 		return nil, fmt.Errorf("provider %s not supported", provider)

--- a/metrics-operator/controllers/common/providers/provider.go
+++ b/metrics-operator/controllers/common/providers/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
+	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/datadog"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/dynatrace"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,11 @@ func NewProvider(provider string, log logr.Logger, k8sClient client.Client) (Kep
 			k8sClient,
 			dynatrace.WithLogger(log),
 		), nil
+	case DataDogProviderName:
+		return &datadog.KeptnDataDogProvider{
+			Log:        log,
+			HttpClient: http.Client{},
+		}, nil
 	default:
 		return nil, fmt.Errorf("provider %s not supported", provider)
 	}

--- a/metrics-operator/controllers/common/providers/provider_test.go
+++ b/metrics-operator/controllers/common/providers/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/datadog"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/dynatrace"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/prometheus"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,11 @@ func TestFactory(t *testing.T) {
 		{
 			name:     DynatraceProviderName,
 			provider: &dynatrace.KeptnDynatraceProvider{},
+			err:      false,
+		},
+		{
+			name:     DataDogProviderName,
+			provider: &datadog.KeptnDataDogProvider{},
 			err:      false,
 		},
 		{

--- a/metrics-operator/go.mod
+++ b/metrics-operator/go.mod
@@ -3,6 +3,7 @@ module github.com/keptn/lifecycle-toolkit/metrics-operator
 go 1.18
 
 require (
+	github.com/DataDog/datadog-api-client-go/v2 v2.9.0
 	github.com/benbjohnson/clock v1.3.0
 	github.com/go-logr/logr v1.2.3
 	github.com/gorilla/mux v1.8.0
@@ -27,6 +28,7 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	github.com/DataDog/zstd v1.5.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/metrics-operator/go.sum
+++ b/metrics-operator/go.sum
@@ -43,6 +43,10 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/datadog-api-client-go/v2 v2.9.0 h1:1Cz3mqj95iqnQPykEovq2p52rrU26XvLC2Fz6hPE+TU=
+github.com/DataDog/datadog-api-client-go/v2 v2.9.0/go.mod h1:sHt3EuVMN8PSYJu065qwp3pZxCwR3RZP4sJnYwj/ZQY=
+github.com/DataDog/zstd v1.5.0 h1:+K/VEwIAaPcHiMtQvpLD4lqW7f0Gk3xdYZmI1hD+CXo=
+github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Fixes #554

**_Due to a breaking change I have closed my previous draft and opened this updated one._**

I am hoping to get your opinion on DataDog APIs. I'm still getting the hang of things and would appreciate your input on what I've learned so far and where to go next. As a newcomer to DataDog, I'm eager to soak up as much knowledge as possible, so any assistance you can provide would be awesome :+1: 

**Progress**

- I have looked into the [dyantrace.go](https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go) and [prometheus.go](https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/controllers/common/providers/prometheus/prometheus.go) files and tried to understand EvaluateQuery function.
- Similar to the above implementation the goal `datadog.go` is to fetch the SLIs from the DataDog API.
- Also using [this](https://docs.datadoghq.com/api/latest/metrics/#query-timeseries-points) API we can query time series data from data dog.
- I looked into the @vadasambar's [code (here) ](https://github.com/keptn-sandbox/datadog-service/blob/10483aa887e7955910d08eab61f3b5e89b5a8632/eventhandlers.go#L123) and  found some logic for fetching the metric data and preparing `Sliresult` :heavy_check_mark: 
- I have tried [Go Client for DD](https://github.com/DataDog/datadog-api-client-go) which was suggested in the issue description page. Unfortunately, it has **some limitations.**
    - I could not mock the **target-server**
    - According to the docs you can change the target-server like [this](https://github.com/DataDog/datadog-api-client-go#changing-server). However it does not work as you can only choose target-server among ```"datadoghq.com",
							"us3.datadoghq.com",
							"us5.datadoghq.com",
							"datadoghq.eu",
							"ddog-gov.com"```
    - It limits the possibility to test the provider using mock server (similar to[ dynatrace provider](https://github.com/keptn/lifecycle-toolkit/blob/bd493578df8825a52ec0f027583341a80b3c90f6/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go#L147))
- I proceed with **httpclient**

**Suggestion required**

- :heavy_check_mark: How do I get 2 keys (APP_KEY and API_KEY) from Kubernetes secret? [KeptnMetricsProviderSpec](https://github.com/keptn/lifecycle-toolkit/blob/bd493578df8825a52ec0f027583341a80b3c90f6/metrics-operator/api/v1alpha2/keptnmetricsprovider_types.go#L27) can handle only one `SecretKeyRef`, I am not sure about the syntax on how to handle 2 keys here. **Update:** marked `SecretKeySelector` as optional. Now e can expect as many keys as we need in the Kubernetes secret. 
- To get a single value from the metric API I used [this](https://github.com/keptn-sandbox/datadog-service/blob/10483aa887e7955910d08eab61f3b5e89b5a8632/eventhandlers.go#L135) logic found in [keptn-sandbox/datadog-service](https://github.com/keptn-sandbox/datadog-service/blob/10483aa887e7955910d08eab61f3b5e89b5a8632/eventhandlers.go#L135)
- I saw in dynatrace implementation, a [getSingleValue](https://github.com/keptn/lifecycle-toolkit/blob/bd493578df8825a52ec0f027583341a80b3c90f6/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go#L82) is implemented. It basically, returns the average of the metric value. Therefore, I think the current logic might need some amendments. Please suggest.

I need suggestions and mentorship to successfully implement this. I would appreciate any reference materials or comment.