### PR TITLE
docs: modify footer

### DIFF
--- a/docs/assets/scss/_variables_project.scss
+++ b/docs/assets/scss/_variables_project.scss
@@ -1,0 +1,1 @@
+$light: #fff;

--- a/docs/assets/scss/_variables_project.scss
+++ b/docs/assets/scss/_variables_project.scss
@@ -1,1 +1,0 @@
-$light: #fff;

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -46,6 +46,7 @@ cascade:
 {{% blocks/feature icon="fa-lightbulb" title="Keptn Recordings" %}}
 See Keptn in Action
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 <a class="btn -bg-white rounded-lg" href="https://youtube.com/playlist?list=PL6i801Rjt9DbikPPILz38U1TLMrEjppzZ">
   Watch now!
  </a>
@@ -55,6 +56,7 @@ See Keptn in Action
 We do a [Pull Request](https://github.com/keptn/lifecycle-toolkit/pulls) contributions workflow on **GitHub**.
 New users are always welcome!
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 <a class="btn -bg-white rounded-lg" href="https://github.com/keptn/lifecycle-toolkit">
   Contribute on GitHub
  </a>
@@ -63,6 +65,7 @@ New users are always welcome!
 {{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!" %}}
 For announcement of latest features etc.
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 <a class="btn -bg-white rounded-lg" href="https://twitter.com/keptnProject">
   Follow us!
  </a>

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -34,7 +34,7 @@ cascade:
  </a>
     <a class="btn btn-lg btn-primary mr-3 mb-4" href="https://github.com/keptn/lifecycle-toolkit/releases">
   Releases <i class="fab fa-github ml-2 "></i>
- </a>
+ </a>   
 </div>
 {{< /blocks/cover >}}
 <!-- markdownlint-enable MD033 -->
@@ -44,18 +44,28 @@ cascade:
 {{% /blocks/lead %}}
 {{< blocks/section color="dark" >}}
 {{% blocks/feature icon="fa-lightbulb" title="Keptn Recordings" %}}
-See Keptn [in Action](https://youtube.com/playlist?list=PL6i801Rjt9DbikPPILz38U1TLMrEjppzZ)
+See Keptn in Action
+
+<a class="btn btn-light rounded-lg" href="https://youtube.com/playlist?list=PL6i801Rjt9DbikPPILz38U1TLMrEjppzZ">
+  Youtube
+ </a>
 {{% /blocks/feature %}}
 
-<!-- markdownlint-disable-next-line line-length no-bare-urls -->
-{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/keptn/lifecycle-toolkit" %}}
+{{% blocks/feature icon="fab fa-github" title="Contributions welcome!" %}}
 We do a [Pull Request](https://github.com/keptn/lifecycle-toolkit/pulls) contributions workflow on **GitHub**.
 New users are always welcome!
+
+<a class="btn btn-light rounded-lg" href="https://github.com/keptn/lifecycle-toolkit">
+  GitHub
+ </a>
 {{% /blocks/feature %}}
 
-<!-- markdownlint-disable-next-line line-length no-bare-urls -->
-{{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!" url="https://twitter.com/keptnProject" %}}
+{{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!" %}}
 For announcement of latest features etc.
+
+<a class="btn btn-light rounded-lg" href="https://twitter.com/keptnProject">
+  Twitter
+ </a>
 {{% /blocks/feature %}}
 
 {{< /blocks/section >}}

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -34,7 +34,7 @@ cascade:
  </a>
     <a class="btn btn-lg btn-primary mr-3 mb-4" href="https://github.com/keptn/lifecycle-toolkit/releases">
   Releases <i class="fab fa-github ml-2 "></i>
- </a>   
+ </a>
 </div>
 {{< /blocks/cover >}}
 <!-- markdownlint-enable MD033 -->

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -46,8 +46,8 @@ cascade:
 {{% blocks/feature icon="fa-lightbulb" title="Keptn Recordings" %}}
 See Keptn in Action
 
-<a class="btn btn-light rounded-lg" href="https://youtube.com/playlist?list=PL6i801Rjt9DbikPPILz38U1TLMrEjppzZ">
-  Youtube
+<a class="btn -bg-white rounded-lg" href="https://youtube.com/playlist?list=PL6i801Rjt9DbikPPILz38U1TLMrEjppzZ">
+  Watch now!
  </a>
 {{% /blocks/feature %}}
 
@@ -55,16 +55,16 @@ See Keptn in Action
 We do a [Pull Request](https://github.com/keptn/lifecycle-toolkit/pulls) contributions workflow on **GitHub**.
 New users are always welcome!
 
-<a class="btn btn-light rounded-lg" href="https://github.com/keptn/lifecycle-toolkit">
-  GitHub
+<a class="btn -bg-white rounded-lg" href="https://github.com/keptn/lifecycle-toolkit">
+  Contribute on GitHub
  </a>
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!" %}}
 For announcement of latest features etc.
 
-<a class="btn btn-light rounded-lg" href="https://twitter.com/keptnProject">
-  Twitter
+<a class="btn -bg-white rounded-lg" href="https://twitter.com/keptnProject">
+  Follow us!
  </a>
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
Fixes #1136 

Modified the footer of the website with the following changes:
- In the Keptn Recordings part, added a new button that redirects to Youtube.
- Renamed the `Read more....` to `Github` in the contributions welcome part.
- Renaming the `Read more...` to `Twitter` in the Follow us on Twitter part.
- Added a new `assets/scss/_variable_project.scss` file for the custom modification of the styles.

### Screenshots

#### New
![Screenshot from 2023-03-31 15-14-05](https://user-images.githubusercontent.com/98955085/229092727-d0722b9b-7a6e-48be-9100-bb9d22494989.png)

#### Old
![Screenshot from 2023-03-31 15-14-10](https://user-images.githubusercontent.com/98955085/229092776-dba88923-ecca-4e85-96f5-1da77f349980.png)
