### PR TITLE
fix: adapt mapping for community files

### DIFF
--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -22,7 +22,7 @@ module:
       ignoreConfig: false
       mounts:
         - source: ./
-          target: ./content/en/community
+          target: ./content/community
           excludeFiles:
             - "mentorship"
         - source: "README.md"


### PR DESCRIPTION
Within #1077 a small regression slipped through, due to the constant rebasing.