### PR TITLE
chore: release-please updates Helm value.yaml

### DIFF
--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -15,7 +15,7 @@ certificateOperator:
       labelSelectorValue: "true"
     image:
       repository: ghcr.keptn.sh/keptn/certificate-operator
-      tag: v0.7.0
+      tag: v0.7.0  # x-release-please-version
     imagePullPolicy: Always
     livenessProbe:
       httpGet:
@@ -67,7 +67,7 @@ lifecycleOperator:
       seccompProfile:
         type: RuntimeDefault
     env:
-      functionRunnerImage: ghcr.keptn.sh/keptn/functions-runtime:v0.7.0
+      functionRunnerImage: ghcr.keptn.sh/keptn/functions-runtime:v0.7.0  # x-release-please-version
       keptnAppControllerLogLevel: "0"
       keptnAppCreationRequestControllerLogLevel: "0"
       keptnAppVersionControllerLogLevel: "0"
@@ -80,7 +80,7 @@ lifecycleOperator:
       otelCollectorUrl: otel-collector:4317
     image:
       repository: ghcr.keptn.sh/keptn/lifecycle-operator
-      tag: v0.7.0
+      tag: v0.7.0 # x-release-please-version
     imagePullPolicy: Always
     livenessProbe:
       httpGet:
@@ -147,7 +147,7 @@ metricsOperator:
       metricsControllerLogLevel: "0"
     image:
       repository: ghcr.keptn.sh/keptn/metrics-operator
-      tag: v0.7.0
+      tag: v0.7.0  # x-release-please-version
     livenessProbe:
       httpGet:
         path: /healthz
@@ -210,7 +210,7 @@ scheduler:
       otelCollectorUrl: otel-collector:4317
     image:
       repository: ghcr.keptn.sh/keptn/scheduler
-      tag: v0.7.0
+      tag: v0.7.0  # x-release-please-version
     imagePullPolicy: Always
     livenessProbe:
       httpGet:


### PR DESCRIPTION
Without this, the release of the Helm chart won't have the latest tags. 