### PR TITLE
docs: mention Prometheus in intro

### DIFF
--- a/docs/content/en/docs/getting-started/metrics/_index.md
+++ b/docs/content/en/docs/getting-started/metrics/_index.md
@@ -6,7 +6,8 @@ weight: 25
 
 The Keptn metrics component of the Keptn Lifecycle Toolkit
 allow you to define any type of metric
-from multiple instances of any type of data source in your Kubernetes cluster.
+from multiple instances
+of any type of data source in your Kubernetes cluster.
 You may have deployment tools like Argo, Flux, KEDA, HPA, or Keptn
 that need observability data to make automated decisions
 such as whether a rollout is good, whether to scale up or down.

--- a/docs/content/en/docs/getting-started/metrics/_index.md
+++ b/docs/content/en/docs/getting-started/metrics/_index.md
@@ -7,16 +7,17 @@ weight: 25
 The Keptn metrics component of the Keptn Lifecycle Toolkit
 allow you to define any type of metric
 from multiple instances of any type of data source in your Kubernetes cluster.
-You may have tools like Argo, Flux, KEDA, HPA, or Keptn
-that need observability data to make automated decisions.
-Whether a rollout is good, whether to scale up or down.
+You may have deployment tools like Argo, Flux, KEDA, HPA, or Keptn
+that need observability data to make automated decisions
+such as whether a rollout is good, whether to scale up or down.
 Your observability data may come
 from multiple observability solutions --
-Datadog, Dynatrace, Lightstep, Honeycomb, Splunk,
+Prometheus, Dynatrace, Datadog and others --
 or data directly from your cloud provider such as AWS, Google, or Azure.
 
-The Keptn Lifecycle Toolkit hooks directly into Kubernetes primitives
-so minimal configuration is required.
+The Keptn Metrics Server unifies and standardizes access to all this data.
+Minimal configuration is required
+because the Keptn Lifecycle Toolkit hooks directly into Kubernetes primitives.
 
 The
 [Kubernetes metric server](https://github.com/kubernetes-sigs/metrics-server)
@@ -26,7 +27,6 @@ Each has plugins but it is difficult to maintain them,
 especially if you are using multiple tools,
 and multible observability platforms,
 and multiple instance of some tools or observability platforms.
-The Keptn Metrics Server unifies and standardizes access to this data.
 
 ## Using this exercise
 


### PR DESCRIPTION
@agardnerIT commented:

Nitpicking but: Datadog, Dynatrace, Lightstep, Honeycomb, Splunk
1) missing Prometheus
2) it should be alphabetical OR we are subtly suggesting that datadog is better than DT.
3) (My opinion) but we shouldn’t give free promotion. If the vendors want their name listed here, they should write a provider. By giving this list, we’re putting Honeycomb on the same footing at DT.

This PR:
* Adds Prometheus to the list of data providers and arranges them in the order they were implemented for KLT
* Replaced the names of other data providers with "and others"
* Tweaked the prose a bit for better flow