### PR TITLE
fix: added metric-operator prefix to related ClusterRole and ClusterRoleBindings

### DIFF
--- a/metrics-operator/config/metrics/role.yaml
+++ b/metrics-operator/config/metrics/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: server-resources
+  name: metrics-operator-server-resources
 rules:
   - apiGroups:
       - custom.metrics.k8s.io

--- a/metrics-operator/config/metrics/role_binding.yaml
+++ b/metrics-operator/config/metrics/role_binding.yaml
@@ -15,11 +15,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hpa-controller-keptn-metrics
+  name: metrics-operator-hpa-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: server-resources
+  name: metrics-operator-server-resources
 subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler


### PR DESCRIPTION
This PR adds the `metrics-operator` prefix to the ClusterRole and ClusterRoleBinding required by the HPA to read KeptnMetrics.  The resulting names are now:

```
server-resources --> metrics-operator-server-resources
hpa-controller-keptn-metrics -> metrics-operator-hpa-controller 
```

The name of the ClusterRoleBinding has been changed to avoid errors when upgrading from the previous version, due to the limitation of not being able to change the roleRef of an existing ClusterRoleBinding