### PR TITLE
ci: fix set-date pipeline bug

### DIFF
--- a/.github/workflows/set-date.yml
+++ b/.github/workflows/set-date.yml
@@ -38,10 +38,10 @@ jobs:
               }
             }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
           echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
-          echo 'START_DATE_FIELD_ID='\
-            $(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Start Date") | .id' project_data.json) >> $GITHUB_ENV
-          echo 'END_DATE_FIELD_ID='\
-            $(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "End Date") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'START_DATE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Start Date") | .id' project_data.json) \
+            >> $GITHUB_ENV
+          echo 'END_DATE_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "End Date") | .id' project_data.json) \
+            >> $GITHUB_ENV
 
       - name: Get date
         run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV


### PR DESCRIPTION
Modified the `set-date.yml` file to fix the [issue](https://github.com/keptn/lifecycle-toolkit/actions/runs/4667145006/jobs/8262562937) with the set-date pipeline.

After the modification of YAML files (due to the addition of YAMLLinter), there was an extra space added in the `Get project data` step. I have modified the step and it should work properly now.