### PR TITLE
fix: htmltest error for newly created documents

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@ VOLUMES := -v $(ROOT_DIR):/src
 HUGO_VERSION := 0.107.0
 IMAGE := klakegg/hugo:$(HUGO_VERSION)-ext
 PORT := 1314
-DOCKER_CMD := docker run --rm -t -e HUGO_CACHEDIR=/src/tmp/.hugo
+DOCKER_CMD := docker run --rm -t -e HUGO_CACHEDIR=/src/tmp/.hugo -e HUGOxPARAMSxGITHUB_REPO=""
 
 .PHONY: build server clean shell
 


### PR DESCRIPTION
HTMLTest will complain, when we create new documentation pages, as they are not within the git repository. As we used to display the edit and create issue links pointing to the main branch, our build would fail.

With this change, we will deactivate the rendering of those edit links, when invoked via make target. This means locally and with GitHub Actions, we will not see them. But netlify etc will render them properly.