### PR TITLE
docs: expanded code snippet on the apps page

### DIFF
--- a/docs/content/en/docs/concepts/apps/_index.md
+++ b/docs/content/en/docs/concepts/apps/_index.md
@@ -27,7 +27,7 @@ spec:
   # The following are optional
   preDeploymentTasks:
   - pre-deployment-hello
-  preDeploymentEvaluations:    
+  preDeploymentEvaluations:
   - my-pre-deploy-evaluation
   postDeploymentTasks:
   - post-deployment-hello

--- a/docs/content/en/docs/concepts/apps/_index.md
+++ b/docs/content/en/docs/concepts/apps/_index.md
@@ -24,10 +24,15 @@ spec:
     version: 0.1.0
   - name: podtato-head-left-leg
     version: 1.2.3
+  # The following are optional
+  preDeploymentTasks:
+  - pre-deployment-hello
+  preDeploymentEvaluations:    
+  - my-pre-deploy-evaluation
   postDeploymentTasks:
   - post-deployment-hello
-  preDeploymentEvaluations:    
-  - my-prometheus-definition
+  postDeploymentEvaluations:
+  - my-post-deploy-evaluation
 ```
 
 While changes in the workload version will affect only workload checks, a change in the app version will also cause a


### PR DESCRIPTION
Fixes #1310 

Expanded code snippet on the [Apps Page](https://lifecycle.keptn.sh/docs/concepts/apps/) to: 

```
apiVersion: lifecycle.keptn.sh/v1alpha2
kind: KeptnApp
metadata:
  name: podtato-head
  namespace: podtato-kubectl
spec:
  version: "1.3"
  workloads:
  - name: podtato-head-left-arm
    version: 0.1.0
  - name: podtato-head-left-leg
    version: 1.2.3
  # The following are optional
  preDeploymentTasks:
  - pre-deployment-hello
  preDeploymentEvaluations:    
  - my-pre-deploy-evaluation
  postDeploymentTasks:
  - post-deployment-hello
  postDeploymentEvaluations:
  - my-post-deploy-evaluation
```