### PR TITLE
docs: update README and CONTRIBUTING instructions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,10 +76,9 @@ To set up a local Docsy build:
    * [Install on Linux](https://docs.docker.com/desktop/install/linux-install/)
    * [Install on Windows](https://docs.docker.com/desktop/install/windows-install/)
 
-1. Clone and build the Keptn Docsy repo:
+1. Build the Keptn Docsy repo:
 
    ```console
-   make clone
    make build
    ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,6 @@ from <https://github.com/keptn-sandbox/lifecycle-toolkit-docs> or from <https://
 To verify your changes to the dev documentations you can use the makefile:
 
 ```shell
-cd  lifecycle-toolkit/docs
 make build
 make server
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,6 @@ To verify your changes to the dev documentations you can use the makefile:
 
 ```shell
 cd  lifecycle-toolkit/docs
-make clone
 make build
 make server
 ```


### PR DESCRIPTION
This PR removes the outdated step to run `make clone` 