### PR TITLE
fix: helm generation checker pipeline

### DIFF
--- a/.github/workflows/validate-helm-chart.yml
+++ b/.github/workflows/validate-helm-chart.yml
@@ -69,7 +69,9 @@ jobs:
           path: ./bin
           key: build-tools-${{ github.ref_name }}
 
-      - name: Generate new Helm Chart
+      - name: Generate helm charts
+        env:
+          RELEASE_REGISTRY: ghcr.keptn.sh/keptn
         run: make helm-package
 
       - name: Compare YAML file changes
@@ -79,6 +81,6 @@ jobs:
             echo "There are no changes in the manifests"
           else
             echo ""
-            echo "Helm charts were not re-generated. Please regenerate them using make helm-package"
+            echo "Helm charts were not re-generated. Please regenerate them using make helm-package RELEASE_REGISTRY=ghcr.keptn.sh/keptn"
             exit 1
           fi

--- a/.github/workflows/validate-helm-chart.yml
+++ b/.github/workflows/validate-helm-chart.yml
@@ -69,27 +69,16 @@ jobs:
           path: ./bin
           key: build-tools-${{ github.ref_name }}
 
-      - name: Generate current YAML
-        run: |
-          make release-helm-manifests
-          helm template helm/chart > current.yaml
-
       - name: Generate new Helm Chart
         run: make helm-package
 
-      - name: Generate new YAML
+      - name: Compare YAML file changes
         run: |
-          helm template helm/chart > new.yaml
-
-      - name: Compare YAML files
-        run: |
-          if ! cmp --quiet ./current.yaml ./new.yaml; then
-            echo "Helm charts were not re-generated. Please regenerate them using make helm-package"
-            echo ""
-            echo "=========== Diff ==========="
-            diff -u ./current.yaml ./new.yaml
-            exit 1
-          else
+          if [ -z "$(git status --porcelain)" ]; then
             echo ""
             echo "There are no changes in the manifests"
+          else
+            echo ""
+            echo "Helm charts were not re-generated. Please regenerate them using make helm-package"
+            exit 1
           fi

--- a/.github/workflows/validate-helm-chart.yml
+++ b/.github/workflows/validate-helm-chart.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Generate current YAML
         run: |
+          make release-helm-manifests
           helm template helm/chart > current.yaml
 
       - name: Generate new Helm Chart
@@ -82,8 +83,11 @@ jobs:
 
       - name: Compare YAML files
         run: |
-          if ! diff -rq current.yaml new.yaml &>/dev/null; then
+          if ! cmp --quiet ./current.yaml ./new.yaml; then
             echo "Helm charts were not re-generated. Please regenerate them using make helm-package"
+            echo ""
+            echo "=========== Diff ==========="
+            diff -u ./current.yaml ./new.yaml
             exit 1
           else
             echo ""

--- a/.yamllint
+++ b/.yamllint
@@ -7,10 +7,15 @@ ignore: |
   **/rendered/release.yaml
   examples/support/observability/config/prometheus
   dashboards/grafana
-  operator/config/crd/bases
-  metrics-operator/config/crd/bases
+  operator/config/crd/bases/*
+  metrics-operator/config/crd/bases/*
+  klt-cert-manager/config/crd/bases/*
+  operator/config/rbac/role.yaml
+  metrics-operator/config/rbac/role.yaml
+  klt-cert-manager/config/rbac/role.yaml
   helm/chart/templates
   helm/chart/rendered.yaml
+  helm/chart/values.yaml
   helmchart.yaml
 
 rules:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -11,7 +11,7 @@ certificateOperator:
       seccompProfile:
         type: RuntimeDefault
     image:
-      repository: ghcr.io/keptn/certificate-operator
+      repository: ghcr.keptn.sh/keptn/certificate-operator
       tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
@@ -76,7 +76,7 @@ lifecycleOperator:
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
     image:
-      repository: ghcr.io/keptn/lifecycle-operator
+      repository: ghcr.keptn.sh/keptn/lifecycle-operator
       tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
@@ -137,7 +137,7 @@ metricsOperator:
       exposeKeptnMetrics: "true"
       metricsControllerLogLevel: "0"
     image:
-      repository: ghcr.io/keptn/metrics-operator
+      repository: ghcr.keptn.sh/keptn/metrics-operator
       tag: v0.7.0
     livenessProbe:
       httpGet:
@@ -200,7 +200,7 @@ scheduler:
     env:
       otelCollectorUrl: otel-collector:4317
     image:
-      repository: ghcr.io/keptn/scheduler
+      repository: ghcr.keptn.sh/keptn/scheduler
       tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -4,14 +4,14 @@ certificateOperator:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-          - ALL
+        - ALL
       readOnlyRootFilesystem: true
       runAsGroup: 65532
       runAsUser: 65532
       seccompProfile:
         type: RuntimeDefault
     image:
-      repository: ghcr.keptn.sh/keptn/certificate-operator
+      repository: ghcr.io/keptn/certificate-operator
       tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
@@ -56,7 +56,7 @@ lifecycleOperator:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-          - ALL
+        - ALL
       privileged: false
       runAsGroup: 65532
       runAsNonRoot: true
@@ -76,7 +76,7 @@ lifecycleOperator:
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
     image:
-      repository: ghcr.keptn.sh/keptn/lifecycle-operator
+      repository: ghcr.io/keptn/lifecycle-operator
       tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
@@ -104,16 +104,16 @@ lifecycleOperator:
   topologySpreadConstraints: []
 lifecycleOperatorMetricsService:
   ports:
-    - name: metrics
-      port: 2222
-      protocol: TCP
-      targetPort: metrics
+  - name: metrics
+    port: 2222
+    protocol: TCP
+    targetPort: metrics
   type: ClusterIP
 lifecycleWebhookService:
   ports:
-    - port: 443
-      protocol: TCP
-      targetPort: 9443
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
   type: ClusterIP
 metricsManagerConfig:
   controllerManagerConfigYaml:
@@ -132,12 +132,12 @@ metricsOperator:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-          - ALL
+        - ALL
     env:
       exposeKeptnMetrics: "true"
       metricsControllerLogLevel: "0"
     image:
-      repository: ghcr.keptn.sh/keptn/metrics-operator
+      repository: ghcr.io/keptn/metrics-operator
       tag: v0.7.0
     livenessProbe:
       httpGet:
@@ -164,23 +164,23 @@ metricsOperator:
   topologySpreadConstraints: []
 metricsOperatorService:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
-    - name: custom-metrics
-      port: 443
-      targetPort: custom-metrics
-    - name: metrics
-      port: 9999
-      protocol: TCP
-      targetPort: metrics
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  - name: custom-metrics
+    port: 443
+    targetPort: custom-metrics
+  - name: metrics
+    port: 9999
+    protocol: TCP
+    targetPort: metrics
   type: ClusterIP
 metricsWebhookService:
   ports:
-    - port: 443
-      protocol: TCP
-      targetPort: 9443
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
   type: ClusterIP
 scheduler:
   nodeSelector: {}
@@ -190,7 +190,7 @@ scheduler:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-          - ALL
+        - ALL
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
@@ -200,7 +200,7 @@ scheduler:
     env:
       otelCollectorUrl: otel-collector:4317
     image:
-      repository: ghcr.keptn.sh/keptn/scheduler
+      repository: ghcr.io/keptn/scheduler
       tag: v0.7.0
     imagePullPolicy: Always
     livenessProbe:
@@ -228,8 +228,8 @@ schedulerConfig:
     leaderElection:
       leaderElect: false
     profiles:
-      - plugins:
-          permit:
-            enabled:
-              - name: KLCPermit
-        schedulerName: keptn-scheduler
+    - plugins:
+        permit:
+          enabled:
+          - name: KLCPermit
+      schedulerName: keptn-scheduler

--- a/klt-cert-manager/config/rbac/role.yaml
+++ b/klt-cert-manager/config/rbac/role.yaml
@@ -5,44 +5,44 @@ metadata:
   creationTimestamp: null
   name: certificate-operator-role
 rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -51,15 +51,15 @@ metadata:
   name: certificate-operator-role
   namespace: keptn-lifecycle-toolkit-system
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetrics.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetrics.yaml
@@ -15,155 +15,155 @@ spec:
     singular: keptnmetric
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.provider.name
-          name: Provider
-          type: string
-        - jsonPath: .spec.query
-          name: Query
-          type: string
-        - jsonPath: .status.value
-          name: Value
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnMetric is the Schema for the keptnmetrics API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    - jsonPath: .spec.query
+      name: Query
+      type: string
+    - jsonPath: .status.value
+      name: Value
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetric is the Schema for the keptnmetrics API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnMetricSpec defines the desired state of KeptnMetric
-              properties:
-                fetchIntervalSeconds:
-                  description: FetchIntervalSeconds represents the update frequency
-                    in seconds that is used to update the metric
-                  type: integer
-                provider:
-                  description: Provider represents the provider object
-                  properties:
-                    name:
-                      description: Name of the provider
-                      type: string
-                  required:
-                    - name
-                  type: object
-                query:
-                  description: Query represents the query to be run
-                  type: string
-              required:
-                - fetchIntervalSeconds
-                - provider
-                - query
-              type: object
-            status:
-              description: KeptnMetricStatus defines the observed state of KeptnMetric
-              properties:
-                lastUpdated:
-                  description: LastUpdated represents the time when the status data
-                    was last updated
-                  format: date-time
-                  type: string
-                rawValue:
-                  description: RawValue represents the resulting value in raw format
-                  format: byte
-                  type: string
-                value:
-                  description: Value represents the resulting value
-                  type: string
-              required:
-                - lastUpdated
-                - rawValue
-                - value
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.provider.name
-          name: Provider
-          type: string
-        - jsonPath: .spec.query
-          name: Query
-          type: string
-        - jsonPath: .status.value
-          name: Value
-          type: string
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnMetric is the Schema for the keptnmetrics API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricSpec defines the desired state of KeptnMetric
+            properties:
+              fetchIntervalSeconds:
+                description: FetchIntervalSeconds represents the update frequency
+                  in seconds that is used to update the metric
+                type: integer
+              provider:
+                description: Provider represents the provider object
+                properties:
+                  name:
+                    description: Name of the provider
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: Query represents the query to be run
+                type: string
+            required:
+            - fetchIntervalSeconds
+            - provider
+            - query
+            type: object
+          status:
+            description: KeptnMetricStatus defines the observed state of KeptnMetric
+            properties:
+              lastUpdated:
+                description: LastUpdated represents the time when the status data
+                  was last updated
+                format: date-time
+                type: string
+              rawValue:
+                description: RawValue represents the resulting value in raw format
+                format: byte
+                type: string
+              value:
+                description: Value represents the resulting value
+                type: string
+            required:
+            - lastUpdated
+            - rawValue
+            - value
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    - jsonPath: .spec.query
+      name: Query
+      type: string
+    - jsonPath: .status.value
+      name: Value
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetric is the Schema for the keptnmetrics API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnMetricSpec defines the desired state of KeptnMetric
-              properties:
-                fetchIntervalSeconds:
-                  description: FetchIntervalSeconds represents the update frequency
-                    in seconds that is used to update the metric
-                  type: integer
-                provider:
-                  description: Provider represents the provider object
-                  properties:
-                    name:
-                      description: Name of the provider
-                      type: string
-                  required:
-                    - name
-                  type: object
-                query:
-                  description: Query represents the query to be run
-                  type: string
-              required:
-                - fetchIntervalSeconds
-                - provider
-                - query
-              type: object
-            status:
-              description: KeptnMetricStatus defines the observed state of KeptnMetric
-              properties:
-                lastUpdated:
-                  description: LastUpdated represents the time when the status data
-                    was last updated
-                  format: date-time
-                  type: string
-                rawValue:
-                  description: RawValue represents the resulting value in raw format
-                  format: byte
-                  type: string
-                value:
-                  description: Value represents the resulting value
-                  type: string
-              required:
-                - lastUpdated
-                - rawValue
-                - value
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricSpec defines the desired state of KeptnMetric
+            properties:
+              fetchIntervalSeconds:
+                description: FetchIntervalSeconds represents the update frequency
+                  in seconds that is used to update the metric
+                type: integer
+              provider:
+                description: Provider represents the provider object
+                properties:
+                  name:
+                    description: Name of the provider
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: Query represents the query to be run
+                type: string
+            required:
+            - fetchIntervalSeconds
+            - provider
+            - query
+            type: object
+          status:
+            description: KeptnMetricStatus defines the observed state of KeptnMetric
+            properties:
+              lastUpdated:
+                description: LastUpdated represents the time when the status data
+                  was last updated
+                format: date-time
+                type: string
+              rawValue:
+                description: RawValue represents the resulting value in raw format
+                format: byte
+                type: string
+              value:
+                description: Value represents the resulting value
+                type: string
+            required:
+            - lastUpdated
+            - rawValue
+            - value
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetricsproviders.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetricsproviders.yaml
@@ -13,60 +13,60 @@ spec:
     listKind: KeptnMetricsProviderList
     plural: keptnmetricsproviders
     shortNames:
-      - kmp
+    - kmp
     singular: keptnmetricsprovider
   scope: Namespaced
   versions:
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnMetricsProvider is the Schema for the keptnmetricsproviders
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetricsProvider is the Schema for the keptnmetricsproviders
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
-              properties:
-                secretKeyRef:
-                  description: SecretKeySelector selects a key of a Secret.
-                  properties:
-                    key:
-                      description: The key of the secret to select from.  Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
+            properties:
+              secretKeyRef:
+                description: SecretKeySelector selects a key of a Secret.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or its key must be defined
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-                  x-kubernetes-map-type: atomic
-                targetServer:
-                  type: string
-              required:
-                - targetServer
-              type: object
-            status:
-              description: KeptnMetricsProviderStatus defines the observed state of
-                KeptnMetricsProvider
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              targetServer:
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: KeptnMetricsProviderStatus defines the observed state of
+              KeptnMetricsProvider
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/metrics-operator/config/rbac/role.yaml
+++ b/metrics-operator/config/rbac/role.yaml
@@ -5,55 +5,55 @@ metadata:
   creationTimestamp: null
   name: metrics-operator-role
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-  - apiGroups:
-      - metrics.keptn.sh
-    resources:
-      - keptnmetrics
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - metrics.keptn.sh
-    resources:
-      - keptnmetrics/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - metrics.keptn.sh
-    resources:
-      - keptnmetrics/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - metrics.keptn.sh
-    resources:
-      - keptnmetricsproviders
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - metrics.keptn.sh
-    resources:
-      - providers
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetricsproviders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - providers
+  verbs:
+  - get
+  - list
+  - watch

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnapps.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnapps.yaml
@@ -15,201 +15,201 @@ spec:
     singular: keptnapp
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnApp is the Schema for the keptnapps API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnAppSpec defines the desired state of KeptnApp
-              properties:
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                version:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
                   type: string
-                workloads:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
-                      - name
-                      - version
-                    type: object
-                  type: array
-              required:
-                - version
-              type: object
-            status:
-              description: KeptnAppStatus defines the observed state of KeptnApp
-              properties:
-                currentVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnApp is the Schema for the keptnapps API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnAppSpec defines the desired state of KeptnApp
-              properties:
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                revision:
-                  default: 1
-                  type: integer
-                version:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
                   type: string
-                workloads:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
-                      - name
-                      - version
-                    type: object
-                  type: array
-              required:
-                - version
-              type: object
-            status:
-              description: KeptnAppStatus defines the observed state of KeptnApp
-              properties:
-                currentVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnApp is the Schema for the keptnapps API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                type: integer
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnAppSpec defines the desired state of KeptnApp
-              properties:
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                revision:
-                  default: 1
-                  type: integer
-                version:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
                   type: string
-                workloads:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
-                      - name
-                      - version
-                    type: object
-                  type: array
-              required:
-                - version
-              type: object
-            status:
-              description: KeptnAppStatus defines the observed state of KeptnApp
-              properties:
-                currentVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                type: integer
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnappversions.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnappversions.yaml
@@ -13,704 +13,704 @@ spec:
     listKind: KeptnAppVersionList
     plural: keptnappversions
     shortNames:
-      - kav
+    - kav
     singular: keptnappversion
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.appName
-          name: AppName
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Phase
-          type: string
-        - jsonPath: .status.preDeploymentStatus
-          name: PreDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.preDeploymentEvaluationStatus
-          name: PreDeploymentEvaluationStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.workloadOverallStatus
-          name: WorkloadOverallStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentStatus
-          name: PostDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentEvaluationStatus
-          name: PostDeploymentEvaluationStatus
-          priority: 1
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnAppVersion is the Schema for the keptnappversions API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
-              properties:
-                appName:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                previousVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-                traceId:
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
                   additionalProperties:
                     type: string
+                  description: MapCarrier is a TextMapCarrier that uses a map held
+                    in memory as a storage medium for propagated key-value pairs.
                   type: object
-                version:
-                  type: string
-                workloads:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
                       - name
                       - version
-                    type: object
-                  type: array
-              required:
-                - appName
-                - version
-              type: object
-            status:
-              description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
-              properties:
-                currentPhase:
-                  type: string
-                endTime:
-                  format: date-time
-                  type: string
-                phaseTraceIDs:
-                  additionalProperties:
-                    additionalProperties:
-                      type: string
-                    description: MapCarrier is a TextMapCarrier that uses a map held
-                      in memory as a storage medium for propagated key-value pairs.
-                    type: object
+                      type: object
                   type: object
-                postDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                postDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      evaluationDefinitionName:
-                        type: string
-                      evaluationName:
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                postDeploymentStatus:
-                  default: Pending
-                  type: string
-                postDeploymentTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                      taskDefinitionName:
-                        type: string
-                      taskName:
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                preDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      evaluationDefinitionName:
-                        type: string
-                      evaluationName:
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentStatus:
-                  default: Pending
-                  type: string
-                preDeploymentTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                      taskDefinitionName:
-                        type: string
-                      taskName:
-                        type: string
-                    type: object
-                  type: array
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-                workloadOverallStatus:
-                  default: Pending
-                  type: string
-                workloadStatus:
-                  items:
-                    properties:
-                      status:
-                        default: Pending
-                        type: string
-                      workload:
-                        properties:
-                          name:
-                            type: string
-                          version:
-                            type: string
-                        required:
-                          - name
-                          - version
-                        type: object
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.appName
-          name: AppName
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Phase
-          type: string
-        - jsonPath: .status.preDeploymentStatus
-          name: PreDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.preDeploymentEvaluationStatus
-          name: PreDeploymentEvaluationStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.workloadOverallStatus
-          name: WorkloadOverallStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentStatus
-          name: PostDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentEvaluationStatus
-          name: PostDeploymentEvaluationStatus
-          priority: 1
-          type: string
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnAppVersion is the Schema for the keptnappversions API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
-              properties:
-                appName:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                previousVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-                revision:
-                  default: 1
-                  type: integer
-                traceId:
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              revision:
+                default: 1
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
                   additionalProperties:
                     type: string
+                  description: MapCarrier is a TextMapCarrier that uses a map held
+                    in memory as a storage medium for propagated key-value pairs.
                   type: object
-                version:
-                  type: string
-                workloads:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
                       - name
                       - version
-                    type: object
-                  type: array
-              required:
-                - appName
-                - version
-              type: object
-            status:
-              description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
-              properties:
-                currentPhase:
-                  type: string
-                endTime:
-                  format: date-time
-                  type: string
-                phaseTraceIDs:
-                  additionalProperties:
-                    additionalProperties:
-                      type: string
-                    description: MapCarrier is a TextMapCarrier that uses a map held
-                      in memory as a storage medium for propagated key-value pairs.
-                    type: object
+                      type: object
                   type: object
-                postDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                postDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                postDeploymentStatus:
-                  default: Pending
-                  type: string
-                postDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                preDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentStatus:
-                  default: Pending
-                  type: string
-                preDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-                workloadOverallStatus:
-                  default: Pending
-                  type: string
-                workloadStatus:
-                  items:
-                    properties:
-                      status:
-                        default: Pending
-                        type: string
-                      workload:
-                        properties:
-                          name:
-                            type: string
-                          version:
-                            type: string
-                        required:
-                          - name
-                          - version
-                        type: object
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.appName
-          name: AppName
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Phase
-          type: string
-        - jsonPath: .status.preDeploymentStatus
-          name: PreDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.preDeploymentEvaluationStatus
-          name: PreDeploymentEvaluationStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.workloadOverallStatus
-          name: WorkloadOverallStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentStatus
-          name: PostDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentEvaluationStatus
-          name: PostDeploymentEvaluationStatus
-          priority: 1
-          type: string
-      name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnAppVersion is the Schema for the keptnappversions API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
-              properties:
-                appName:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                previousVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-                revision:
-                  default: 1
-                  type: integer
-                traceId:
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              revision:
+                default: 1
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
                   additionalProperties:
                     type: string
+                  description: MapCarrier is a TextMapCarrier that uses a map held
+                    in memory as a storage medium for propagated key-value pairs.
                   type: object
-                version:
-                  type: string
-                workloads:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      version:
-                        type: string
-                    required:
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
                       - name
                       - version
-                    type: object
-                  type: array
-              required:
-                - appName
-                - version
-              type: object
-            status:
-              description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
-              properties:
-                currentPhase:
-                  type: string
-                endTime:
-                  format: date-time
-                  type: string
-                phaseTraceIDs:
-                  additionalProperties:
-                    additionalProperties:
-                      type: string
-                    description: MapCarrier is a TextMapCarrier that uses a map held
-                      in memory as a storage medium for propagated key-value pairs.
-                    type: object
+                      type: object
                   type: object
-                postDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                postDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                postDeploymentStatus:
-                  default: Pending
-                  type: string
-                postDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                preDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentStatus:
-                  default: Pending
-                  type: string
-                preDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-                workloadOverallStatus:
-                  default: Pending
-                  type: string
-                workloadStatus:
-                  items:
-                    properties:
-                      status:
-                        default: Pending
-                        type: string
-                      workload:
-                        properties:
-                          name:
-                            type: string
-                          version:
-                            type: string
-                        required:
-                          - name
-                          - version
-                        type: object
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnevaluationdefinitions.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnevaluationdefinitions.yaml
@@ -13,164 +13,164 @@ spec:
     listKind: KeptnEvaluationDefinitionList
     plural: keptnevaluationdefinitions
     shortNames:
-      - ked
+    - ked
     singular: keptnevaluationdefinition
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationDefinitionSpec defines the desired state of
-                KeptnEvaluationDefinition
-              properties:
-                objectives:
-                  items:
-                    properties:
-                      evaluationTarget:
-                        type: string
-                      name:
-                        type: string
-                      query:
-                        type: string
-                    required:
-                      - evaluationTarget
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: KeptnEvaluationDefinitionStatus defines the observed state
+              of KeptnEvaluationDefinition
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: KeptnEvaluationDefinitionStatus defines the observed state
+              of KeptnEvaluationDefinition
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    keptnMetricRef:
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
                       - name
-                      - query
-                    type: object
-                  type: array
-                source:
-                  type: string
-              required:
-                - objectives
-                - source
-              type: object
-            status:
-              description: KeptnEvaluationDefinitionStatus defines the observed state
-                of KeptnEvaluationDefinition
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationDefinitionSpec defines the desired state of
-                KeptnEvaluationDefinition
-              properties:
-                objectives:
-                  items:
-                    properties:
-                      evaluationTarget:
-                        type: string
-                      name:
-                        type: string
-                      query:
-                        type: string
-                    required:
-                      - evaluationTarget
-                      - name
-                      - query
-                    type: object
-                  type: array
-                source:
-                  type: string
-              required:
-                - objectives
-                - source
-              type: object
-            status:
-              description: KeptnEvaluationDefinitionStatus defines the observed state
-                of KeptnEvaluationDefinition
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationDefinitionSpec defines the desired state of
-                KeptnEvaluationDefinition
-              properties:
-                objectives:
-                  items:
-                    properties:
-                      evaluationTarget:
-                        type: string
-                      keptnMetricRef:
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                          - name
-                        type: object
-                    required:
-                      - evaluationTarget
-                      - keptnMetricRef
-                    type: object
-                  type: array
-              required:
-                - objectives
-              type: object
-            status:
-              description: KeptnEvaluationDefinitionStatus defines the observed state
-                of KeptnEvaluationDefinition
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+            required:
+            - objectives
+            type: object
+          status:
+            description: KeptnEvaluationDefinitionStatus defines the observed state
+              of KeptnEvaluationDefinition
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnevaluationproviders.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnevaluationproviders.yaml
@@ -13,153 +13,153 @@ spec:
     listKind: KeptnEvaluationProviderList
     plural: keptnevaluationproviders
     shortNames:
-      - kep
+    - kep
     singular: keptnevaluationprovider
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluationProvider is the Schema for the keptnevaluationproviders
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationProvider is the Schema for the keptnevaluationproviders
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationProviderSpec defines the desired state of
-                KeptnEvaluationProvider
-              properties:
-                secretName:
-                  type: string
-                targetServer:
-                  type: string
-              required:
-                - targetServer
-              type: object
-            status:
-              description: KeptnEvaluationProviderStatus defines the observed state
-                of KeptnEvaluationProvider
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluationProvider is the Schema for the keptnevaluationproviders
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationProviderSpec defines the desired state of
+              KeptnEvaluationProvider
+            properties:
+              secretName:
+                type: string
+              targetServer:
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: KeptnEvaluationProviderStatus defines the observed state
+              of KeptnEvaluationProvider
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationProvider is the Schema for the keptnevaluationproviders
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationProviderSpec defines the desired state of
-                KeptnEvaluationProvider
-              properties:
-                secretKeyRef:
-                  description: SecretKeySelector selects a key of a Secret.
-                  properties:
-                    key:
-                      description: The key of the secret to select from.  Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationProviderSpec defines the desired state of
+              KeptnEvaluationProvider
+            properties:
+              secretKeyRef:
+                description: SecretKeySelector selects a key of a Secret.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or its key must be defined
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-                  x-kubernetes-map-type: atomic
-                targetServer:
-                  type: string
-              required:
-                - targetServer
-              type: object
-            status:
-              description: KeptnEvaluationProviderStatus defines the observed state
-                of KeptnEvaluationProvider
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluationProvider is the Schema for the keptnevaluationproviders
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              targetServer:
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: KeptnEvaluationProviderStatus defines the observed state
+              of KeptnEvaluationProvider
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationProvider is the Schema for the keptnevaluationproviders
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationProviderSpec defines the desired state of
-                KeptnEvaluationProvider
-              properties:
-                secretKeyRef:
-                  description: SecretKeySelector selects a key of a Secret.
-                  properties:
-                    key:
-                      description: The key of the secret to select from.  Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationProviderSpec defines the desired state of
+              KeptnEvaluationProvider
+            properties:
+              secretKeyRef:
+                description: SecretKeySelector selects a key of a Secret.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or its key must be defined
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-                  x-kubernetes-map-type: atomic
-                targetServer:
-                  type: string
-              required:
-                - targetServer
-              type: object
-            status:
-              description: KeptnEvaluationProviderStatus defines the observed state
-                of KeptnEvaluationProvider
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              targetServer:
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: KeptnEvaluationProviderStatus defines the observed state
+              of KeptnEvaluationProvider
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnevaluations.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnevaluations.yaml
@@ -13,325 +13,325 @@ spec:
     listKind: KeptnEvaluationList
     plural: keptnevaluations
     shortNames:
-      - ke
+    - ke
     singular: keptnevaluation
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.appName
-          name: AppName
-          type: string
-        - jsonPath: .spec.appVersion
-          name: AppVersion
-          type: string
-        - jsonPath: .spec.workload
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.workloadVersion
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.retryCount
-          name: RetryCount
-          type: string
-        - jsonPath: .status.evaluationStatus
-          name: EvaluationStatus
-          type: string
-        - jsonPath: .status.overallStatus
-          name: OverallStatus
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluation is the Schema for the keptnevaluations API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
-              properties:
-                appName:
-                  type: string
-                appVersion:
-                  type: string
-                checkType:
-                  type: string
-                evaluationDefinition:
-                  type: string
-                failAction:
-                  type: string
-                retries:
-                  default: 10
-                  type: integer
-                retryInterval:
-                  default: 5s
-                  pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                  type: string
-                workload:
-                  type: string
-                workloadVersion:
-                  type: string
-              required:
-                - evaluationDefinition
-                - workloadVersion
-              type: object
-            status:
-              description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
-              properties:
-                endTime:
-                  format: date-time
-                  type: string
-                evaluationStatus:
-                  additionalProperties:
-                    properties:
-                      message:
-                        type: string
-                      status:
-                        type: string
-                      value:
-                        type: string
-                    required:
-                      - status
-                      - value
-                    type: object
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
                   type: object
-                overallStatus:
-                  default: Pending
-                  type: string
-                retryCount:
-                  default: 0
-                  type: integer
-                startTime:
-                  format: date-time
-                  type: string
-              required:
-                - evaluationStatus
-                - overallStatus
-                - retryCount
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.appName
-          name: AppName
-          type: string
-        - jsonPath: .spec.appVersion
-          name: AppVersion
-          type: string
-        - jsonPath: .spec.workload
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.workloadVersion
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.retryCount
-          name: RetryCount
-          type: string
-        - jsonPath: .status.evaluationStatus
-          name: EvaluationStatus
-          type: string
-        - jsonPath: .status.overallStatus
-          name: OverallStatus
-          type: string
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluation is the Schema for the keptnevaluations API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: object
+              overallStatus:
+                default: Pending
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
-              properties:
-                appName:
-                  type: string
-                appVersion:
-                  type: string
-                checkType:
-                  type: string
-                evaluationDefinition:
-                  type: string
-                failAction:
-                  type: string
-                retries:
-                  default: 10
-                  type: integer
-                retryInterval:
-                  default: 5s
-                  pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                  type: string
-                workload:
-                  type: string
-                workloadVersion:
-                  type: string
-              required:
-                - evaluationDefinition
-                - workloadVersion
-              type: object
-            status:
-              description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
-              properties:
-                endTime:
-                  format: date-time
-                  type: string
-                evaluationStatus:
-                  additionalProperties:
-                    properties:
-                      message:
-                        type: string
-                      status:
-                        type: string
-                      value:
-                        type: string
-                    required:
-                      - status
-                      - value
-                    type: object
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
                   type: object
-                overallStatus:
-                  default: Pending
-                  type: string
-                retryCount:
-                  default: 0
-                  type: integer
-                startTime:
-                  format: date-time
-                  type: string
-              required:
-                - evaluationStatus
-                - overallStatus
-                - retryCount
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.appName
-          name: AppName
-          type: string
-        - jsonPath: .spec.appVersion
-          name: AppVersion
-          type: string
-        - jsonPath: .spec.workload
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.workloadVersion
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.retryCount
-          name: RetryCount
-          type: string
-        - jsonPath: .status.evaluationStatus
-          name: EvaluationStatus
-          type: string
-        - jsonPath: .status.overallStatus
-          name: OverallStatus
-          type: string
-      name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnEvaluation is the Schema for the keptnevaluations API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: object
+              overallStatus:
+                default: Pending
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
-              properties:
-                appName:
-                  type: string
-                appVersion:
-                  type: string
-                checkType:
-                  type: string
-                evaluationDefinition:
-                  type: string
-                failAction:
-                  type: string
-                retries:
-                  default: 10
-                  type: integer
-                retryInterval:
-                  default: 5s
-                  pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                  type: string
-                workload:
-                  type: string
-                workloadVersion:
-                  type: string
-              required:
-                - evaluationDefinition
-                - workloadVersion
-              type: object
-            status:
-              description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
-              properties:
-                endTime:
-                  format: date-time
-                  type: string
-                evaluationStatus:
-                  additionalProperties:
-                    properties:
-                      message:
-                        type: string
-                      status:
-                        type: string
-                      value:
-                        type: string
-                    required:
-                      - status
-                      - value
-                    type: object
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
                   type: object
-                overallStatus:
-                  default: Pending
-                  type: string
-                retryCount:
-                  default: 0
-                  type: integer
-                startTime:
-                  format: date-time
-                  type: string
-              required:
-                - evaluationStatus
-                - overallStatus
-                - retryCount
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              overallStatus:
+                default: Pending
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptntaskdefinitions.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptntaskdefinitions.yaml
@@ -15,242 +15,242 @@ spec:
     singular: keptntaskdefinition
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
-              properties:
-                function:
-                  properties:
-                    configMapRef:
-                      properties:
-                        name:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
                           type: string
-                      type: object
-                    functionRef:
-                      properties:
-                        name:
-                          type: string
-                      type: object
-                    httpRef:
-                      properties:
-                        url:
-                          type: string
-                      type: object
-                    inline:
-                      properties:
-                        code:
-                          type: string
-                      type: object
-                    parameters:
-                      properties:
-                        map:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    secureParameters:
-                      properties:
-                        secret:
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            status:
-              description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
-              properties:
-                function:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
-                  properties:
-                    configMap:
-                      description: 'INSERT ADDITIONAL STATUS FIELD - define observed
+                properties:
+                  configMap:
+                    description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                       state of cluster Important: Run "make" to regenerate code after
                       modifying this file'
-                      type: string
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
-              properties:
-                function:
-                  properties:
-                    configMapRef:
-                      properties:
-                        name:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
                           type: string
-                      type: object
-                    functionRef:
-                      properties:
-                        name:
-                          type: string
-                      type: object
-                    httpRef:
-                      properties:
-                        url:
-                          type: string
-                      type: object
-                    inline:
-                      properties:
-                        code:
-                          type: string
-                      type: object
-                    parameters:
-                      properties:
-                        map:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    secureParameters:
-                      properties:
-                        secret:
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            status:
-              description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
-              properties:
-                function:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
-                  properties:
-                    configMap:
-                      description: 'INSERT ADDITIONAL STATUS FIELD - define observed
+                properties:
+                  configMap:
+                    description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                       state of cluster Important: Run "make" to regenerate code after
                       modifying this file'
-                      type: string
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
-              properties:
-                function:
-                  properties:
-                    configMapRef:
-                      properties:
-                        name:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
                           type: string
-                      type: object
-                    functionRef:
-                      properties:
-                        name:
-                          type: string
-                      type: object
-                    httpRef:
-                      properties:
-                        url:
-                          type: string
-                      type: object
-                    inline:
-                      properties:
-                        code:
-                          type: string
-                      type: object
-                    parameters:
-                      properties:
-                        map:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                    secureParameters:
-                      properties:
-                        secret:
-                          type: string
-                      type: object
-                  type: object
-                retries:
-                  default: 10
-                  format: int32
-                  type: integer
-                timeout:
-                  default: 5m
-                  pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                  type: string
-              type: object
-            status:
-              description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
-              properties:
-                function:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                format: int32
+                type: integer
+              timeout:
+                default: 5m
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
-                  properties:
-                    configMap:
-                      description: 'INSERT ADDITIONAL STATUS FIELD - define observed
+                properties:
+                  configMap:
+                    description: 'INSERT ADDITIONAL STATUS FIELD - define observed
                       state of cluster Important: Run "make" to regenerate code after
                       modifying this file'
-                      type: string
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptntasks.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptntasks.yaml
@@ -15,358 +15,358 @@ spec:
     singular: keptntask
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.appVersion
-          name: AppVersion
-          type: string
-        - jsonPath: .spec.workload
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.workloadVersion
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.jobName
-          name: Job Name
-          type: string
-        - jsonPath: .status.status
-          name: Status
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnTask is the Schema for the keptntasks API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnTaskSpec defines the desired state of KeptnTask
-              properties:
-                app:
-                  type: string
-                appVersion:
-                  type: string
-                checkType:
-                  type: string
-                context:
-                  properties:
-                    appName:
-                      type: string
-                    appVersion:
-                      type: string
-                    objectType:
-                      type: string
-                    taskType:
-                      type: string
-                    workloadName:
-                      type: string
-                    workloadVersion:
-                      type: string
-                  required:
-                    - appName
-                    - appVersion
-                    - objectType
-                    - taskType
-                    - workloadName
-                    - workloadVersion
-                  type: object
-                parameters:
-                  properties:
-                    map:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                secureParameters:
-                  properties:
-                    secret:
-                      type: string
-                  type: object
-                taskDefinition:
-                  type: string
-                workload:
-                  type: string
-                workloadVersion:
-                  type: string
-              required:
-                - app
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
                 - appVersion
-                - context
-                - taskDefinition
-                - workload
+                - objectType
+                - taskType
+                - workloadName
                 - workloadVersion
-              type: object
-            status:
-              description: KeptnTaskStatus defines the observed state of KeptnTask
-              properties:
-                endTime:
-                  format: date-time
-                  type: string
-                jobName:
-                  type: string
-                message:
-                  type: string
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.appVersion
-          name: AppVersion
-          type: string
-        - jsonPath: .spec.workload
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.workloadVersion
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.jobName
-          name: Job Name
-          type: string
-        - jsonPath: .status.status
-          name: Status
-          type: string
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnTask is the Schema for the keptntasks API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnTaskSpec defines the desired state of KeptnTask
-              properties:
-                app:
-                  type: string
-                appVersion:
-                  type: string
-                checkType:
-                  type: string
-                context:
-                  properties:
-                    appName:
-                      type: string
-                    appVersion:
-                      type: string
-                    objectType:
-                      type: string
-                    taskType:
-                      type: string
-                    workloadName:
-                      type: string
-                    workloadVersion:
-                      type: string
-                  required:
-                    - appName
-                    - appVersion
-                    - objectType
-                    - taskType
-                    - workloadName
-                    - workloadVersion
-                  type: object
-                parameters:
-                  properties:
-                    map:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                secureParameters:
-                  properties:
-                    secret:
-                      type: string
-                  type: object
-                taskDefinition:
-                  type: string
-                workload:
-                  type: string
-                workloadVersion:
-                  type: string
-              required:
-                - app
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
                 - appVersion
-                - context
-                - taskDefinition
-                - workload
+                - objectType
+                - taskType
+                - workloadName
                 - workloadVersion
-              type: object
-            status:
-              description: KeptnTaskStatus defines the observed state of KeptnTask
-              properties:
-                endTime:
-                  format: date-time
-                  type: string
-                jobName:
-                  type: string
-                message:
-                  type: string
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.appVersion
-          name: AppVersion
-          type: string
-        - jsonPath: .spec.workload
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.workloadVersion
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.jobName
-          name: Job Name
-          type: string
-        - jsonPath: .status.status
-          name: Status
-          type: string
-      name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnTask is the Schema for the keptntasks API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnTaskSpec defines the desired state of KeptnTask
-              properties:
-                app:
-                  type: string
-                appVersion:
-                  type: string
-                checkType:
-                  type: string
-                context:
-                  properties:
-                    appName:
-                      type: string
-                    appVersion:
-                      type: string
-                    objectType:
-                      type: string
-                    taskType:
-                      type: string
-                    workloadName:
-                      type: string
-                    workloadVersion:
-                      type: string
-                  required:
-                    - appName
-                    - appVersion
-                    - objectType
-                    - taskType
-                    - workloadName
-                    - workloadVersion
-                  type: object
-                parameters:
-                  properties:
-                    map:
-                      additionalProperties:
-                        type: string
-                      type: object
-                  type: object
-                retries:
-                  default: 10
-                  format: int32
-                  type: integer
-                secureParameters:
-                  properties:
-                    secret:
-                      type: string
-                  type: object
-                taskDefinition:
-                  type: string
-                timeout:
-                  default: 5m
-                  pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                  type: string
-                workload:
-                  type: string
-                workloadVersion:
-                  type: string
-              required:
-                - app
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
                 - appVersion
-                - context
-                - taskDefinition
-                - workload
+                - objectType
+                - taskType
+                - workloadName
                 - workloadVersion
-              type: object
-            status:
-              description: KeptnTaskStatus defines the observed state of KeptnTask
-              properties:
-                endTime:
-                  format: date-time
-                  type: string
-                jobName:
-                  type: string
-                message:
-                  type: string
-                reason:
-                  type: string
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                format: int32
+                type: integer
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              timeout:
+                default: 5m
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              reason:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnworkloadinstances.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnworkloadinstances.yaml
@@ -13,686 +13,686 @@ spec:
     listKind: KeptnWorkloadInstanceList
     plural: keptnworkloadinstances
     shortNames:
-      - kwi
+    - kwi
     singular: keptnworkloadinstance
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.workloadName
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.version
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Phase
-          type: string
-        - jsonPath: .status.preDeploymentStatus
-          name: PreDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.preDeploymentEvaluationStatus
-          name: PreDeploymentEvaluationStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.deploymentStatus
-          name: DeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentStatus
-          name: PostDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentEvaluationStatus
-          name: PostDeploymentEvaluationStatus
-          priority: 1
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnWorkloadInstance is the Schema for the keptnworkloadinstances
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadInstance is the Schema for the keptnworkloadinstances
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
-              properties:
-                app:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                previousVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-                resourceReference:
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: UID is a type that holds unique ID values, including
+                      UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
+                      string.  Being a type captures intent and helps make sure that
+                      UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloadName:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: KeptnWorkloadInstanceStatus defines the observed state of
+              KeptnWorkloadInstance
+            properties:
+              currentPhase:
+                type: string
+              deploymentStatus:
+                default: Pending
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: MapCarrier is a TextMapCarrier that uses a map held
+                    in memory as a storage medium for propagated key-value pairs.
+                  type: object
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
                   properties:
-                    kind:
+                    endTime:
+                      format: date-time
                       type: string
-                    name:
+                    evaluationDefinitionName:
                       type: string
-                    uid:
-                      description: UID is a type that holds unique ID values, including
-                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
-                        string.  Being a type captures intent and helps make sure that
-                        UIDs and names do not get conflated.
+                    evaluationName:
                       type: string
-                  required:
-                    - kind
-                    - name
-                    - uid
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
                   type: object
-                traceId:
-                  additionalProperties:
-                    type: string
-                  type: object
-                version:
-                  type: string
-                workloadName:
-                  type: string
-              required:
-                - app
-                - resourceReference
-                - version
-                - workloadName
-              type: object
-            status:
-              description: KeptnWorkloadInstanceStatus defines the observed state of
-                KeptnWorkloadInstance
-              properties:
-                currentPhase:
-                  type: string
-                deploymentStatus:
-                  default: Pending
-                  type: string
-                endTime:
-                  format: date-time
-                  type: string
-                phaseTraceIDs:
-                  additionalProperties:
-                    additionalProperties:
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
                       type: string
-                    description: MapCarrier is a TextMapCarrier that uses a map held
-                      in memory as a storage medium for propagated key-value pairs.
-                    type: object
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
                   type: object
-                postDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                postDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      evaluationDefinitionName:
-                        type: string
-                      evaluationName:
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                postDeploymentStatus:
-                  default: Pending
-                  type: string
-                postDeploymentTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                      taskDefinitionName:
-                        type: string
-                      taskName:
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                preDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      evaluationDefinitionName:
-                        type: string
-                      evaluationName:
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentStatus:
-                  default: Pending
-                  type: string
-                preDeploymentTaskStatus:
-                  items:
-                    properties:
-                      endTime:
-                        format: date-time
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                      taskDefinitionName:
-                        type: string
-                      taskName:
-                        type: string
-                    type: object
-                  type: array
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.workloadName
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.version
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Phase
-          type: string
-        - jsonPath: .status.preDeploymentStatus
-          name: PreDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.preDeploymentEvaluationStatus
-          name: PreDeploymentEvaluationStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.deploymentStatus
-          name: DeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentStatus
-          name: PostDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentEvaluationStatus
-          name: PostDeploymentEvaluationStatus
-          priority: 1
-          type: string
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnWorkloadInstance is the Schema for the keptnworkloadinstances
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadInstance is the Schema for the keptnworkloadinstances
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
-              properties:
-                app:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                previousVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-                resourceReference:
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: UID is a type that holds unique ID values, including
+                      UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
+                      string.  Being a type captures intent and helps make sure that
+                      UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloadName:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: KeptnWorkloadInstanceStatus defines the observed state of
+              KeptnWorkloadInstance
+            properties:
+              currentPhase:
+                type: string
+              deploymentStatus:
+                default: Pending
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: MapCarrier is a TextMapCarrier that uses a map held
+                    in memory as a storage medium for propagated key-value pairs.
+                  type: object
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
                   properties:
-                    kind:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
                       type: string
                     name:
+                      description: Name is the name of the Evaluation/Task
                       type: string
-                    uid:
-                      description: UID is a type that holds unique ID values, including
-                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
-                        string.  Being a type captures intent and helps make sure that
-                        UIDs and names do not get conflated.
+                    startTime:
+                      format: date-time
                       type: string
-                  required:
-                    - kind
-                    - name
-                    - uid
-                  type: object
-                traceId:
-                  additionalProperties:
-                    type: string
-                  type: object
-                version:
-                  type: string
-                workloadName:
-                  type: string
-              required:
-                - app
-                - resourceReference
-                - version
-                - workloadName
-              type: object
-            status:
-              description: KeptnWorkloadInstanceStatus defines the observed state of
-                KeptnWorkloadInstance
-              properties:
-                currentPhase:
-                  type: string
-                deploymentStatus:
-                  default: Pending
-                  type: string
-                endTime:
-                  format: date-time
-                  type: string
-                phaseTraceIDs:
-                  additionalProperties:
-                    additionalProperties:
+                    status:
+                      default: Pending
                       type: string
-                    description: MapCarrier is a TextMapCarrier that uses a map held
-                      in memory as a storage medium for propagated key-value pairs.
-                    type: object
                   type: object
-                postDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                postDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                postDeploymentStatus:
-                  default: Pending
-                  type: string
-                postDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                preDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentStatus:
-                  default: Pending
-                  type: string
-                preDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.workloadName
-          name: WorkloadName
-          type: string
-        - jsonPath: .spec.version
-          name: WorkloadVersion
-          type: string
-        - jsonPath: .status.currentPhase
-          name: Phase
-          type: string
-        - jsonPath: .status.preDeploymentStatus
-          name: PreDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.preDeploymentEvaluationStatus
-          name: PreDeploymentEvaluationStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.deploymentStatus
-          name: DeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentStatus
-          name: PostDeploymentStatus
-          priority: 1
-          type: string
-        - jsonPath: .status.postDeploymentEvaluationStatus
-          name: PostDeploymentEvaluationStatus
-          priority: 1
-          type: string
-      name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnWorkloadInstance is the Schema for the keptnworkloadinstances
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadInstance is the Schema for the keptnworkloadinstances
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
-              properties:
-                app:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                previousVersion:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-                resourceReference:
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: UID is a type that holds unique ID values, including
+                      UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
+                      string.  Being a type captures intent and helps make sure that
+                      UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloadName:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: KeptnWorkloadInstanceStatus defines the observed state of
+              KeptnWorkloadInstance
+            properties:
+              currentPhase:
+                type: string
+              deploymentStatus:
+                default: Pending
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: MapCarrier is a TextMapCarrier that uses a map held
+                    in memory as a storage medium for propagated key-value pairs.
+                  type: object
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
                   properties:
-                    kind:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
                       type: string
                     name:
+                      description: Name is the name of the Evaluation/Task
                       type: string
-                    uid:
-                      description: UID is a type that holds unique ID values, including
-                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
-                        string.  Being a type captures intent and helps make sure that
-                        UIDs and names do not get conflated.
+                    startTime:
+                      format: date-time
                       type: string
-                  required:
-                    - kind
-                    - name
-                    - uid
-                  type: object
-                traceId:
-                  additionalProperties:
-                    type: string
-                  type: object
-                version:
-                  type: string
-                workloadName:
-                  type: string
-              required:
-                - app
-                - resourceReference
-                - version
-                - workloadName
-              type: object
-            status:
-              description: KeptnWorkloadInstanceStatus defines the observed state of
-                KeptnWorkloadInstance
-              properties:
-                currentPhase:
-                  type: string
-                deploymentStatus:
-                  default: Pending
-                  type: string
-                endTime:
-                  format: date-time
-                  type: string
-                phaseTraceIDs:
-                  additionalProperties:
-                    additionalProperties:
+                    status:
+                      default: Pending
                       type: string
-                    description: MapCarrier is a TextMapCarrier that uses a map held
-                      in memory as a storage medium for propagated key-value pairs.
-                    type: object
                   type: object
-                postDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                postDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                postDeploymentStatus:
-                  default: Pending
-                  type: string
-                postDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentEvaluationStatus:
-                  default: Pending
-                  type: string
-                preDeploymentEvaluationTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                preDeploymentStatus:
-                  default: Pending
-                  type: string
-                preDeploymentTaskStatus:
-                  items:
-                    properties:
-                      definitionName:
-                        description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
-                        type: string
-                      endTime:
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the Evaluation/Task
-                        type: string
-                      startTime:
-                        format: date-time
-                        type: string
-                      status:
-                        default: Pending
-                        type: string
-                    type: object
-                  type: array
-                startTime:
-                  format: date-time
-                  type: string
-                status:
-                  default: Pending
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/lifecycle.keptn.sh_keptnworkloads.yaml
+++ b/operator/config/crd/bases/lifecycle.keptn.sh_keptnworkloads.yaml
@@ -15,243 +15,243 @@ spec:
     singular: keptnworkload
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnWorkload is the Schema for the keptnworkloads API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
-              properties:
-                app:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                resourceReference:
-                  properties:
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                    uid:
-                      description: UID is a type that holds unique ID values, including
-                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
-                        string.  Being a type captures intent and helps make sure that
-                        UIDs and names do not get conflated.
-                      type: string
-                  required:
-                    - kind
-                    - name
-                    - uid
-                  type: object
-                version:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-              required:
-                - app
-                - resourceReference
-                - version
-              type: object
-            status:
-              description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
-              properties:
-                currentVersion:
+                type: array
+              preDeploymentEvaluations:
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-      name: v1alpha2
-      schema:
-        openAPIV3Schema:
-          description: KeptnWorkload is the Schema for the keptnworkloads API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: UID is a type that holds unique ID values, including
+                      UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
+                      string.  Being a type captures intent and helps make sure that
+                      UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
-              properties:
-                app:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                resourceReference:
-                  properties:
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                    uid:
-                      description: UID is a type that holds unique ID values, including
-                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
-                        string.  Being a type captures intent and helps make sure that
-                        UIDs and names do not get conflated.
-                      type: string
-                  required:
-                    - kind
-                    - name
-                    - uid
-                  type: object
-                version:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-              required:
-                - app
-                - resourceReference
-                - version
-              type: object
-            status:
-              description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
-              properties:
-                currentVersion:
+                type: array
+              preDeploymentEvaluations:
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.app
-          name: AppName
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-      name: v1alpha3
-      schema:
-        openAPIV3Schema:
-          description: KeptnWorkload is the Schema for the keptnworkloads API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: UID is a type that holds unique ID values, including
+                      UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
+                      string.  Being a type captures intent and helps make sure that
+                      UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
-              properties:
-                app:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
                   type: string
-                postDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                postDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentEvaluations:
-                  items:
-                    type: string
-                  type: array
-                preDeploymentTasks:
-                  items:
-                    type: string
-                  type: array
-                resourceReference:
-                  properties:
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                    uid:
-                      description: UID is a type that holds unique ID values, including
-                        UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
-                        string.  Being a type captures intent and helps make sure that
-                        UIDs and names do not get conflated.
-                      type: string
-                  required:
-                    - kind
-                    - name
-                    - uid
-                  type: object
-                version:
+                type: array
+              postDeploymentTasks:
+                items:
                   type: string
-              required:
-                - app
-                - resourceReference
-                - version
-              type: object
-            status:
-              description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
-              properties:
-                currentVersion:
+                type: array
+              preDeploymentEvaluations:
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: UID is a type that holds unique ID values, including
+                      UUIDs.  Because we don't ONLY use UUIDs, this is an alias to
+                      string.  Being a type captures intent and helps make sure that
+                      UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/crd/bases/options.keptn.sh_keptnconfigs.yaml
+++ b/operator/config/crd/bases/options.keptn.sh_keptnconfigs.yaml
@@ -15,42 +15,42 @@ spec:
     singular: keptnconfig
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: KeptnConfig is the Schema for the keptnconfigs API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnConfig is the Schema for the keptnconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KeptnConfigSpec defines the desired state of KeptnConfig
-              properties:
-                OTelCollectorUrl:
-                  description: OTelCollectorUrl can be used to set the Open Telemetry
-                    collector that the operator should use
-                  type: string
-                keptnAppCreationRequestTimeoutSeconds:
-                  default: 30
-                  description: KeptnAppCreationRequestTimeout is used to set the interval
-                    in which automatic app discovery searches for workload to put into
-                    the same auto-generated KeptnApp
-                  type: integer
-              type: object
-            status:
-              description: KeptnConfigStatus defines the observed state of KeptnConfig
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnConfigSpec defines the desired state of KeptnConfig
+            properties:
+              OTelCollectorUrl:
+                description: OTelCollectorUrl can be used to set the Open Telemetry
+                  collector that the operator should use
+                type: string
+              keptnAppCreationRequestTimeoutSeconds:
+                default: 30
+                description: KeptnAppCreationRequestTimeoutSeconds is used to set
+                  the interval in which automatic app discovery searches for workload
+                  to put into the same auto-generated KeptnApp
+                type: integer
+            type: object
+          status:
+            description: KeptnConfigStatus defines the observed state of KeptnConfig
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -5,355 +5,363 @@ metadata:
   creationTimestamp: null
   name: lifecycle-operator-role
 rules:
-  - apiGroups:
-      - apps
-    resources:
-      - daemonsets
-      - deployments
-      - replicasets
-      - statefulsets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - create
-      - get
-      - list
-      - update
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - jobs/status
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappcreationrequests
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappcreationrequests/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappcreationrequests/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnapps
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnapps/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnapps/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappversion
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappversion/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappversion/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappversions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappversions/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnappversions/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnevaluationdefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnevaluationproviders
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnevaluations
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnevaluations/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnevaluations/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptntaskdefinitions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptntaskdefinitions/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptntaskdefinitions/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptntasks
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptntasks/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptntasks/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnworkloadinstances
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnworkloadinstances/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnworkloadinstances/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnworkloads
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnworkloads/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - lifecycle.keptn.sh
-    resources:
-      - keptnworkloads/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - metrics.keptn.sh
-    resources:
-      - keptnmetrics
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - options.keptn.sh
-    resources:
-      - keptnconfigs
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - options.keptn.sh
-    resources:
-      - keptnconfigs/status
-    verbs:
-      - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluationdefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluationproviders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadinstances
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadinstances/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadinstances/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs/status
+  verbs:
+  - get


### PR DESCRIPTION
## This PR
- fixed helm generation checker pipeline
- executed `make manifests && make generate` on each operator
- executed `make helm-package`
- add ignore to yamllint check for generated files (they have different indentation)