### PR TITLE
chore: add Hugo caching

### DIFF
--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -33,5 +33,12 @@ jobs:
             tmp/.htmltest
           key: ${{ runner.os }}-htmltest
 
+      - name: Cache Hugo packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            tmp/.hugo
+          key: ${{ runner.os }}-hugo
+
       - name: Check HTML
         run: make htmltest

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -30,14 +30,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            tmp/.htmltest
+            docs/tmp/.htmltest
           key: ${{ runner.os }}-htmltest
 
       - name: Cache Hugo packages
         uses: actions/cache@v3
         with:
           path: |
-            tmp/.hugo
+            docs/tmp/.hugo
           key: ${{ runner.os }}-hugo
 
       - name: Check HTML

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,20 +4,21 @@ VOLUMES := -v $(ROOT_DIR):/src
 HUGO_VERSION := 0.105.0-ext
 IMAGE := klakegg/hugo:$(HUGO_VERSION)
 PORT := 1314
+DOCKER_CMD := docker run --rm -t -e HUGO_CACHEDIR=/src/tmp/.hugo
 
 .PHONY: build server clean shell htmltest
 
 build:
-	docker run --rm -t $(VOLUMES) $(IMAGE) -D -v
+	$(DOCKER_CMD) $(VOLUMES) $(IMAGE) -D -v
 
 shell:
-	docker run --rm -it $(VOLUMES) $(IMAGE) shell
+	$(DOCKER_CMD) -i $(VOLUMES) $(IMAGE) shell
 
 server:
-	docker run --rm -t $(VOLUMES) -p  $(PORT):$(PORT) $(IMAGE) server -D -p $(PORT)
+	$(DOCKER_CMD) $(VOLUMES) -p  $(PORT):$(PORT) $(IMAGE) server -D -p $(PORT)
 
 clean:
-	docker run --rm -t $(VOLUMES) $(IMAGE) --cleanDestinationDir
+	$(DOCKER_CMD) $(VOLUMES) $(IMAGE) --cleanDestinationDir
 
 htmltest: build
-	docker run --rm -t -v $(ROOT_DIR):/test wjdp/htmltest -c .htmltest.yml public
+	$(DOCKER_CMD) -v $(ROOT_DIR):/test wjdp/htmltest -c .htmltest.yml public


### PR DESCRIPTION
Adding Caching of hugomodules to the makefile and build target.
This way, we don't need to fetch them all the time. This should
speed up the build time, especially on slow internet connections.