### PR TITLE
fix(metrics-operator): use correct port for serving metrics api

### DIFF
--- a/metrics-operator/config/manager/manager.yaml
+++ b/metrics-operator/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
             name: webhook-server
             protocol: TCP
           - name: metrics
-            containerPort: 2222
+            containerPort: 9999
             protocol: TCP
           - name: custom-metrics
             containerPort: 6443

--- a/metrics-operator/config/manager/service.yaml
+++ b/metrics-operator/config/manager/service.yaml
@@ -16,7 +16,7 @@ spec:
       port: 443
     - name: metrics
       protocol: TCP
-      port: 2222
+      port: 9999
       targetPort: metrics
   selector:
     control-plane: metrics-operator

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -19,9 +19,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -36,7 +34,6 @@ import (
 	metricscontroller "github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/metrics"
 	keptnserver "github.com/keptn/lifecycle-toolkit/metrics-operator/pkg/metrics"
 	"github.com/open-feature/go-sdk/pkg/openfeature"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -91,9 +88,6 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	// Start the prometheus HTTP server and pass the exporter Collector to it
-	go serveMetrics()
 
 	// Start the custom metrics adapter
 	go startCustomMetricsAdapter(env.PodNamespace)
@@ -174,17 +168,6 @@ func main() {
 			setupLog.Error(err, "problem running manager")
 			os.Exit(1)
 		}
-	}
-}
-
-func serveMetrics() {
-	log.Printf("serving metrics at localhost:2222/metrics")
-
-	http.Handle("/metrics", promhttp.Handler())
-	err := http.ListenAndServe(":2222", nil)
-	if err != nil {
-		fmt.Printf("error serving http: %v", err)
-		return
 	}
 }
 

--- a/metrics-operator/pkg/metrics/server.go
+++ b/metrics-operator/pkg/metrics/server.go
@@ -108,7 +108,8 @@ func (m *serverManager) setup() error {
 	klog.Infof("Keptn Metrics server enabled: %v", serverEnabled)
 
 	if serverEnabled && m.server == nil {
-		klog.Infof("serving metrics at localhost:9999/metrics")
+		klog.Infof("serving Prometheus metrics at localhost:9999/metrics")
+		klog.Infof("serving KeptnMetrics at localhost:9999/api/v1/metrics/{namespace}/{metric}")
 
 		router := mux.NewRouter()
 		router.Path("/metrics").Handler(promhttp.Handler())

--- a/test/integration/expose-keptn-metric/00-install.yaml
+++ b/test/integration/expose-keptn-metric/00-install.yaml
@@ -7,15 +7,26 @@ spec:
   template:
     spec:
       containers:
-      - name: test
+      - name: test-prometheus
         image: curlimages/curl:7.72.0
         args:
         - /bin/sh
         - -ec
         - |
-          curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:2222/metrics > ~/out.txt
+          curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/metrics > ~/out.txt
           if grep -Fxq "# HELP keptnmetric_sample keptnmetric-sample" ~/out.txt
           then
             exit 1
           fi
+      - name: test-api-endpoint
+        image: curlimages/curl:7.72.0
+        args:
+          - /bin/sh
+          - -ec
+          - |
+            curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/api/v1/metrics//keptnmetric-sample > ~/out.txt
+            if grep -Fxq "keptnmetric-sample" ~/out.txt
+            then
+              exit 1
+            fi
       restartPolicy: Never

--- a/test/integration/expose-keptn-metric/00-install.yaml
+++ b/test/integration/expose-keptn-metric/00-install.yaml
@@ -25,7 +25,7 @@ spec:
           - -ec
           - |
             curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/api/v1/metrics//keptnmetric-sample > ~/out.txt
-            if grep -Fxq "keptnmetric-sample" ~/out.txt
+            if grep -F "keptnmetric-sample" ~/out.txt
             then
               exit 1
             fi

--- a/test/integration/expose-keptn-metric/01-install.yaml
+++ b/test/integration/expose-keptn-metric/01-install.yaml
@@ -37,7 +37,7 @@ spec:
           - -ec
           - |
             curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/api/v1/metrics/keptn-lifecycle-toolkit-system/keptnmetric-sample > ~/out.txt
-            if grep -Fxq "keptnmetric-sample" ~/out.txt
+            if grep -F "keptnmetric-sample" ~/out.txt
             then
               exit 0
             fi

--- a/test/integration/expose-keptn-metric/01-install.yaml
+++ b/test/integration/expose-keptn-metric/01-install.yaml
@@ -36,7 +36,7 @@ spec:
           - /bin/sh
           - -ec
           - |
-            curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/api/v1/metrics//keptnmetric-sample > ~/out.txt
+            curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/api/v1/metrics/keptn-lifecycle-toolkit-system/keptnmetric-sample > ~/out.txt
             if grep -Fxq "keptnmetric-sample" ~/out.txt
             then
               exit 0

--- a/test/integration/expose-keptn-metric/01-install.yaml
+++ b/test/integration/expose-keptn-metric/01-install.yaml
@@ -18,16 +18,28 @@ spec:
   template:
     spec:
       containers:
-      - name: test
+      - name: test-prometheus
         image: curlimages/curl:7.72.0
         args:
         - /bin/sh
         - -ec
         - |
-          curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:2222/metrics > ~/out.txt
+          curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/metrics > ~/out.txt
           if grep -Fxq "# HELP keptnmetric_sample keptnmetric-sample" ~/out.txt
           then
             exit 0
           fi
           exit 1
+      - name: test-api-endpoint
+        image: curlimages/curl:7.72.0
+        args:
+          - /bin/sh
+          - -ec
+          - |
+            curl -s metrics-operator-service.keptn-lifecycle-toolkit-system.svc.cluster.local:9999/api/v1/metrics//keptnmetric-sample > ~/out.txt
+            if grep -Fxq "keptnmetric-sample" ~/out.txt
+            then
+              exit 0
+            fi
+            exit 1
       restartPolicy: Never


### PR DESCRIPTION
Follow up to #823 
This PR fixes the setup of the K8s service and deployment to be able to access the metrics API endpoint