### PR TITLE
docs: add community files to webpage

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -4,6 +4,7 @@ IgnoreDirectoryMissingTrailingSlash: true
 IgnoreDirs:
   - favicons
   - docs/crd-ref/lifecycle/
+  - community/
 IgnoreURLs:
   - "linkedin.com"
   - "localhost"

--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -24,9 +24,9 @@ module:
         - source: ./
           target: ./content/en/community
           excludeFiles:
-            - "/readme.md"
-          includeFiles:
-            - "*.md"
+            - "mentorship"
+        - source: "README.md"
+          target: "./content/community/_index.md"
   proxy: direct
 languages:
   en:

--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -18,6 +18,15 @@ module:
           target: assets
         - source: archetypes
           target: archetypes
+    - path: github.com/keptn/community
+      ignoreConfig: false
+      mounts:
+        - source: ./
+          target: ./content/en/community
+          excludeFiles:
+            - "/readme.md"
+          includeFiles:
+            - "*.md"
   proxy: direct
 languages:
   en:

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -11,7 +11,7 @@ cascade:
     sitemap:
       priority: 0.1
 
- - _target:
+  - _target:
       path: "/community/**"
     type: docs
   - _target:
@@ -23,6 +23,7 @@ cascade:
     menu:
       main:
         weight: 20
+---
 
 <!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable-next-line MD013 -->
@@ -41,7 +42,7 @@ cascade:
 {{% blocks/lead color="white" %}}
 [![Keptn Lifecycle Toolkit in a Nutshell](https://img.youtube.com/vi/K-cvnZ8EtGc/0.jpg)](https://www.youtube.com/watch?v=K-cvnZ8EtGc)
 {{% /blocks/lead %}}
-
+git add
 {{< blocks/section color="dark" >}}
 {{% blocks/feature icon="fa-lightbulb" title="Keptn Recordings" %}}
 See Keptn [in Action](https://youtube.com/playlist?list=PL6i801Rjt9DbikPPILz38U1TLMrEjppzZ)

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -10,7 +10,19 @@ cascade:
       path: "/docs-*/**"
     sitemap:
       priority: 0.1
----
+
+ - _target:
+      path: "/community/**"
+    type: docs
+  - _target:
+      path: "/community/readme.md"
+    draft: true
+  - _target:
+      path: "/community/_index.md"
+    title: Community
+    menu:
+      main:
+        weight: 20
 
 <!-- markdownlint-disable MD033 -->
 <!-- markdownlint-disable-next-line MD013 -->

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,7 +3,7 @@ module github.com/keptn/keptn-lifecycle-toolkit/docs
 go 1.19
 
 require (
-	github.com/aepfli/community v0.0.0-20230321102249-305cdd09d47a // indirect
 	github.com/google/docsy/dependencies v0.6.0 // indirect
+	github.com/keptn/community v0.0.0-20230412061900-85b0a5576ec5 // indirect
 	github.com/keptn/docs-tooling v0.1.1 // indirect
 )

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,6 +3,7 @@ module github.com/keptn/keptn-lifecycle-toolkit/docs
 go 1.19
 
 require (
+	github.com/aepfli/community v0.0.0-20230321102249-305cdd09d47a // indirect
 	github.com/google/docsy/dependencies v0.6.0 // indirect
 	github.com/keptn/docs-tooling v0.1.1 // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,8 +1,8 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/aepfli/community v0.0.0-20230321102249-305cdd09d47a h1:QmoiIW5GOlzvmOhkXDYfJVusBmxO3xtlGBXVD/99mUs=
-github.com/aepfli/community v0.0.0-20230321102249-305cdd09d47a/go.mod h1:qgGL1QErzayKIteEvv42gFTU8usgyH/N7ZiMKESUgRw=
 github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
 github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/keptn/community v0.0.0-20230412061900-85b0a5576ec5 h1:7B0khjhyk8QlzvxJ82Rg+Alj38ODw3VghjD04sP3jeU=
+github.com/keptn/community v0.0.0-20230412061900-85b0a5576ec5/go.mod h1:0G5nUhSv7ch9BgIFXiY7+U+cV5SbVmneysNGQwQkH8s=
 github.com/keptn/docs-tooling v0.1.1 h1:IuI0Fgs0JrtffLN05iaRZVkRMbPu6h9bxR4C8q1ApGU=
 github.com/keptn/docs-tooling v0.1.1/go.mod h1:x0iT5YsJosz6wzjQke/YaLgiXF6PV+N8QzxSAc2MY/4=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,4 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/aepfli/community v0.0.0-20230321102249-305cdd09d47a h1:QmoiIW5GOlzvmOhkXDYfJVusBmxO3xtlGBXVD/99mUs=
+github.com/aepfli/community v0.0.0-20230321102249-305cdd09d47a/go.mod h1:qgGL1QErzayKIteEvv42gFTU8usgyH/N7ZiMKESUgRw=
 github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
 github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/keptn/docs-tooling v0.1.1 h1:IuI0Fgs0JrtffLN05iaRZVkRMbPu6h9bxR4C8q1ApGU=

--- a/docs/static/google2c8933a0d1bc803c.html
+++ b/docs/static/google2c8933a0d1bc803c.html
@@ -1,0 +1,1 @@
+google-site-verification: google2c8933a0d1bc803c.html

--- a/docs/static/google2c8933a0d1bc803c.html
+++ b/docs/static/google2c8933a0d1bc803c.html
@@ -1,1 +1,0 @@
-google-site-verification: google2c8933a0d1bc803c.html


### PR DESCRIPTION
It is hard to navigate our community files within GitHub. They're not well structured etc. To make this problem more visible, we integrate them into the webpage.

This way, we can easier manage them, fix any content issues and share this for multiple pages.


close: #1009