### PR TITLE
chore: adapt CODEOWNERS to new team structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,8 +6,7 @@
 #
 # Learn about CODEOWNERS file format:
 #  https://help.github.com/en/articles/about-code-owners
-#
-*   @thisthat @thschue @bacherfl
-/.github/ @thisthat @thschue @bacherfl @mowies @philipp-hinteregger
-/scheduler/ @thisthat @thschue @bacherfl @RealAnna
-/docs @thisthat @thschue @bacherfl @StackScribe
+* @keptn/lifecycle-toolkit-maintainers
+
+# The Documentation workgroup should also be able to approve documentation pullrequests
+/docs @keptn/lifecycle-toolkit-maintainers @keptn/docs-maintainers


### PR DESCRIPTION
improving the CODEOWNERs With the new keptn-org team-structure for easier maintaince and configuration.

The CODEOWNERS are now defined via teams, which are configured with peribolos within #keptn/community

closes: #1180
blocked-by: keptn/community#280