### PR TITLE
fix(operator): fix otel collector URL setup 

### DIFF
--- a/operator/controllers/common/otel_utils.go
+++ b/operator/controllers/common/otel_utils.go
@@ -39,6 +39,8 @@ type otelConfig struct {
 	TracerProvider *trace.TracerProvider
 	OtelExporter   *trace.SpanExporter
 
+	lastAppliedCollectorURL string
+
 	mtx     sync.RWMutex
 	tracers map[string]ITracer
 }
@@ -58,6 +60,9 @@ func GetOtelInstance() *otelConfig {
 }
 
 func (o *otelConfig) InitOtelCollector(otelCollectorUrl string) error {
+	if o.lastAppliedCollectorURL == otelCollectorUrl {
+		return nil
+	}
 	tpOptions, otelExporter, err := GetOTelTracerProviderOptions(otelCollectorUrl)
 	if err != nil {
 		return err
@@ -68,6 +73,7 @@ func (o *otelConfig) InitOtelCollector(otelCollectorUrl string) error {
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 	o.OtelExporter = &otelExporter
 	o.cleanTracers()
+	o.lastAppliedCollectorURL = otelCollectorUrl
 	logger.Info("Successfully initialized OTel collector")
 	return nil
 }

--- a/operator/controllers/common/otel_utils_test.go
+++ b/operator/controllers/common/otel_utils_test.go
@@ -322,7 +322,7 @@ func Test_otelConfig_InitOtelCollector_ReInitWithDifferentURL(t *testing.T) {
 	require.NotNil(t, tracer)
 	require.Len(t, o.tracers, 1)
 
-	// init with the same URL again
+	// init with a different URL
 	err = o.InitOtelCollector("localhost:9001")
 
 	require.Nil(t, err)

--- a/operator/controllers/common/otel_utils_test.go
+++ b/operator/controllers/common/otel_utils_test.go
@@ -34,6 +34,8 @@ func TestGetOTelTracerProviderOptions(t *testing.T) {
 		}
 	}()
 
+	defer s.Stop()
+
 	type args struct {
 		oTelCollectorUrl string
 	}
@@ -239,4 +241,93 @@ func Test_otelConfig_GetTracer(t *testing.T) {
 	otelConfig.cleanTracers()
 
 	require.Empty(t, otelConfig.tracers)
+}
+
+func Test_otelConfig_InitOtelCollector_ReInitWithSameURL(t *testing.T) {
+
+	listener, err := net.Listen("tcp", ":9000")
+	if err != nil {
+		panic(err)
+	}
+
+	s := grpc.NewServer()
+	go func() {
+		err := s.Serve(listener)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	defer s.Stop()
+
+	o := GetOtelInstance()
+	err = o.InitOtelCollector("localhost:9000")
+
+	require.Nil(t, err)
+
+	require.Equal(t, "localhost:9000", o.lastAppliedCollectorURL)
+
+	tracer := o.GetTracer("my-tracer")
+	require.NotNil(t, tracer)
+	require.Len(t, o.tracers, 1)
+
+	// init with the same URL again
+	err = o.InitOtelCollector("localhost:9000")
+
+	require.Nil(t, err)
+
+	// in this case the init function should NOT have changed any internal state,
+	// i.e. the tracers should NOT have been cleaned up
+	require.Len(t, o.tracers, 1)
+}
+
+func Test_otelConfig_InitOtelCollector_ReInitWithDifferentURL(t *testing.T) {
+
+	listener, err := net.Listen("tcp", ":9000")
+	if err != nil {
+		panic(err)
+	}
+
+	listener2, err := net.Listen("tcp", ":9001")
+	if err != nil {
+		panic(err)
+	}
+
+	s := grpc.NewServer()
+	go func() {
+		err := s.Serve(listener)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	s2 := grpc.NewServer()
+	go func() {
+		err := s2.Serve(listener2)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	defer s.Stop()
+
+	o := GetOtelInstance()
+	err = o.InitOtelCollector("localhost:9000")
+
+	require.Nil(t, err)
+
+	require.Equal(t, "localhost:9000", o.lastAppliedCollectorURL)
+
+	tracer := o.GetTracer("my-tracer")
+	require.NotNil(t, tracer)
+	require.Len(t, o.tracers, 1)
+
+	// init with the same URL again
+	err = o.InitOtelCollector("localhost:9001")
+
+	require.Nil(t, err)
+
+	// in this case the init function should have changed any internal state,
+	// i.e. the tracers should have been cleaned up
+	require.Empty(t, o.tracers)
 }

--- a/operator/controllers/options/keptnconfig_controller.go
+++ b/operator/controllers/options/keptnconfig_controller.go
@@ -76,12 +76,9 @@ func (r *KeptnConfigReconciler) reconcileOtelCollectorUrl(config *optionsv1alpha
 	r.Log.Info(fmt.Sprintf("reconciling Keptn Config: %s", config.Name))
 	otelConfig := controllercommon.GetOtelInstance()
 
-	// collector URL changed, so we need to re-initialize the exporter
-	if r.LastAppliedSpec.OTelCollectorUrl != config.Spec.OTelCollectorUrl {
-		if err := otelConfig.InitOtelCollector(config.Spec.OTelCollectorUrl); err != nil {
-			r.Log.Error(err, "unable to initialize OTel tracer options")
-			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
-		}
+	if err := otelConfig.InitOtelCollector(config.Spec.OTelCollectorUrl); err != nil {
+		r.Log.Error(err, "unable to initialize OTel tracer options")
+		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
 	}
 	return ctrl.Result{}, nil
 }

--- a/operator/controllers/options/keptnconfig_controller_test.go
+++ b/operator/controllers/options/keptnconfig_controller_test.go
@@ -198,9 +198,6 @@ func TestKeptnConfigReconciler_reconcileOtelCollectorUrl(t *testing.T) {
 				Client: nil,
 				Scheme: nil,
 				Log:    ctrl.Log.WithName("test-keptn-config-controller"),
-				LastAppliedSpec: &optionsv1alpha1.KeptnConfigSpec{
-					OTelCollectorUrl: "some-url",
-				},
 			},
 			args: args{
 				config: &optionsv1alpha1.KeptnConfig{
@@ -208,7 +205,7 @@ func TestKeptnConfigReconciler_reconcileOtelCollectorUrl(t *testing.T) {
 						Name: "test-config",
 					},
 					Spec: optionsv1alpha1.KeptnConfigSpec{
-						OTelCollectorUrl: "some-url",
+						OTelCollectorUrl: "",
 					},
 				},
 			},


### PR DESCRIPTION
Closes #1261

With these changes the traces should be exported correctly again:

![Screenshot 2023-04-20 at 16 53 59](https://user-images.githubusercontent.com/2143586/233408051-457e771c-165e-419e-ac60-ab7d0e5687c0.png)
