### PR TITLE
feat(operator): add information about evaluation target in status

### DIFF
--- a/operator/controllers/lifecycle/keptnevaluation/controller.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller.go
@@ -217,6 +217,7 @@ func (r *KeptnEvaluationReconciler) evaluateObjective(ctx context.Context, evalu
 		statusItem.Message = err.Error()
 		r.Log.Error(err, "Could not check objective result")
 	} else {
+		// if there is no error, we set the message depending on if the value passed the objective, or not
 		if check {
 			statusItem.Status = apicommon.StateSucceeded
 			statusItem.Message = fmt.Sprintf("value '%s' met objective '%s'", value, objective.EvaluationTarget)

--- a/operator/controllers/lifecycle/keptnevaluation/controller.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller.go
@@ -216,12 +216,13 @@ func (r *KeptnEvaluationReconciler) evaluateObjective(ctx context.Context, evalu
 	if err != nil {
 		statusItem.Message = err.Error()
 		r.Log.Error(err, "Could not check objective result")
-	}
-	if check {
-		statusItem.Status = apicommon.StateSucceeded
-		statusItem.Message = fmt.Sprintf("value '%s' met objective '%s'", value, objective.EvaluationTarget)
 	} else {
-		statusItem.Message = fmt.Sprintf("value '%s' did not meet objective '%s'", value, objective.EvaluationTarget)
+		if check {
+			statusItem.Status = apicommon.StateSucceeded
+			statusItem.Message = fmt.Sprintf("value '%s' met objective '%s'", value, objective.EvaluationTarget)
+		} else {
+			statusItem.Message = fmt.Sprintf("value '%s' did not meet objective '%s'", value, objective.EvaluationTarget)
+		}
 	}
 	statusSummary = apicommon.UpdateStatusSummary(statusItem.Status, statusSummary)
 	newStatus[objective.KeptnMetricRef.Name] = *statusItem

--- a/operator/controllers/lifecycle/keptnevaluation/controller_test.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package keptnevaluation
 
 import (

--- a/operator/controllers/lifecycle/keptnevaluation/controller_test.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller_test.go
@@ -2,6 +2,8 @@ package keptnevaluation
 
 import (
 	"context"
+	"testing"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
@@ -20,7 +22,6 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 const KltNamespace = "klt-namespace"

--- a/operator/controllers/lifecycle/keptnevaluation/controller_test.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller_test.go
@@ -2,16 +2,25 @@ package keptnevaluation
 
 import (
 	"context"
-	"testing"
-
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha2"
 	klcv1alpha3 "github.com/keptn/lifecycle-toolkit/operator/apis/lifecycle/v1alpha3"
+	"github.com/keptn/lifecycle-toolkit/operator/apis/lifecycle/v1alpha3/common"
+	controllercommon "github.com/keptn/lifecycle-toolkit/operator/controllers/common"
 	"github.com/keptn/lifecycle-toolkit/operator/controllers/common/fake"
 	"github.com/keptn/lifecycle-toolkit/operator/controllers/common/providers"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
 )
 
 const KltNamespace = "klt-namespace"
@@ -121,4 +130,176 @@ func setupProviders() (*metricsapi.KeptnMetricsProvider, *metricsapi.KeptnMetric
 	}
 
 	return DTProv, PromProv
+}
+
+func TestKeptnEvaluationReconciler_Reconcile_FailEvaluation(t *testing.T) {
+
+	const namespace = "my-namespace"
+	metric := &metricsapi.KeptnMetric{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-metric",
+			Namespace: namespace,
+		},
+		Status: metricsapi.KeptnMetricStatus{
+			Value: "10",
+		},
+	}
+
+	evaluationDefinition := &klcv1alpha3.KeptnEvaluationDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-definition",
+			Namespace: namespace,
+		},
+		Spec: klcv1alpha3.KeptnEvaluationDefinitionSpec{
+			Objectives: []klcv1alpha3.Objective{
+				{
+					KeptnMetricRef: klcv1alpha3.KeptnMetricReference{
+						Name:      metric.Name,
+						Namespace: namespace,
+					},
+					EvaluationTarget: "<5",
+				},
+			},
+		},
+	}
+
+	evaluation := &klcv1alpha3.KeptnEvaluation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-evaluation",
+			Namespace: namespace,
+		},
+		Spec: klcv1alpha3.KeptnEvaluationSpec{
+			EvaluationDefinition: evaluationDefinition.Name,
+			Retries:              1,
+		},
+	}
+
+	reconciler, fakeClient := setupReconcilerAndClient(t, metric, evaluationDefinition, evaluation)
+
+	request := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      evaluation.Name,
+		},
+	}
+
+	reconcile, err := reconciler.Reconcile(context.TODO(), request)
+
+	require.Nil(t, err)
+	require.True(t, reconcile.Requeue)
+
+	updatedEvaluation := &klcv1alpha3.KeptnEvaluation{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      evaluation.Name,
+	}, updatedEvaluation)
+
+	require.Nil(t, err)
+
+	require.Equal(t, common.StateFailed, updatedEvaluation.Status.EvaluationStatus[metric.Name].Status)
+	require.Equal(t, "value '10' did not meet objective '<5'", updatedEvaluation.Status.EvaluationStatus[metric.Name].Message)
+}
+
+func TestKeptnEvaluationReconciler_Reconcile_SucceedEvaluation(t *testing.T) {
+
+	const namespace = "my-namespace"
+	metric := &metricsapi.KeptnMetric{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-metric",
+			Namespace: namespace,
+		},
+		Status: metricsapi.KeptnMetricStatus{
+			Value: "10",
+		},
+	}
+
+	evaluationDefinition := &klcv1alpha3.KeptnEvaluationDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-definition",
+			Namespace: namespace,
+		},
+		Spec: klcv1alpha3.KeptnEvaluationDefinitionSpec{
+			Objectives: []klcv1alpha3.Objective{
+				{
+					KeptnMetricRef: klcv1alpha3.KeptnMetricReference{
+						Name:      metric.Name,
+						Namespace: namespace,
+					},
+					EvaluationTarget: "<11",
+				},
+			},
+		},
+	}
+
+	evaluation := &klcv1alpha3.KeptnEvaluation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-evaluation",
+			Namespace: namespace,
+		},
+		Spec: klcv1alpha3.KeptnEvaluationSpec{
+			EvaluationDefinition: evaluationDefinition.Name,
+			Retries:              1,
+		},
+	}
+
+	reconciler, fakeClient := setupReconcilerAndClient(t, metric, evaluationDefinition, evaluation)
+
+	request := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: namespace,
+			Name:      evaluation.Name,
+		},
+	}
+
+	reconcile, err := reconciler.Reconcile(context.TODO(), request)
+
+	require.Nil(t, err)
+	require.False(t, reconcile.Requeue)
+
+	updatedEvaluation := &klcv1alpha3.KeptnEvaluation{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      evaluation.Name,
+	}, updatedEvaluation)
+
+	require.Nil(t, err)
+
+	require.Equal(t, common.StateSucceeded, updatedEvaluation.Status.EvaluationStatus[metric.Name].Status)
+	require.Equal(t, "value '10' met objective '<11'", updatedEvaluation.Status.EvaluationStatus[metric.Name].Message)
+}
+
+func setupReconcilerAndClient(t *testing.T, objects ...client.Object) (*KeptnEvaluationReconciler, client.Client) {
+	scheme := runtime.NewScheme()
+
+	err := klcv1alpha3.AddToScheme(scheme)
+	require.Nil(t, err)
+
+	err = metricsapi.AddToScheme(scheme)
+	require.Nil(t, err)
+
+	// fake a tracer
+	tr := &fake.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+		return ctx, trace.SpanFromContext(ctx)
+	}}
+
+	tf := &fake.TracerFactoryMock{GetTracerFunc: func(name string) trace.Tracer {
+		return tr
+	}}
+
+	recorder := record.NewFakeRecorder(100)
+
+	fakeClient := k8sfake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	provider := metric.NewMeterProvider()
+	meter := provider.Meter("keptn/task")
+
+	r := &KeptnEvaluationReconciler{
+		Client:        fakeClient,
+		Scheme:        fakeClient.Scheme(),
+		Log:           logr.Logger{},
+		Recorder:      recorder,
+		Meters:        controllercommon.SetUpKeptnTaskMeters(meter),
+		TracerFactory: tf,
+	}
+	return r, fakeClient
 }

--- a/operator/test/component/evaluation/evaluation_test.go
+++ b/operator/test/component/evaluation/evaluation_test.go
@@ -97,8 +97,9 @@ var _ = Describe("Evaluation", Ordered, func() {
 					g.Expect(evaluation2.Status.OverallStatus).To(Equal(apicommon.StateSucceeded))
 					g.Expect(evaluation2.Status.EvaluationStatus).To(Equal(map[string]klcv1alpha3.EvaluationStatusItem{
 						metricName: {
-							Value:  "5",
-							Status: apicommon.StateSucceeded,
+							Value:   "5",
+							Status:  apicommon.StateSucceeded,
+							Message: "value '5' met objective '<10'",
 						},
 					}))
 				}, "30s").Should(Succeed())


### PR DESCRIPTION
Closes #1339 

This PR adds the reason for a failing evaluation in the `status.message` field of the evaluation CR.
As a result, the reason will also be properly displayed in the trace event - see screenshot below

![Screenshot 2023-05-02 at 14 22 27](https://user-images.githubusercontent.com/2143586/235665026-91d435f1-f47f-4fc6-96cb-6201e8158986.png)
