### PR TITLE
chore: close issues and PRs if they get stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,26 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "pinned"
+  - "security"
+  - "future"
+  - "help wanted"
+  - "integrations"
+  - "known issue"
+  - "known-limitation"
+  - "Epic"
+  - "area:security"
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
### This PR
- adds the stale bot to this repo
- configures stale bot so that issues  with 60 days of inactivity get marked as "stale" with a label
- issues get closed after they have been labeled stale for 7 days and without further activity