### PR TITLE
fix: fix kubecon examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,7 +5,7 @@ PODTATO_NAMESPACE ?= podtato-kubectl
 GRAFANA_PORT_FORWARD ?= 3000
 
 .PHONY: install
-install: install-observability install-argo
+install: install-observability
 	@echo "-----------------------------------"
 	@echo "Create Namespace and install Keptn-lifecycle-toolkit"
 	@echo "-----------------------------------"
@@ -46,13 +46,17 @@ deploy-version-3:
 	kubectl create namespace "$(PODTATO_NAMESPACE)" --dry-run=client -o yaml | kubectl apply -f -
 	kubectl apply -k sample-app/version-3
 
-.PHONY: undeploy-podtatohead
-undeploy-podtatohead:
+.PHONY: cleanup
+cleanup:
 	kubectl delete ns "$(PODTATO_NAMESPACE)" --ignore-not-found=true
 
 	@echo "######################"
 	@echo "PodTatoHead undeployed"
 	@echo "######################"
+
+.PHONY: undeploy-podtatohead
+undeploy-podtatohead: cleanup
+
 
 .PHONY: uninstall-observability
 uninstall-observability: undeploy-podtatohead

--- a/examples/support/observability/Makefile
+++ b/examples/support/observability/Makefile
@@ -19,8 +19,8 @@ install: install-cert-manager
 	@echo "Configure Prometheus"
 	@echo "------------------"
 	kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-#	kubectl apply --server-side -f config/prometheus/setup
-#	kubectl wait --for=condition=Established --all CustomResourceDefinition --namespace=monitoring
+	kubectl apply --server-side -f config/prometheus/setup
+	kubectl wait --for=condition=Established --all CustomResourceDefinition --namespace=monitoring
 
 	@echo ""
 	@echo "-------------------------------"
@@ -35,23 +35,23 @@ install: install-cert-manager
 	kubectl wait --for=condition=available deployment/jaeger -n "$(TOOLKIT_NAMESPACE)" --timeout=120s
 	kubectl wait --for=condition=available deployment/otel-collector -n "$(TOOLKIT_NAMESPACE)" --timeout=120s
 
-#	@echo ""
-#	@echo "------------------"
-#	@echo "Install Prometheus"
-#	@echo "------------------"
-#	kubectl apply -f config/prometheus/
-#	kubectl wait --for=condition=available deployment/prometheus-operator -n monitoring --timeout=120s
-#	kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
-#	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
-#	kubectl wait --for=condition=available deployment/grafana -n monitoring --timeout=120s
-
 	@echo ""
 	@echo "------------------"
-	@echo "Install Prometheus Mockserver"
+	@echo "Install Prometheus"
 	@echo "------------------"
-	kubectl apply -n "$(TOOLKIT_NAMESPACE)" -f config/prometheus-mock/mockserver-config.yaml
-	helm repo add mockserver "https://www.mock-server.com"
-	helm upgrade --install -n "$(TOOLKIT_NAMESPACE)" --version 5.13.0 mockserver mockserver/mockserver --set service.type=ClusterIP --wait
+	kubectl apply -f config/prometheus/
+	kubectl wait --for=condition=available deployment/prometheus-operator -n monitoring --timeout=120s
+	kubectl wait --for=condition=available deployment/prometheus-adapter -n monitoring --timeout=120s
+	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
+	kubectl wait --for=condition=available deployment/grafana -n monitoring --timeout=120s
+
+	# @echo ""
+	# @echo "------------------"
+	# @echo "Install Prometheus Mockserver"
+	# @echo "------------------"
+	# kubectl apply -n "$(TOOLKIT_NAMESPACE)" -f config/prometheus-mock/mockserver-config.yaml
+	# helm repo add mockserver "https://www.mock-server.com"
+	# helm upgrade --install -n "$(TOOLKIT_NAMESPACE)" --version 5.13.0 mockserver mockserver/mockserver --set service.type=ClusterIP --wait
 
 
 	@echo ""

--- a/examples/support/observability/config/otel-collector.yaml
+++ b/examples/support/observability/config/otel-collector.yaml
@@ -134,21 +134,21 @@ spec:
                 path: otel-collector-config.yaml
           name: otel-collector-config-vol
 ---
-# apiVersion: monitoring.coreos.com/v1
-# kind: ServiceMonitor
-# metadata:
-#   labels:
-#     serviceapp: otel-collector
-#   name: otel-collector
-#   namespace: keptn-lifecycle-toolkit-system
-# spec:
-#   endpoints:
-#     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-#       interval: 30s
-#       port: metrics
-#   namespaceSelector:
-#     matchNames:
-#       - keptn-lifecycle-toolkit-system
-#   selector:
-#     matchLabels:
-#       app: opentelemetry
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    serviceapp: otel-collector
+  name: otel-collector
+  namespace: keptn-lifecycle-toolkit-system
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - keptn-lifecycle-toolkit-system
+  selector:
+    matchLabels:
+      app: opentelemetry


### PR DESCRIPTION
The examples have been changed to support Killercoda and the limited resource available there. However, this breaks all the tutorials and examples. We should instead provision a new repo for just running the killercoda demo. 