### PR TITLE
docs: improve headline of Getting Started subsection

### DIFF
--- a/docs/content/en/docs/getting-started/orchestrate/_index.md
+++ b/docs/content/en/docs/getting-started/orchestrate/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Lifecycle Toolkit
+title: Orchestrate deployment checks
 description: Learn how the Keptn Lifecycle Toolkit can orchestrate deployment checks.
 weight: 55
 ---


### PR DESCRIPTION
The headline in the getting started section has a wrong caption 