### PR TITLE
fix: move prometheus install into make file

### DIFF
--- a/.github/actions/deploy-prometheus-on-cluster/action.yml
+++ b/.github/actions/deploy-prometheus-on-cluster/action.yml
@@ -4,28 +4,17 @@ runs:
   using: "composite"
   steps:
     - name: Install and expose Prometheus
-      working-directory: ./test
       shell: bash
       run: |
-        kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-        kubectl apply --server-side -f ./prometheus/setup
-        kubectl wait --for=condition=Established --all CustomResourceDefinition --namespace=monitoring
-        kubectl apply -f ./prometheus/
-        kubectl wait --for=condition=available deployment/prometheus-operator -n monitoring --timeout=120s
-        kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
-        kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
-        kubectl wait pod/prometheus-k8s-0 --for=condition=ready --timeout=120s -n monitoring
-        kubectl -n monitoring port-forward svc/prometheus-k8s 9090 &
-        kubectl -n monitoring port-forward svc/node-exporter 9100 &
-
+        make install-prometheus
         # wait for port 9090 to become available
         while ! nc -vz localhost 9090 > /dev/null 2>&1 ; do
-          echo "Sleeping until port-forward for Prometheus at port 9090 is ready..."
-          sleep 5
+        echo "Sleeping until port-forward for Prometheus at port 9090 is ready..."
+        sleep 5
         done
-
+        
         # wait until node exporter is available
         while ! nc -vz localhost 9100 > /dev/null 2>&1 ; do
-          echo "Sleeping until port-forward for node exporter at port 9100 is ready..."
-          sleep 5
+        echo "Sleeping until port-forward for node exporter at port 9100 is ready..."
+        sleep 5
         done

--- a/.github/actions/deploy-prometheus-on-cluster/action.yml
+++ b/.github/actions/deploy-prometheus-on-cluster/action.yml
@@ -7,6 +7,10 @@ runs:
       shell: bash
       run: |
         make install-prometheus
+        
+        kubectl -n monitoring port-forward svc/prometheus-k8s 9090 &
+        kubectl -n monitoring port-forward svc/node-exporter 9100 &
+        
         # wait for port 9090 to become available
         while ! nc -vz localhost 9090 > /dev/null 2>&1 ; do
         echo "Sleeping until port-forward for Prometheus at port 9090 is ready..."

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ integration-test:
 	kubectl kuttl test --start-kind=false ./test/integration/ --config=kuttl-test.yaml
 
 .PHONY: integration-test-local #these tests should run on a real cluster!
-integration-test-local:
+integration-test-local: install-prometheus
 	kubectl kuttl test --start-kind=false ./test/integration/ --config=kuttl-test-local.yaml
 
 .PHONY: load-test
@@ -45,6 +45,20 @@ load-test:
 	kubectl apply -f ./test/load/assets/templates/namespace.yaml
 	kubectl apply -f ./test/load/assets/templates/provider.yaml
 	kube-burner init -c ./test/load/cfg.yml --metrics-profile ./test/load/metrics.yml
+
+.PHONY: install-prometheus
+install-prometheus:
+	kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+	kubectl apply --server-side -f test/prometheus/setup
+	kubectl wait --for=condition=Established --all CustomResourceDefinition --namespace=monitoring
+	kubectl apply -f test/prometheus/
+	kubectl wait --for=condition=available deployment/prometheus-operator -n monitoring --timeout=120s
+	kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
+	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
+	kubectl wait pod/prometheus-k8s-0 --for=condition=ready --timeout=120s -n monitoring
+	kubectl -n monitoring port-forward svc/prometheus-k8s 9090 &
+	kubectl -n monitoring port-forward svc/node-exporter 9100 &
+
 
 .PHONY: cleanup-manifests
 cleanup-manifests:
@@ -67,7 +81,6 @@ release-helm-manifests: helmify
 helm-package:
 	$(MAKE) build-release-manifests CHART_APPVERSION=$(CHART_APPVERSION) RELEASE_REGISTRY=$(RELEASE_REGISTRY)
 	$(MAKE) release-helm-manifests CHART_APPVERSION=$(CHART_APPVERSION) RELEASE_REGISTRY=$(RELEASE_REGISTRY)
-
 
 .PHONY: build-release-manifests
 build-release-manifests:

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ install-prometheus:
 	kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
 	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
 	kubectl wait pod/prometheus-k8s-0 --for=condition=ready --timeout=120s -n monitoring
-	kubectl -n monitoring port-forward svc/prometheus-k8s 9090 &
-	kubectl -n monitoring port-forward svc/node-exporter 9100 &
+
 
 
 .PHONY: cleanup-manifests


### PR DESCRIPTION
closes #1085

1. `kind create cluster`
2. `helm upgrade --install klt klt/klt  -n keptn-lifecycle-toolkit-system   --create-namespace`
3. than run `make integration-test-local ` now Prometheus is installed before running so all tests pass locally