### PR TITLE
fix(metrics-operator): introduce IsStatusSet method to KeptnMetric

### DIFF
--- a/metrics-operator/api/v1alpha3/keptnmetric_types.go
+++ b/metrics-operator/api/v1alpha3/keptnmetric_types.go
@@ -79,3 +79,7 @@ type KeptnMetricList struct {
 func init() {
 	SchemeBuilder.Register(&KeptnMetric{}, &KeptnMetricList{})
 }
+
+func (s *KeptnMetric) IsStatusSet() bool {
+	return s.Status.Value != ""
+}

--- a/metrics-operator/api/v1alpha3/keptnmetric_types_test.go
+++ b/metrics-operator/api/v1alpha3/keptnmetric_types_test.go
@@ -1,0 +1,53 @@
+package v1alpha3
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKeptnMetric_IsStatusSet(t *testing.T) {
+	type fields struct {
+		TypeMeta   v1.TypeMeta
+		ObjectMeta v1.ObjectMeta
+		Spec       KeptnMetricSpec
+		Status     KeptnMetricStatus
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "No value set",
+			fields: fields{
+				Status: KeptnMetricStatus{
+					Value: "",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "we have a value",
+			fields: fields{
+				Status: KeptnMetricStatus{
+					Value: "1.0",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &KeptnMetric{
+				TypeMeta:   tt.fields.TypeMeta,
+				ObjectMeta: tt.fields.ObjectMeta,
+				Spec:       tt.fields.Spec,
+				Status:     tt.fields.Status,
+			}
+			if got := s.IsStatusSet(); got != tt.want {
+				t.Errorf("IsStatusSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The introduced method was removed by this PR https://github.com/keptn/lifecycle-toolkit/commit/3c465d07044b0317cbb6e462004dff9cf8f1d533#diff-62dbadcf91fc4f2b7cb287a2251c530635223016577a548b21fcf6eda8291137L134

but it's used by the klt-operator here https://github.com/keptn/lifecycle-toolkit/blob/main/operator/controllers/common/providers/keptnmetric/keptnmetric.go#L27