### PR TITLE
chore: change theme repository

### DIFF
--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -5,7 +5,7 @@ module:
   hugoVersion:
     extended: true
   imports:
-  - path: github.com/keptn-sandbox/lifecycle-toolkit-docs
+  - path: github.com/keptn/docs-tooling
     ignoreConfig: false
     mounts:
     - source: static

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,6 +2,7 @@ module github.com/keptn/keptn-lifecycle-toolkit/docs
 
 go 1.19
 
-require github.com/keptn-sandbox/lifecycle-toolkit-docs v0.0.0-20230209144724-01b35a6cfc44 // indirect=
-
-require github.com/google/docsy/dependencies v0.6.0 // indirect
+require (
+	github.com/google/docsy/dependencies v0.6.0 // indirect
+	github.com/keptn/docs-tooling v0.0.1 // indirect
+)

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,6 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
 github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
-github.com/keptn-sandbox/lifecycle-toolkit-docs v0.0.0-20230209144724-01b35a6cfc44 h1:sKOYLKoh17pIouIO3G03C7lBfxSLTSxTfv4d/tWy280=
-github.com/keptn-sandbox/lifecycle-toolkit-docs v0.0.0-20230209144724-01b35a6cfc44/go.mod h1:G40ZMFR7InR/tEEHwZ3yiSafww+CU2jf7xxQ0wQjV1M=
+github.com/keptn/docs-tooling v0.0.1 h1:J9OvIp1Xhkwpp4aiIZ0sKzEeoMY5CsWhfkQv8ruxlwA=
+github.com/keptn/docs-tooling v0.0.1/go.mod h1:6nzm4ykIXyoxsJo3gFsaNWbpycj4pG03lOwE3x927eo=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Our theme has matured and is now part of the keptn organization. The first release v0.0.1 is a simple fork of the keptn-sandbox version.

We will gradually increase our repository and hope to improve it to be generally available for all our tools.