### PR TITLE
chore: set new documentation approach live

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,8 +43,8 @@ We are using Netlify to publish our pages.
 There are 3 different types of publication:
 
 1. pull request previews
-2. development documentation aka staging (build of `main` branch) - [link](https://main.lifecycle-test.keptn.sh)
-3. official documentation aka production (build of `page` branch) - [link](https://lifecycle-test.keptn.sh)
+2. development documentation aka staging (build of `main` branch) - [link](https://main.lifecycle.keptn.sh)
+3. official documentation aka production (build of `page` branch) - [link](https://lifecycle.keptn.sh)
 
 Within the navigation bar, we do have version links pointing to the different publications - if it makes sense.
 For example, we are not linking from development and production to pull request previews.

--- a/docs/config/_default/params.yaml
+++ b/docs/config/_default/params.yaml
@@ -6,7 +6,7 @@ github_subdir: docs
 versions:
   - url: /docs/
     version: branch-preview
-  - url: https://main.lifecycle-test.keptn.sh/docs
+  - url: https://main.lifecycle.keptn.sh/docs
     version: development
-  - url: https://lifecycle-test.keptn.sh/docs
+  - url: https://lifecycle.keptn.sh/docs
     version: latest

--- a/docs/config/production/params.yaml
+++ b/docs/config/production/params.yaml
@@ -1,4 +1,4 @@
 versions:
-  - url: https://main.lifecycle-test.keptn.sh/docs
+  - url: https://main.lifecycle.keptn.sh/docs
     version: development
 github_branch: pages

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,11 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 HUGO_VERSION = "0.107.0"
 HUGO_ENABLEGITINFO = "true"
 
+# On netlify our branch will always be the one we are currently building for
+# important information regarding naming 
+# https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
+HUGOxPARAMSxGITHUB_BRANCH="$BRANCH"
+
 [context.deploy-preview]
 HUGO_ENV = "development"
 


### PR DESCRIPTION
set the urls properly for the new page.

Update the github_branch to point always to the current branch, which netlify used for a build