### PR TITLE
fix: adapted patch for mutating webhook to correctly add release namespace to exclusions

### DIFF
--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -27,7 +27,7 @@ annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: "Full Lifecycle"
 
-kubeVersion: ">= 1.24.0"
+kubeVersion: ">= 1.24.0-0"
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/helm/overlay/kustomization.yaml
+++ b/helm/overlay/kustomization.yaml
@@ -23,3 +23,25 @@ patches:
       kind: MutatingWebhookConfiguration
       name: "(lifecycle-mutating-webhook-configuration)"
 
+  - patch: |
+      - op: replace
+        path: '/spec/service/namespace'
+        value: '{{ .Release.Namespace }}'      
+      - op: replace
+        path: '/spec/service/name'
+        value: '{{ include "chart.fullname" . }}-metrics-operator-service'
+    target:
+      kind: APIService
+      name: "(v1beta2.custom.metrics.k8s.io)"
+
+  - patch: |
+      - op: replace
+        path: '/spec/service/namespace'
+        value: '{{ .Release.Namespace }}'
+      - op: replace
+        path: '/spec/service/name'
+        value: '{{ include "chart.fullname" . }}-metrics-operator-service'
+    target:
+      kind: APIService
+      name: "(v1beta1.custom.metrics.k8s.io)"
+

--- a/helm/overlay/kustomization.yaml
+++ b/helm/overlay/kustomization.yaml
@@ -21,5 +21,5 @@ patches:
             - '{{ .Release.Namespace }}'
     target:
       kind: MutatingWebhookConfiguration
-      name: "(mutating-webhook-configuration)"
+      name: "(lifecycle-mutating-webhook-configuration)"
 


### PR DESCRIPTION
Further, this PR modifies the minimum version check for K8s to also allow prerelease versions of K8s, since I ran into an error telling me that the chart can not be installed on `v1.25.6-gke.1000` 