### PR TITLE
docs: add heading and fix CR name

### DIFF
--- a/docs/content/en/docs/concepts/metrics/_index.md
+++ b/docs/content/en/docs/concepts/metrics/_index.md
@@ -44,7 +44,9 @@ spec:
   targetServer: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
 ```
 
-As you can see, the provider type is set to `prometheus`, which is one of the currently supported `KeptnMetricProviders`.
+### Keptn Metrics Provider
+
+As you can see, the provider type is set to `prometheus`, which is one of the currently supported `KeptnMetricsProvider`.
 By using different names for different providers of the same type, you can fetch metrics from multiple
 provider instances at the same time.
 


### PR DESCRIPTION
This PR:

- Adds a heading for `Keptn Metrics Provider`
- Fixes CR name from `KeptnMetricProviders` to `KeptnMetricsProvider` for clarity
- Fixes #1315
Signed-off-by: Adam Gardner <adam@agardner.net>