### PR TITLE
fix(helm-chart): fix missing values in the KLT helm chart

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -320,7 +320,7 @@ jobs:
       run: make helm-package
 
     - name: Copy charts from klt to helm repo
-      run: rsync -av --exclude='charts/*.tgz' ./helm/chart/ ./helm-charts-repository/charts/keptn-lifecycle-toolkit/
+      run: rsync -av --delete --exclude='charts/*.tgz' ./helm/chart/ ./helm-charts-repository/charts/keptn-lifecycle-toolkit/
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -37,12 +37,14 @@ kubeVersion: ">= 1.24.0-0"
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.1
+
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.0" # x-release-please-version
+appVersion: "v0.7.0" # x-release-please-version

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -12,8 +12,8 @@ checks
 | -------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------- |
 | `scheduler.scheduler.containerSecurityContext`                                   | Sets security context                                          |                           |
 | `scheduler.scheduler.env.otelCollectorUrl`                                       | sets url for open telemetry collector                          | `otel-collector:4317`     |
-| `scheduler.scheduler.image.repository`                                           | set image repository for scheduler                             | `ghcr.io/keptn/scheduler` |
-| `scheduler.scheduler.image.tag`                                                  | set image tag for scheduler                                    | `0.6.0`                   |
+| `scheduler.scheduler.image.repository`                                           | set image repository for scheduler                             | `ghcr.keptn.sh/scheduler` |
+| `scheduler.scheduler.image.tag`                                                  | set image tag for scheduler                                    | `v0.7.0`                  |
 | `scheduler.scheduler.imagePullPolicy`                                            | set image pull policy for scheduler                            | `Always`                  |
 | `scheduler.scheduler.livenessProbe`                                              | customizable liveness probe for the scheduler                  |                           |
 | `scheduler.scheduler.readinessProbe`                                             | customizable readiness probe for the scheduler                 |                           |
@@ -45,8 +45,8 @@ checks
 | Name                                                   | Description                                      | Value                                |
 | ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------ |
 | `certificateOperator.manager.containerSecurityContext` | Sets security context for the cert manager       |                                      |
-| `certificateOperator.manager.image.repository`         | specify repo for manager image                   | `ghcr.io/keptn/certificate-operator` |
-| `certificateOperator.manager.image.tag`                | select tag for manager container                 | `0.6.0`                              |
+| `certificateOperator.manager.image.repository`         | specify repo for manager image                   | `ghcr.keptn.sh/certificate-operator` |
+| `certificateOperator.manager.image.tag`                | select tag for manager container                 | `v0.7.0`                             |
 | `certificateOperator.manager.imagePullPolicy`          | select image pull policy for manager container   | `Always`                             |
 | `certificateOperator.manager.livenessProbe`            | custom RBAC proxy liveness probe                 |                                      |
 | `certificateOperator.manager.readinessProbe`           | custom manager readiness probe                   |                                      |
@@ -54,17 +54,18 @@ checks
 
 ### Keptn Lifecycle Operator common
 
-| Name                                          | Description                                               | Value       |
-| --------------------------------------------- | --------------------------------------------------------- | ----------- |
-| `lifecycleOperator.replicas`                  | customize number of installed lifecycle operator replicas | `1`         |
-| `Mutating`                                    | Webhook Configurations for lifecycle Operator             |             |
-| `lifecycleWebhookService.ports[0].port`       |                                                           | `443`       |
-| `lifecycleWebhookService.ports[0].protocol`   |                                                           | `TCP`       |
-| `lifecycleWebhookService.ports[0].targetPort` |                                                           | `9443`      |
-| `lifecycleWebhookService.type`                |                                                           | `ClusterIP` |
-| `lifecycleOperator.nodeSelector`              | add custom nodes selector to lifecycle operator           | `{}`        |
-| `lifecycleOperator.tolerations`               | add custom tolerations to lifecycle operator              | `[]`        |
-| `lifecycleOperator.topologySpreadConstraints` | add custom topology constraints to lifecycle operator     | `[]`        |
+| Name                                          | Description                                                                    | Value       |
+| --------------------------------------------- | ------------------------------------------------------------------------------ | ----------- |
+| `lifecycleOperator.replicas`                  | customize number of installed lifecycle operator replicas                      | `1`         |
+| `lifecycleOperatorMetricsService`             | Adjust settings here to change the k8s service for scraping Prometheus metrics |             |
+| `lifecycleWebhookService`                     | Mutating Webhook Configurations for lifecycle Operator                         |             |
+| `lifecycleWebhookService.ports[0].port`       |                                                                                | `443`       |
+| `lifecycleWebhookService.ports[0].protocol`   |                                                                                | `TCP`       |
+| `lifecycleWebhookService.ports[0].targetPort` |                                                                                | `9443`      |
+| `lifecycleWebhookService.type`                |                                                                                | `ClusterIP` |
+| `lifecycleOperator.nodeSelector`              | add custom nodes selector to lifecycle operator                                | `{}`        |
+| `lifecycleOperator.tolerations`               | add custom tolerations to lifecycle operator                                   | `[]`        |
+| `lifecycleOperator.topologySpreadConstraints` | add custom topology constraints to lifecycle operator                          | `[]`        |
 
 ### Keptn Lifecycle Operator controller
 
@@ -87,9 +88,9 @@ checks
 | `lifecycleOperator.manager.env.keptnWorkloadInstanceControllerLogLevel`       | sets the log level of Keptn WorkloadInstance Controller | `0`                                            |
 | `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller          | `0`                                            |
 | `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector           | `otel-collector:4317`                          |
-| `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for task runtime                          | `ghcr.keptn.sh/keptn/functions-runtime:v0.6.0` |
-| `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                      | `ghcr.io/keptn/lifecycle-operator`             |
-| `lifecycleOperator.manager.image.tag`                                         | select tag for manager image                            | `0.6.0`                                        |
+| `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for task runtime                          | `ghcr.keptn.sh/keptn/functions-runtime:v0.7.0` |
+| `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                      | `ghcr.keptn.sh/lifecycle-operator`             |
+| `lifecycleOperator.manager.image.tag`                                         | select tag for manager image                            | `v0.7.0`                                       |
 | `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                   | `Always`                                       |
 | `lifecycleOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container              |                                                |
 | `lifecycleOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container             |                                                |
@@ -136,8 +137,8 @@ checks
 | `metricsOperator.manager.containerSecurityContext`                          | Sets security context privileges                  |                                  |
 | `metricsOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                          |
 | `metricsOperator.manager.containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                        |
-| `metricsOperator.manager.image.repository`                                  | specify registry for manager image                | `ghcr.io/keptn/metrics-operator` |
-| `metricsOperator.manager.image.tag`                                         | select tag for manager image                      | `0.6.0`                          |
+| `metricsOperator.manager.image.repository`                                  | specify registry for manager image                | `ghcr.keptn.sh/metrics-operator` |
+| `metricsOperator.manager.image.tag`                                         | select tag for manager image                      | `v0.7.0`                         |
 | `metricsOperator.manager.env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                           |
 | `metricsOperator.manager.env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                              |
 | `metricsOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container        |                                  |

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -8,23 +8,23 @@ checks
 
 ### Keptn Scheduler
 
-| Name                                                                             | Description                                                    | Value                     |
-| -------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------- |
-| `scheduler.scheduler.containerSecurityContext`                                   | Sets security context                                          |                           |
-| `scheduler.scheduler.env.otelCollectorUrl`                                       | sets url for open telemetry collector                          | `otel-collector:4317`     |
-| `scheduler.scheduler.image.repository`                                           | set image repository for scheduler                             | `ghcr.keptn.sh/scheduler` |
-| `scheduler.scheduler.image.tag`                                                  | set image tag for scheduler                                    | `v0.7.0`                  |
-| `scheduler.scheduler.imagePullPolicy`                                            | set image pull policy for scheduler                            | `Always`                  |
-| `scheduler.scheduler.livenessProbe`                                              | customizable liveness probe for the scheduler                  |                           |
-| `scheduler.scheduler.readinessProbe`                                             | customizable readiness probe for the scheduler                 |                           |
-| `scheduler.scheduler.resources`                                                  | sets cpu and memory resurces/limits for scheduler              |                           |
-| `schedulerConfig.schedulerConfigYaml.leaderElection.leaderElect`                 | enables leader election for multiple replicas of the scheduler | `false`                   |
-| `schedulerConfig.schedulerConfigYaml.profiles[0].plugins.permit.enabled[0].name` | enables permit plugin                                          | `KLCPermit`               |
-| `schedulerConfig.schedulerConfigYaml.profiles[0].schedulerName`                  | changes scheduler name                                         | `keptn-scheduler`         |
-| `scheduler.nodeSelector`                                                         | adds node selectors for scheduler                              | `{}`                      |
-| `scheduler.replicas`                                                             | modifies replicas                                              | `1`                       |
-| `scheduler.tolerations`                                                          | adds tolerations for scheduler                                 | `[]`                      |
-| `scheduler.topologySpreadConstraints`                                            | add topology constraints for scheduler                         | `[]`                      |
+| Name                                                                             | Description                                                    | Value                           |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------- |
+| `scheduler.scheduler.containerSecurityContext`                                   | Sets security context                                          |                                 |
+| `scheduler.scheduler.env.otelCollectorUrl`                                       | sets url for open telemetry collector                          | `otel-collector:4317`           |
+| `scheduler.scheduler.image.repository`                                           | set image repository for scheduler                             | `ghcr.keptn.sh/keptn/scheduler` |
+| `scheduler.scheduler.image.tag`                                                  | set image tag for scheduler                                    | `v0.7.0`                        |
+| `scheduler.scheduler.imagePullPolicy`                                            | set image pull policy for scheduler                            | `Always`                        |
+| `scheduler.scheduler.livenessProbe`                                              | customizable liveness probe for the scheduler                  |                                 |
+| `scheduler.scheduler.readinessProbe`                                             | customizable readiness probe for the scheduler                 |                                 |
+| `scheduler.scheduler.resources`                                                  | sets cpu and memory resurces/limits for scheduler              |                                 |
+| `schedulerConfig.schedulerConfigYaml.leaderElection.leaderElect`                 | enables leader election for multiple replicas of the scheduler | `false`                         |
+| `schedulerConfig.schedulerConfigYaml.profiles[0].plugins.permit.enabled[0].name` | enables permit plugin                                          | `KLCPermit`                     |
+| `schedulerConfig.schedulerConfigYaml.profiles[0].schedulerName`                  | changes scheduler name                                         | `keptn-scheduler`               |
+| `scheduler.nodeSelector`                                                         | adds node selectors for scheduler                              | `{}`                            |
+| `scheduler.replicas`                                                             | modifies replicas                                              | `1`                             |
+| `scheduler.tolerations`                                                          | adds tolerations for scheduler                                 | `[]`                            |
+| `scheduler.topologySpreadConstraints`                                            | add topology constraints for scheduler                         | `[]`                            |
 
 ### Keptn Certificate Operator common
 
@@ -42,15 +42,15 @@ checks
 
 ### Keptn Certificate Operator controller
 
-| Name                                                   | Description                                      | Value                                |
-| ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------ |
-| `certificateOperator.manager.containerSecurityContext` | Sets security context for the cert manager       |                                      |
-| `certificateOperator.manager.image.repository`         | specify repo for manager image                   | `ghcr.keptn.sh/certificate-operator` |
-| `certificateOperator.manager.image.tag`                | select tag for manager container                 | `v0.7.0`                             |
-| `certificateOperator.manager.imagePullPolicy`          | select image pull policy for manager container   | `Always`                             |
-| `certificateOperator.manager.livenessProbe`            | custom RBAC proxy liveness probe                 |                                      |
-| `certificateOperator.manager.readinessProbe`           | custom manager readiness probe                   |                                      |
-| `certificateOperator.manager.resources`                | custom limits and requests for manager container |                                      |
+| Name                                                   | Description                                      | Value                                      |
+| ------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------ |
+| `certificateOperator.manager.containerSecurityContext` | Sets security context for the cert manager       |                                            |
+| `certificateOperator.manager.image.repository`         | specify repo for manager image                   | `ghcr.keptn.sh/keptn/certificate-operator` |
+| `certificateOperator.manager.image.tag`                | select tag for manager container                 | `v0.7.0`                                   |
+| `certificateOperator.manager.imagePullPolicy`          | select image pull policy for manager container   | `Always`                                   |
+| `certificateOperator.manager.livenessProbe`            | custom RBAC proxy liveness probe                 |                                            |
+| `certificateOperator.manager.readinessProbe`           | custom manager readiness probe                   |                                            |
+| `certificateOperator.manager.resources`                | custom limits and requests for manager container |                                            |
 
 ### Keptn Lifecycle Operator common
 
@@ -89,7 +89,7 @@ checks
 | `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller          | `0`                                            |
 | `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector           | `otel-collector:4317`                          |
 | `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for task runtime                          | `ghcr.keptn.sh/keptn/functions-runtime:v0.7.0` |
-| `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                      | `ghcr.keptn.sh/lifecycle-operator`             |
+| `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                      | `ghcr.keptn.sh/keptn/lifecycle-operator`       |
 | `lifecycleOperator.manager.image.tag`                                         | select tag for manager image                            | `v0.7.0`                                       |
 | `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                   | `Always`                                       |
 | `lifecycleOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container              |                                                |
@@ -132,18 +132,18 @@ checks
 
 ### Keptn Metrics Operator controller
 
-| Name                                                                        | Description                                       | Value                            |
-| --------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------- |
-| `metricsOperator.manager.containerSecurityContext`                          | Sets security context privileges                  |                                  |
-| `metricsOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                          |
-| `metricsOperator.manager.containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                        |
-| `metricsOperator.manager.image.repository`                                  | specify registry for manager image                | `ghcr.keptn.sh/metrics-operator` |
-| `metricsOperator.manager.image.tag`                                         | select tag for manager image                      | `v0.7.0`                         |
-| `metricsOperator.manager.env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                           |
-| `metricsOperator.manager.env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                              |
-| `metricsOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container        |                                  |
-| `metricsOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container       |                                  |
-| `metricsOperator.manager.resources`                                         | specify limits and requests for manager container |                                  |
+| Name                                                                        | Description                                       | Value                                  |
+| --------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------- |
+| `metricsOperator.manager.containerSecurityContext`                          | Sets security context privileges                  |                                        |
+| `metricsOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                                |
+| `metricsOperator.manager.containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                              |
+| `metricsOperator.manager.image.repository`                                  | specify registry for manager image                | `ghcr.keptn.sh/keptn/metrics-operator` |
+| `metricsOperator.manager.image.tag`                                         | select tag for manager image                      | `v0.7.0`                               |
+| `metricsOperator.manager.env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                                 |
+| `metricsOperator.manager.env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                                    |
+| `metricsOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container        |                                        |
+| `metricsOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container       |                                        |
+| `metricsOperator.manager.resources`                                         | specify limits and requests for manager container |                                        |
 
 ### Global
 

--- a/helm/chart/doc.yaml
+++ b/helm/chart/doc.yaml
@@ -90,7 +90,14 @@
 
 ## @param   lifecycleOperator.replicas customize number of installed lifecycle operator replicas
 
-## @extra Mutating Webhook Configurations for lifecycle Operator
+## @extra   lifecycleOperatorMetricsService Adjust settings here to change the k8s service for scraping Prometheus metrics
+## @skip    lifecycleOperatorMetricsService.ports[0].name
+## @skip    lifecycleOperatorMetricsService.ports[0].port
+## @skip    lifecycleOperatorMetricsService.ports[0].protocol
+## @skip    lifecycleOperatorMetricsService.ports[0].targetPort
+## @skip    lifecycleOperatorMetricsService.type
+
+## @extra    lifecycleWebhookService Mutating Webhook Configurations for lifecycle Operator
 ## @param    lifecycleWebhookService.ports[0].port
 ## @param    lifecycleWebhookService.ports[0].protocol
 ## @param    lifecycleWebhookService.ports[0].targetPort

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -11,8 +11,8 @@ certificateOperator:
       seccompProfile:
         type: RuntimeDefault
     image:
-      repository: ghcr.io/keptn/certificate-operator
-      tag: 0.6.0
+      repository: ghcr.keptn.sh/keptn/certificate-operator
+      tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
       httpGet:
@@ -64,7 +64,7 @@ lifecycleOperator:
       seccompProfile:
         type: RuntimeDefault
     env:
-      functionRunnerImage: ghcr.keptn.sh/keptn/functions-runtime:v0.6.0
+      functionRunnerImage: ghcr.keptn.sh/keptn/functions-runtime:v0.7.0
       keptnAppControllerLogLevel: "0"
       keptnAppVersionControllerLogLevel: "0"
       keptnEvaluationControllerLogLevel: "0"
@@ -75,8 +75,8 @@ lifecycleOperator:
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
     image:
-      repository: ghcr.io/keptn/lifecycle-operator
-      tag: 0.6.0
+      repository: ghcr.keptn.sh/keptn/lifecycle-operator
+      tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
       httpGet:
@@ -101,6 +101,13 @@ lifecycleOperator:
   replicas: 1
   tolerations: []
   topologySpreadConstraints: []
+lifecycleOperatorMetricsService:
+  ports:
+  - name: metrics
+    port: 2222
+    protocol: TCP
+    targetPort: metrics
+  type: ClusterIP
 lifecycleWebhookService:
   ports:
   - port: 443
@@ -129,8 +136,8 @@ metricsOperator:
       exposeKeptnMetrics: "true"
       metricsControllerLogLevel: "0"
     image:
-      repository: ghcr.io/keptn/metrics-operator
-      tag: 0.6.0
+      repository: ghcr.keptn.sh/keptn/metrics-operator
+      tag: v0.7.0
     livenessProbe:
       httpGet:
         path: /healthz
@@ -192,8 +199,8 @@ scheduler:
     env:
       otelCollectorUrl: otel-collector:4317
     image:
-      repository: ghcr.io/keptn/scheduler
-      tag: 0.6.0
+      repository: ghcr.keptn.sh/keptn/scheduler
+      tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
       httpGet:

--- a/klt-cert-manager/config/manager/kustomization.yaml
+++ b/klt-cert-manager/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/keptn/certificate-operator
-  newTag: 0.6.0
+  newName: ghcr.keptn.sh/keptn/certificate-operator
+  newTag: v0.7.0

--- a/metrics-operator/config/manager/kustomization.yaml
+++ b/metrics-operator/config/manager/kustomization.yaml
@@ -11,5 +11,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/keptn/metrics-operator
-  newTag: 0.6.0
+  newName: ghcr.keptn.sh/keptn/metrics-operator
+  newTag: v0.7.0

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -11,5 +11,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/keptn/lifecycle-operator
-  newTag: 0.6.0
+  newName: ghcr.keptn.sh/keptn/lifecycle-operator
+  newTag: v0.7.0

--- a/scheduler/manifests/install/kustomization.yaml
+++ b/scheduler/manifests/install/kustomization.yaml
@@ -13,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: scheduler
-  newName: ghcr.io/keptn/scheduler
-  newTag: 0.6.0
+  newName: ghcr.keptn.sh/keptn/scheduler
+  newTag: v0.7.0


### PR DESCRIPTION
### This PR
- adds some missing values that were not re-auto-generated before the v0.7.0 release
- adds docs for the missing values
- updates changes from released chart version 0.2.1
- fixes a pipeline issue that prevented renamed files to be deleted during `rsync`