### PR TITLE
feat: make examples resource footprint smaller, fix bugs

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -40,6 +40,7 @@ jobs:
             metrics-operator
             functions-runtime
             dashboards
+            examples
           # Configure that a scope must always be provided.
           requireScope: false
           # When using "Squash and merge" on a PR with only one commit, GitHub

--- a/examples/sample-app/base/app.yaml
+++ b/examples/sample-app/base/app.yaml
@@ -8,15 +8,9 @@ spec:
   workloads:
     - name: podtato-head-left-arm
       version: 0.1.0
-    - name: podtato-head-left-leg
-      version: 0.1.0
     - name: podtato-head-frontend
       version: 0.1.0
     - name: podtato-head-right-arm
       version: 0.1.0
-    - name: podtato-head-right-leg
-      version: 0.1.0
     - name: podtato-head-hat
       version: 0.1.0
-
-

--- a/examples/sample-app/base/manifest.yaml
+++ b/examples/sample-app/base/manifest.yaml
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: podtato-head-frontend
           env:
+            - name: PODTATO_COMPONENT
+              value: "frontend"
             - name: PODTATO_STARTUP_DELAY
               value: "20s"
             - name: PODTATO_VERSION
@@ -36,6 +38,7 @@ metadata:
   name: podtato-head-hat
   namespace: podtato-kubectl
 spec:
+  replicas: 1
   template:
     metadata:
       labels:
@@ -58,6 +61,7 @@ metadata:
   name: podtato-head-left-leg
   namespace: podtato-kubectl
 spec:
+  replicas: 0
   template:
     metadata:
       labels:
@@ -80,6 +84,7 @@ metadata:
   name: podtato-head-right-leg
   namespace: podtato-kubectl
 spec:
+  replicas: 0
   template:
     metadata:
       labels:
@@ -102,6 +107,7 @@ metadata:
   name: podtato-head-left-arm
   namespace: podtato-kubectl
 spec:
+  replicas: 1
   template:
     metadata:
       labels:
@@ -124,6 +130,7 @@ metadata:
   name: podtato-head-right-arm
   namespace: podtato-kubectl
 spec:
+  replicas: 1
   template:
     metadata:
       labels:

--- a/examples/sample-app/base/provider.yaml
+++ b/examples/sample-app/base/provider.yaml
@@ -4,4 +4,4 @@ metadata:
   name: prometheus
   namespace: podtato-kubectl
 spec:
-  targetServer: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
+  targetServer: "http://mockserver.keptn-lifecycle-toolkit-system.svc.cluster.local:1080"

--- a/examples/sample-app/version-1/app.yaml
+++ b/examples/sample-app/version-1/app.yaml
@@ -8,13 +8,9 @@ spec:
   workloads:
     - name: podtato-head-left-arm
       version: 0.1.1
-    - name: podtato-head-left-leg
-      version: 0.1.1
     - name: podtato-head-frontend
       version: 0.1.0
     - name: podtato-head-right-arm
-      version: 0.1.1
-    - name: podtato-head-right-leg
       version: 0.1.1
     - name: podtato-head-hat
       version: 0.1.1

--- a/examples/sample-app/version-2/app.yaml
+++ b/examples/sample-app/version-2/app.yaml
@@ -8,13 +8,9 @@ spec:
   workloads:
     - name: podtato-head-left-arm
       version: 0.1.1
-    - name: podtato-head-left-leg
-      version: 0.1.1
     - name: podtato-head-frontend
       version: 0.1.0
     - name: podtato-head-right-arm
-      version: 0.1.1
-    - name: podtato-head-right-leg
       version: 0.1.1
     - name: podtato-head-hat
       version: 0.1.1

--- a/examples/sample-app/version-3/app.yaml
+++ b/examples/sample-app/version-3/app.yaml
@@ -8,13 +8,9 @@ spec:
   workloads:
     - name: podtato-head-left-arm
       version: 0.1.1
-    - name: podtato-head-left-leg
-      version: 0.1.1
     - name: podtato-head-frontend
       version: 0.1.0
     - name: podtato-head-right-arm
-      version: 0.1.1
-    - name: podtato-head-right-leg
       version: 0.1.1
     - name: podtato-head-hat
       version: 0.1.2

--- a/examples/support/observability/Makefile
+++ b/examples/support/observability/Makefile
@@ -1,5 +1,5 @@
 # renovate: datasource=github-tags depName=jaegertracing/jaeger-operator
-JAEGER_VERSION ?= v1.43.0
+JAEGER_VERSION ?= v1.42.0
 TOOLKIT_NAMESPACE ?= keptn-lifecycle-toolkit-system
 PODTATO_NAMESPACE ?= podtato-kubectl
 GRAFANA_PORT_FORWARD ?= 3000
@@ -19,8 +19,8 @@ install: install-cert-manager
 	@echo "Configure Prometheus"
 	@echo "------------------"
 	kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-	kubectl apply --server-side -f config/prometheus/setup
-	kubectl wait --for=condition=Established --all CustomResourceDefinition --namespace=monitoring
+#	kubectl apply --server-side -f config/prometheus/setup
+#	kubectl wait --for=condition=Established --all CustomResourceDefinition --namespace=monitoring
 
 	@echo ""
 	@echo "-------------------------------"
@@ -35,15 +35,24 @@ install: install-cert-manager
 	kubectl wait --for=condition=available deployment/jaeger -n "$(TOOLKIT_NAMESPACE)" --timeout=120s
 	kubectl wait --for=condition=available deployment/otel-collector -n "$(TOOLKIT_NAMESPACE)" --timeout=120s
 
+#	@echo ""
+#	@echo "------------------"
+#	@echo "Install Prometheus"
+#	@echo "------------------"
+#	kubectl apply -f config/prometheus/
+#	kubectl wait --for=condition=available deployment/prometheus-operator -n monitoring --timeout=120s
+#	kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
+#	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
+#	kubectl wait --for=condition=available deployment/grafana -n monitoring --timeout=120s
+
 	@echo ""
 	@echo "------------------"
-	@echo "Install Prometheus"
+	@echo "Install Prometheus Mockserver"
 	@echo "------------------"
-	kubectl apply -f config/prometheus/
-	kubectl wait --for=condition=available deployment/prometheus-operator -n monitoring --timeout=120s
-	kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
-	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
-	kubectl wait --for=condition=available deployment/grafana -n monitoring --timeout=120s
+	kubectl apply -n "$(TOOLKIT_NAMESPACE)" -f config/prometheus-mock/mockserver-config.yaml
+	helm repo add mockserver "https://www.mock-server.com"
+	helm upgrade --install -n "$(TOOLKIT_NAMESPACE)" --version 5.13.0 mockserver mockserver/mockserver --set service.type=ClusterIP --wait
+
 
 	@echo ""
 	@echo "#######################################################"
@@ -99,8 +108,8 @@ import-grafana-dashboard:
 uninstall:
 	kubectl delete -f config/jaeger.yaml -n "$(TOOLKIT_NAMESPACE)" --ignore-not-found=true
 	kubectl delete -f https://github.com/jaegertracing/jaeger-operator/releases/download/$(JAEGER_VERSION)/jaeger-operator.yaml -n observability --ignore-not-found=true
-	kubectl delete -f config/prometheus/ --ignore-not-found=true
-	kubectl delete -f config/prometheus/setup --ignore-not-found=true
+	#kubectl delete -f config/prometheus/ --ignore-not-found=true
+	#kubectl delete -f config/prometheus/setup --ignore-not-found=true
 	kubectl delete ns observability --ignore-not-found=true
 	kubectl delete ns monitoring --ignore-not-found=true
 	@echo ""

--- a/examples/support/observability/config/otel-collector.yaml
+++ b/examples/support/observability/config/otel-collector.yaml
@@ -107,11 +107,11 @@ spec:
           name: otel-collector
           resources:
             limits:
-              cpu: 1
-              memory: 2Gi
+              cpu: 400m
+              memory: 1Gi
             requests:
-              cpu: 200m
-              memory: 400Mi
+              cpu: 75m
+              memory: 200Mi
           ports:
             - containerPort: 4317 # Default endpoint for otlp receiver.
             - containerPort: 8889 # Default endpoint for querying metrics.
@@ -134,22 +134,22 @@ spec:
                 path: otel-collector-config.yaml
           name: otel-collector-config-vol
 ---
-
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    serviceapp: otel-collector
-  name: otel-collector
-  namespace: keptn-lifecycle-toolkit-system
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 30s
-      port: metrics
-  namespaceSelector:
-    matchNames:
-      - keptn-lifecycle-toolkit-system
-  selector:
-    matchLabels:
-      app: opentelemetry
+#
+#apiVersion: monitoring.coreos.com/v1
+#kind: ServiceMonitor
+#metadata:
+#  labels:
+#    serviceapp: otel-collector
+#  name: otel-collector
+#  namespace: keptn-lifecycle-toolkit-system
+#spec:
+#  endpoints:
+#    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+#      interval: 30s
+#      port: metrics
+#  namespaceSelector:
+#    matchNames:
+#      - keptn-lifecycle-toolkit-system
+#  selector:
+#    matchLabels:
+#      app: opentelemetry

--- a/examples/support/observability/config/prometheus-mock/mockserver-config.yaml
+++ b/examples/support/observability/config/prometheus-mock/mockserver-config.yaml
@@ -1,0 +1,61 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: mockserver-config
+data:
+  initializerJson.json: |-
+    [
+      {
+        "httpRequest": {
+          "path": "/api/v1/query",
+          "method": "POST"
+        },
+        "httpResponse": {
+          "body": {
+            "status": "success",
+            "data": {
+              "resultType": "vector",
+              "result": [
+                {
+                  "metric": {
+                    "__name__": "metric-name",
+                    "job": "",
+                    "instance": ""
+                  },
+                  "value": [1669714193.275, "4"]
+                }
+              ]
+            }
+          },
+          "statusCode": 200
+        }
+      }
+    ]
+  mockserver.properties: |-
+    ###############################
+    # MockServer & Proxy Settings #
+    ###############################
+    # Socket & Port Settings
+    # socket timeout in milliseconds (default 120000)
+    mockserver.maxSocketTimeout=120000
+    # Certificate Generation
+    # dynamically generated CA key pair (if they don't already exist in
+    specified directory)
+    mockserver.dynamicallyCreateCertificateAuthorityCertificate=true
+    # save dynamically generated CA key pair in working directory
+    mockserver.directoryToSaveDynamicSSLCertificate=.
+    # certificate domain name (default "localhost")
+    mockserver.sslCertificateDomainName=localhost
+    # comma separated list of ip addresses for Subject Alternative Name domain
+    names (default empty list)
+    mockserver.sslSubjectAlternativeNameDomains=www.example.com,www.another.com
+    # comma separated list of ip addresses for Subject Alternative Name ips
+    (default empty list)
+    mockserver.sslSubjectAlternativeNameIps=127.0.0.1
+    # CORS
+    # enable CORS for MockServer REST API
+    mockserver.enableCORSForAPI=true
+    # enable CORS for all responses
+    mockserver.enableCORSForAllResponses=true
+    # Json Initialization
+    mockserver.initializationJsonPath=/config/initializerJson.json

--- a/examples/support/observability/config/prometheus/grafana-deployment.yaml
+++ b/examples/support/observability/config/prometheus/grafana-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             cpu: 200m
             memory: 200Mi
           requests:
-            cpu: 100m
+            cpu: 75m
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/support/observability/config/prometheus/kube-state-metrics-deployment.yaml
+++ b/examples/support/observability/config/prometheus/kube-state-metrics-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         name: kube-state-metrics
         resources:
           limits:
-            cpu: 100m
+            cpu: 20m
             memory: 250Mi
           requests:
             cpu: 10m
@@ -60,10 +60,10 @@ spec:
           name: https-main
         resources:
           limits:
-            cpu: 40m
+            cpu: 20m
             memory: 40Mi
           requests:
-            cpu: 20m
+            cpu: 10m
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/support/observability/config/prometheus/node-exporter-daemonset.yaml
+++ b/examples/support/observability/config/prometheus/node-exporter-daemonset.yaml
@@ -42,7 +42,7 @@ spec:
             cpu: 250m
             memory: 180Mi
           requests:
-            cpu: 102m
+            cpu: 75m
             memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/support/observability/config/prometheus/prometheus-adapter-deployment.yaml
+++ b/examples/support/observability/config/prometheus/prometheus-adapter-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             cpu: 250m
             memory: 180Mi
           requests:
-            cpu: 102m
+            cpu: 75m
             memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/examples/support/observability/config/prometheus/prometheus-prometheus.yaml
+++ b/examples/support/observability/config/prometheus/prometheus-prometheus.yaml
@@ -34,7 +34,10 @@ spec:
   probeSelector: {}
   replicas: 1
   resources:
+    limits:
+      cpu: 250m
     requests:
+      cpu: 75m
       memory: 400Mi
   ruleNamespaceSelector: {}
   ruleSelector: {}

--- a/examples/support/observability/config/prometheus/setup/prometheus-operator-deployment.yaml
+++ b/examples/support/observability/config/prometheus/setup/prometheus-operator-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             cpu: 200m
             memory: 200Mi
           requests:
-            cpu: 100m
+            cpu: 75m
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -63,7 +63,7 @@ spec:
             cpu: 20m
             memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 5m
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
### This PR
- fixes a bug in the examples makefile where a missing namespace broke the setup
- reduces the resource footprint for o11y support software
- reduces the resource footprint of the podtato-head example app by removing the legs
- makes use of https://github.com/mock-server/mockserver instead of prometheus to mock metrics