### PR TITLE
ci: allow trailing slashes in links

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -1,5 +1,6 @@
 ---
 CheckDoctype: false
+IgnoreDirectoryMissingTrailingSlash: true
 IgnoreDirs:
   - favicons
   - docs/crd-ref/lifecycle/


### PR DESCRIPTION
As explained in #1170, we do have issues with creating documentations without a separate folder and linking to them. To ease developer experience we remove this check. Although we might encounter redirects within the documentation.

closes: #1170