### PR TITLE
ci: add auto labeling for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+documentation:
+  - docs/**/*
+
+operator:
+  - operator/**/*
+
+scheduler:
+  - scheduler/**/*
+
+metrics-operator:
+  - metrics-operator/**/*
+
+cert-manager:
+  - klt-cert-manager/**/*
+
+ops:
+  - .github/**/*
+
+helm:
+  - helm/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,6 @@
 documentation:
   - docs/**/*
+  - "**/*.md"
 
 operator:
   - operator/**/*
@@ -15,6 +16,8 @@ cert-manager:
 
 ops:
   - .github/**/*
+  - netlify.toml
+  - .markdownlint-cli2.yml
 
 helm:
   - helm/**/*

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -1,0 +1,15 @@
+name: Set PR Labels
+
+on:
+  pull_request_target:
+jobs:
+  set-labels:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update Labels
+        uses: actions/labeler@v4
+        with:
+          sync-labels: true


### PR DESCRIPTION
### This PR
- adds the `actions/labeler` to this repo so that PRs get labeled depending on the content that they update

Fixes #927