### PR TITLE
docs: fix link to v1 docs

### DIFF
--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -38,5 +38,5 @@ menu:
     - name: Keptn v1
       params:
         rel: external
-      url: https://keptn.sh/
+      url: https://v1.keptn.sh/
       weight: 1


### PR DESCRIPTION
backport of https://github.com/keptn/lifecycle-toolkit/pull/1461