### PR TITLE
feat: improve API reference generation script with path extension

### DIFF
--- a/.github/scripts/generate-crd-docs/generate-crd-docs.sh
+++ b/.github/scripts/generate-crd-docs/generate-crd-docs.sh
@@ -15,6 +15,7 @@ METRICS_API_ROOT='metrics-operator/api/'
 TEMPLATE_DIR='.github/scripts/generate-crd-docs/templates'
 RENDERER='markdown'
 RENDERER_CONFIG_FILE='.github/scripts/generate-crd-docs/crd-docs-generator-config.yaml'
+PATH=$PATH:$(go env GOPATH)/bin
 
 echo "Checking if code generator tool is installed..."
 if ! test -s crd-ref-docs; then


### PR DESCRIPTION
As the crd-ref relies on the GOPATH to be part of PATH, we will add this in the script, as not everyone might have this setup properly.