### PR TITLE
fix(metrics-operator): improve error handling in metrics providers

### DIFF
--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -65,7 +65,13 @@ func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metrics
 	err = json.Unmarshal(b, &result)
 	if err != nil {
 		d.Log.Error(err, "Error while parsing response")
-		return "", nil, err
+		return "", b, err
+	}
+
+	if result.Error != nil {
+		err = fmt.Errorf("%s", *result.Error)
+		d.Log.Error(err, "Error from provider")
+		return "", b, err
 	}
 
 	if len(result.Series) == 0 {
@@ -76,7 +82,7 @@ func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metrics
 	points := (result.Series)[0].Pointlist
 	if len(points) == 0 {
 		d.Log.Info("No metric points in query result")
-		return "", nil, fmt.Errorf("no metric points in query result")
+		return "", b, fmt.Errorf("no metric points in query result")
 	}
 
 	r := d.getSingleValue(points)

--- a/metrics-operator/controllers/common/providers/datadog/datadog.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog.go
@@ -70,7 +70,7 @@ func (d *KeptnDataDogProvider) EvaluateQuery(ctx context.Context, metric metrics
 
 	if result.Error != nil {
 		err = fmt.Errorf("%s", *result.Error)
-		d.Log.Error(err, "Error from provider")
+		d.Log.Error(err, "Error from DataDog provider")
 		return "", b, err
 	}
 

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 )
 
 const ddErrorPayload = "{\"error\":\"Token is missing required scope\"}"

--- a/metrics-operator/controllers/common/providers/datadog/datadog_test.go
+++ b/metrics-operator/controllers/common/providers/datadog/datadog_test.go
@@ -18,10 +18,59 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 )
 
+const ddErrorPayload = "{\"error\":\"Token is missing required scope\"}"
 const ddPayload = "{\"from_date\":1677736306000,\"group_by\":[],\"message\":\"\",\"query\":\"system.cpu.idle{*}\",\"res_type\":\"time_series\",\"series\":[{\"aggr\":null,\"display_name\":\"system.cpu.idle\",\"end\":1677821999000,\"expression\":\"system.cpu.idle{*}\",\"interval\":300,\"length\":7,\"metric\":\"system.cpu.idle\",\"pointlist\":[[1677781200000,92.37997436523438],[1677781500000,91.46615447998047],[1677781800000,92.05865631103515],[1677782100000,97.49858474731445],[1677782400000,95.95263163248698],[1677821400000,69.67094268798829],[1677821700000,84.78184509277344]],\"query_index\":0,\"scope\":\"*\",\"start\":1677781200000,\"tag_set\":[],\"unit\":[{\"family\":\"percentage\",\"name\":\"percent\",\"plural\":\"percent\",\"scale_factor\":1,\"short_name\":\"%\"},{}]}],\"status\":\"ok\",\"to_date\":1677822706000}"
 const ddEmptyPayload = "{\"from_date\":1677736306000,\"group_by\":[],\"message\":\"\",\"query\":\"system.cpu.idle{*}\",\"res_type\":\"time_series\",\"series\":[],\"status\":\"ok\",\"to_date\":1677822706000}"
+
+func TestEvaluateQuery_APIError(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(ddErrorPayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	secretName := "datadogSecret"
+	apiKey, apiKeyValue := "DD_CLIENT_API_KEY", "fake-api-key"
+	appKey, appKeyValue := "DD_CLIENT_APP_KEY", "fake-app-key"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			apiKey: []byte(apiKeyValue),
+			appKey: []byte(appKeyValue),
+		},
+	}
+	kdd := setupTest(apiToken)
+	metric := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "system.cpu.idle{*}",
+		},
+	}
+	b := true
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Optional: &b,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+
+	r, raw, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	require.Error(t, e)
+	require.Contains(t, e.Error(), "Token is missing required scope")
+	require.Equal(t, []byte(ddErrorPayload), raw)
+	require.Empty(t, r)
+}
 
 func TestEvaluateQuery_HappyPath(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,13 +92,7 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 			appKey: []byte(appKeyValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
-
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest(apiToken)
 	metric := metricsapi.KeptnMetric{
 		Spec: metricsapi.KeptnMetricSpec{
 			Query: "system.cpu.idle{*}",
@@ -93,13 +136,7 @@ func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
 			appKey: []byte(appKeyValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
-
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest(apiToken)
 	metric := metricsapi.KeptnMetric{
 		Spec: metricsapi.KeptnMetricSpec{
 			Query: "system.cpu.idle{*}",
@@ -120,7 +157,7 @@ func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
 
 	r, raw, e := kdd.EvaluateQuery(context.TODO(), metric, p)
 	require.Equal(t, "", r)
-	require.Equal(t, []byte(nil), raw)
+	require.Equal(t, []byte("garbage"), raw)
 	require.NotNil(t, e)
 }
 func TestEvaluateQuery_MissingSecret(t *testing.T) {
@@ -130,13 +167,7 @@ func TestEvaluateQuery_MissingSecret(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	fakeClient := fake.NewClient()
-
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest()
 	metric := metricsapi.KeptnMetric{
 		Spec: metricsapi.KeptnMetricSpec{
 			Query: "system.cpu.idle{*}",
@@ -159,14 +190,9 @@ func TestEvaluateQuery_SecretNotFound(t *testing.T) {
 	}))
 	defer svr.Close()
 
-	fakeClient := fake.NewClient()
 	secretName := "datadogSecret"
 
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest()
 	metric := metricsapi.KeptnMetric{
 		Spec: metricsapi.KeptnMetricSpec{
 			Query: "system.cpu.idle{*}",
@@ -207,13 +233,7 @@ func TestEvaluateQuery_RefNonExistingKey(t *testing.T) {
 			apiKey: []byte(apiKeyValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
-
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest(apiToken)
 	metric := metricsapi.KeptnMetric{
 		Spec: metricsapi.KeptnMetricSpec{
 			Query: "system.cpu.idle{*}",
@@ -256,13 +276,7 @@ func TestEvaluateQuery_EmptyPayload(t *testing.T) {
 			appKey: []byte(appKeyValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
-
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest(apiToken)
 	metric := metricsapi.KeptnMetric{
 		Spec: metricsapi.KeptnMetricSpec{
 			Query: "system.cpu.idle{*}",
@@ -282,30 +296,22 @@ func TestEvaluateQuery_EmptyPayload(t *testing.T) {
 	}
 
 	r, raw, e := kdd.EvaluateQuery(context.TODO(), metric, p)
+	t.Log(string(raw))
 	require.Nil(t, raw)
 	require.Equal(t, "", r)
 	require.True(t, strings.Contains(e.Error(), "no values in query result"))
 
 }
 func TestGetSingleValue_EmptyPoints(t *testing.T) {
-	fakeClient := fake.NewClient()
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+	kdd := setupTest()
 	var points [][]*float64
 	value := kdd.getSingleValue(points)
 
 	require.Zero(t, value)
 }
 func TestGetSingleValue_HappyPath(t *testing.T) {
-	fakeClient := fake.NewClient()
-	kdd := KeptnDataDogProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
+
+	kdd := setupTest()
 	result := datadogV1.MetricsQueryResponse{}
 	_ = json.Unmarshal([]byte(ddPayload), &result)
 	points := (result.Series)[0].Pointlist
@@ -313,4 +319,16 @@ func TestGetSingleValue_HappyPath(t *testing.T) {
 
 	require.NotZero(t, value)
 	require.Equal(t, 89.11554133097331, value)
+}
+
+func setupTest(objs ...client.Object) KeptnDataDogProvider {
+
+	fakeClient := fake.NewClient(objs...)
+
+	kdd := KeptnDataDogProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	return kdd
 }

--- a/metrics-operator/controllers/common/providers/dynatrace/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common.go
@@ -15,7 +15,7 @@ var ErrSecretKeyRefNotDefined = errors.New("the SecretKeyRef property with the D
 var ErrInvalidResult = errors.New("the answer does not contain any data")
 var ErrDQLQueryTimeout = errors.New("timed out waiting for result of DQL query")
 
-const ErrAPI = "provider api response: %s"
+const ErrAPIMsg = "provider api response: %s"
 
 type Error struct {
 	Code    int    `json:"-"` // optional

--- a/metrics-operator/controllers/common/providers/dynatrace/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common.go
@@ -15,6 +15,13 @@ var ErrSecretKeyRefNotDefined = errors.New("the SecretKeyRef property with the D
 var ErrInvalidResult = errors.New("the answer does not contain any data")
 var ErrDQLQueryTimeout = errors.New("timed out waiting for result of DQL query")
 
+const ErrAPI = "provider api response: %s"
+
+type Error struct {
+	Code    int    `json:"-"` // optional
+	Message string `json:"message"`
+}
+
 func getDTSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) (string, error) {
 	if !provider.HasSecretDefined() {
 		return "", ErrSecretKeyRefNotDefined

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"time"
@@ -41,7 +42,7 @@ type DynatraceData struct {
 // EvaluateQuery fetches the SLI values from dynatrace provider
 func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metricsapi.KeptnMetric, provider metricsapi.KeptnMetricsProvider) (string, []byte, error) {
 	baseURL := d.normalizeAPIURL(provider.Spec.TargetServer)
-	query := trimQuery(metric.Spec.Query)
+	query := url.QueryEscape(metric.Spec.Query)
 	qURL := baseURL + "v2/metrics/query?metricSelector=" + query
 
 	d.Log.Info("Running query: " + qURL)
@@ -87,12 +88,6 @@ func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metri
 	}
 	r := fmt.Sprintf("%f", d.getSingleValue(result))
 	return r, b, nil
-}
-
-func trimQuery(query string) string {
-	str := strings.ReplaceAll(query, " ", "")
-	str = strings.ReplaceAll(str, "\r", "")
-	return strings.ReplaceAll(str, "\n", "")
 }
 
 func (d *KeptnDynatraceProvider) normalizeAPIURL(url string) string {

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ type DynatraceResponse struct {
 	TotalCount int               `json:"totalCount"`
 	Resolution string            `json:"resolution"`
 	Result     []DynatraceResult `json:"result"`
+	Error      `json:"error"`
 }
 
 type DynatraceResult struct {
@@ -39,7 +41,8 @@ type DynatraceData struct {
 // EvaluateQuery fetches the SLI values from dynatrace provider
 func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metricsapi.KeptnMetric, provider metricsapi.KeptnMetricsProvider) (string, []byte, error) {
 	baseURL := d.normalizeAPIURL(provider.Spec.TargetServer)
-	qURL := baseURL + "v2/metrics/query?metricSelector=" + metric.Spec.Query
+	query := trimQuery(metric.Spec.Query)
+	qURL := baseURL + "v2/metrics/query?metricSelector=" + query
 
 	d.Log.Info("Running query: " + qURL)
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
@@ -57,6 +60,7 @@ func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metri
 
 	req.Header.Set("Authorization", "Api-Token "+token)
 	res, err := d.HttpClient.Do(req)
+
 	if err != nil {
 		d.Log.Error(err, "Error while creating request")
 		return "", nil, err
@@ -74,11 +78,21 @@ func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metri
 	err = json.Unmarshal(b, &result)
 	if err != nil {
 		d.Log.Error(err, "Error while parsing response")
-		return "", nil, err
+		return "", b, err
 	}
-
+	if !reflect.DeepEqual(result.Error, Error{}) {
+		err = fmt.Errorf(ErrAPI, result.Error.Message)
+		d.Log.Error(err, "Error from provider")
+		return "", b, err
+	}
 	r := fmt.Sprintf("%f", d.getSingleValue(result))
 	return r, b, nil
+}
+
+func trimQuery(query string) string {
+	str := strings.ReplaceAll(query, " ", "")
+	str = strings.ReplaceAll(str, "\r", "")
+	return strings.ReplaceAll(str, "\n", "")
 }
 
 func (d *KeptnDynatraceProvider) normalizeAPIURL(url string) string {

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -82,7 +82,7 @@ func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metri
 	}
 	if !reflect.DeepEqual(result.Error, Error{}) {
 		err = fmt.Errorf(ErrAPI, result.Error.Message)
-		d.Log.Error(err, "Error from provider")
+		d.Log.Error(err, "Error from Dynatrace provider")
 		return "", b, err
 	}
 	r := fmt.Sprintf("%f", d.getSingleValue(result))

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -81,7 +81,7 @@ func (d *KeptnDynatraceProvider) EvaluateQuery(ctx context.Context, metric metri
 		return "", b, err
 	}
 	if !reflect.DeepEqual(result.Error, Error{}) {
-		err = fmt.Errorf(ErrAPI, result.Error.Message)
+		err = fmt.Errorf(ErrAPIMsg, result.Error.Message)
 		d.Log.Error(err, "Error from Dynatrace provider")
 		return "", b, err
 	}

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
@@ -200,7 +200,7 @@ func (d *keptnDynatraceDQLProvider) retrieveDQLResults(ctx context.Context, hand
 	}
 
 	if !reflect.DeepEqual(result.Error, Error{}) {
-		err = fmt.Errorf(ErrAPI, result.Error.Message)
+		err = fmt.Errorf(ErrAPIMsg, result.Error.Message)
 		d.log.Error(err, "Error from Dynatrace DQL provider")
 		return nil, err
 	}

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
@@ -201,7 +201,7 @@ func (d *keptnDynatraceDQLProvider) retrieveDQLResults(ctx context.Context, hand
 
 	if !reflect.DeepEqual(result.Error, Error{}) {
 		err = fmt.Errorf(ErrAPI, result.Error.Message)
-		d.log.Error(err, "Error from provider")
+		d.log.Error(err, "Error from Dynatrace DQL provider")
 		return nil, err
 	}
 	return result, nil

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
@@ -24,8 +24,11 @@ const dqlRequestHandler = `{"requestToken": "my-token"}`
 
 const dqlPayload = "{\"state\":\"SUCCEEDED\",\"result\":{\"records\":[{\"value\":{\"count\":1,\"sum\":36.50,\"min\":36.50,\"avg\":36.50,\"max\":36.50},\"metric.key\":\"dt.containers.cpu.usage_user_milli_cores\",\"timeframe\":{\"start\":\"2023-01-31T09:11:00.000Z\",\"end\":\"2023-01-31T09:12:00.`00Z\"},\"Container\":\"frontend\",\"host.name\":\"default-pool-349eb8c6-gccf\",\"k8s.namespace.name\":\"hipstershop\",\"k8s.pod.uid\":\"632df64d-474c-4410-968d-666f639ad358\"}],\"types\":[{\"mappings\":{\"value\":{\"type\":\"summary_stats\"},\"metric.key\":{\"type\":\"string\"},\"timeframe\":{\"type\":\"timeframe\"},\"Container\":{\"type\":\"string\"},\"host.name\":{\"type\":\"string\"},\"k8s.namespace.name\":{\"type\":\"string\"},\"k8s.pod.uid\":{\"type\":\"string\"}},\"indexRange\":[0,1]}]}}"
 const dqlPayloadNotFinished = "{\"state\":\"\",\"result\":{\"records\":[{\"value\":{\"count\":1,\"sum\":36.50,\"min\":36.78336878333334,\"avg\":36.50,\"max\":36.50},\"metric.key\":\"dt.containers.cpu.usage_user_milli_cores\",\"timeframe\":{\"start\":\"2023-01-31T09:11:00.000Z\",\"end\":\"2023-01-31T09:12:00.`00Z\"},\"Container\":\"frontend\",\"host.name\":\"default-pool-349eb8c6-gccf\",\"k8s.namespace.name\":\"hipstershop\",\"k8s.pod.uid\":\"632df64d-474c-4410-968d-666f639ad358\"}],\"types\":[{\"mappings\":{\"value\":{\"type\":\"summary_stats\"},\"metric.key\":{\"type\":\"string\"},\"timeframe\":{\"type\":\"timeframe\"},\"Container\":{\"type\":\"string\"},\"host.name\":{\"type\":\"string\"},\"k8s.namespace.name\":{\"type\":\"string\"},\"k8s.pod.uid\":{\"type\":\"string\"}},\"indexRange\":[0,1]}]}}"
+const dqlPayloadError = "{\"error\":{\"code\":403,\"message\":\"Token is missing required scope\"}}"
 
 const dqlPayloadTooManyItems = "{\"state\":\"SUCCEEDED\",\"result\":{\"records\":[{\"value\":{\"count\":1,\"sum\":6.293549483333334,\"min\":6.293549483333334,\"avg\":6.293549483333334,\"max\":6.293549483333334},\"metric.key\":\"dt.containers.cpu.usage_user_milli_cores\",\"timeframe\":{\"start\":\"2023-01-31T09:07:00.000Z\",\"end\":\"2023-01-31T09:08:00.000Z\"},\"Container\":\"loginservice\",\"host.name\":\"default-pool-349eb8c6-gccf\",\"k8s.namespace.name\":\"easytrade\",\"k8s.pod.uid\":\"fc084e57-11a0-4a95-b8a0-76191c31d839\"},{\"value\":{\"count\":1,\"sum\":1.0421756,\"min\":1.0421756,\"avg\":1.0421756,\"max\":1.0421756},\"metric.key\":\"dt.containers.cpu.usage_user_milli_cores\",\"timeframe\":{\"start\":\"2023-01-31T09:07:00.000Z\",\"end\":\"2023-01-31T09:08:00.000Z\"},\"Container\":\"frontendreverseproxy\",\"host.name\":\"default-pool-349eb8c6-gccf\",\"k8s.namespace.name\":\"easytrade\",\"k8s.pod.uid\":\"41b5d6e0-98fc-4dce-a1b4-bb269a03d72b\"},{\"value\":{\"count\":1,\"sum\":6.3881383000000005,\"min\":6.3881383000000005,\"avg\":6.3881383000000005,\"max\":6.3881383000000005},\"metric.key\":\"dt.containers.cpu.usage_user_milli_cores\",\"timeframe\":{\"start\":\"2023-01-31T09:07:00.000Z\",\"end\":\"2023-01-31T09:08:00.000Z\"},\"Container\":\"shippingservice\",\"host.name\":\"default-pool-349eb8c6-gccf\",\"k8s.namespace.name\":\"hipstershop\",\"k8s.pod.uid\":\"96fcf9d7-748a-47f7-b1b3-ca6427e20edd\"}],\"types\":[{\"mappings\":{\"value\":{\"type\":\"summary_stats\"},\"metric.key\":{\"type\":\"string\"},\"timeframe\":{\"type\":\"timeframe\"},\"Container\":{\"type\":\"string\"},\"host.name\":{\"type\":\"string\"},\"k8s.namespace.name\":{\"type\":\"string\"},\"k8s.pod.uid\":{\"type\":\"string\"}},\"indexRange\":[0,3]}]}}"
+
+var ErrUnexpected = errors.New("unexpected path")
 
 //nolint:dupl
 func TestGetDQL(t *testing.T) {
@@ -40,8 +43,7 @@ func TestGetDQL(t *testing.T) {
 		if strings.Contains(path, "query:poll") {
 			return []byte(dqlPayload), nil
 		}
-
-		return nil, errors.New("unexpected path")
+		return nil, ErrUnexpected
 	}
 
 	dqlProvider := NewKeptnDynatraceDQLProvider(
@@ -82,7 +84,7 @@ func TestGetDQLMultipleRecords(t *testing.T) {
 			return []byte(dqlPayloadTooManyItems), nil
 		}
 
-		return nil, errors.New("unexpected path")
+		return nil, ErrUnexpected
 	}
 
 	dqlProvider := NewKeptnDynatraceDQLProvider(
@@ -108,6 +110,46 @@ func TestGetDQLMultipleRecords(t *testing.T) {
 	require.Contains(t, mockClient.DoCalls()[1].Path, "query:poll")
 }
 
+func TestGetDQLAPIError(t *testing.T) {
+
+	mockClient := &fake.DTAPIClientMock{}
+
+	mockClient.DoFunc = func(ctx context.Context, path string, method string, payload []byte) ([]byte, error) {
+		if strings.Contains(path, "query:execute") {
+			return []byte(dqlRequestHandler), nil
+		}
+
+		if strings.Contains(path, "query:poll") {
+			return []byte(dqlPayloadError), nil
+		}
+
+		return nil, ErrUnexpected
+	}
+
+	dqlProvider := NewKeptnDynatraceDQLProvider(
+		nil,
+		WithDTAPIClient(mockClient),
+		WithLogger(logr.New(klog.NewKlogr().GetSink())),
+	)
+
+	result, raw, err := dqlProvider.EvaluateQuery(context.TODO(),
+		metricsapi.KeptnMetric{
+			Spec: metricsapi.KeptnMetricSpec{Query: ""},
+		}, metricsapi.KeptnMetricsProvider{
+			Spec: metricsapi.KeptnMetricsProviderSpec{},
+		},
+	)
+
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Token is missing required scope")
+	require.Empty(t, raw)
+	require.Empty(t, result)
+
+	require.Len(t, mockClient.DoCalls(), 2)
+	require.Contains(t, mockClient.DoCalls()[0].Path, "query:execute")
+	require.Contains(t, mockClient.DoCalls()[1].Path, "query:poll")
+}
+
 func TestGetDQLTimeout(t *testing.T) {
 
 	mockClient := &fake.DTAPIClientMock{}
@@ -121,7 +163,7 @@ func TestGetDQLTimeout(t *testing.T) {
 			return []byte(dqlPayloadNotFinished), nil
 		}
 
-		return nil, errors.New("unexpected path")
+		return nil, ErrUnexpected
 	}
 
 	dqlProvider := NewKeptnDynatraceDQLProvider(
@@ -172,7 +214,7 @@ func TestGetDQLCannotPostQuery(t *testing.T) {
 			return nil, errors.New("oops")
 		}
 
-		return nil, errors.New("unexpected path")
+		return nil, ErrUnexpected
 	}
 
 	dqlProvider := NewKeptnDynatraceDQLProvider(

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const dtpayload = "{\"totalCount\":1,\"nextPageKey\":null,\"resolution\":\"1m\",\"result\":[{\"metricId\":\"dsfm:billing.hostunit.assigned:splitBy():sort(value(auto,descending)):avg\",\"dataPointCountRatio\":6.0E-6,\"dimensionCountRatio\":1.0E-5,\"data\":[{\"dimensions\":[],\"dimensionMap\":{},\"timestamps\":[1666090140000,1666090200000,1666090260000,1666090320000,1666090380000,1666090440000,1666090500000,1666090560000,1666090620000,1666090680000,1666090740000,1666090800000,1666090860000,1666090920000,1666090980000,1666091040000,1666091100000,1666091160000,1666091220000,1666091280000,1666091340000,1666091400000,1666091460000,1666091520000,1666091580000,1666091640000,1666091700000,1666091760000,1666091820000,1666091880000,1666091940000,1666092000000,1666092060000,1666092120000,1666092180000,1666092240000,1666092300000,1666092360000,1666092420000,1666092480000,1666092540000,1666092600000,1666092660000,1666092720000,1666092780000,1666092840000,1666092900000,1666092960000,1666093020000,1666093080000,1666093140000,1666093200000,1666093260000,1666093320000,1666093380000,1666093440000,1666093500000,1666093560000,1666093620000,1666093680000,1666093740000,1666093800000,1666093860000,1666093920000,1666093980000,1666094040000,1666094100000,1666094160000,1666094220000,1666094280000,1666094340000,1666094400000,1666094460000,1666094520000,1666094580000,1666094640000,1666094700000,1666094760000,1666094820000,1666094880000,1666094940000,1666095000000,1666095060000,1666095120000,1666095180000,1666095240000,1666095300000,1666095360000,1666095420000,1666095480000,1666095540000,1666095600000,1666095660000,1666095720000,1666095780000,1666095840000,1666095900000,1666095960000,1666096020000,1666096080000,1666096140000,1666096200000,1666096260000,1666096320000,1666096380000,1666096440000,1666096500000,1666096560000,1666096620000,1666096680000,1666096740000,1666096800000,1666096860000,1666096920000,1666096980000,1666097040000,1666097100000,1666097160000,1666097220000,1666097280000,1666097340000],\"values\":[null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null,null,null,null,null,null,50,null,null,null,null,null,null,null,null,null]}]}]}"
@@ -151,18 +152,7 @@ func TestEvaluateQuery_CorrectHTTP(t *testing.T) {
 		require.Equal(t, 1, len(r.Header["Authorization"]))
 	}))
 	defer svr.Close()
-	fakeClient := fake.NewClient()
-
-	kdp := KeptnDynatraceProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
-	obj := metricsapi.KeptnMetric{
-		Spec: metricsapi.KeptnMetricSpec{
-			Query: query,
-		},
-	}
+	kdp, obj := setupTest()
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
 			SecretKeyRef: v1.SecretKeySelector{
@@ -181,6 +171,43 @@ func TestEvaluateQuery_CorrectHTTP(t *testing.T) {
 
 }
 
+func TestEvaluateQuery_APIError(t *testing.T) {
+	errorResponse := []byte("{\"error\":{\"code\":403,\"message\":\"Token is missing required scope. Use one of: metrics.read (Read metrics)\"}}")
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(errorResponse)
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+	secretName, secretKey, secretValue := "secretName", "secretKey", "secretValue"
+	apiToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "",
+		},
+		Data: map[string][]byte{
+			secretKey: []byte(secretValue),
+		},
+	}
+	kdp, obj := setupTest(apiToken)
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: secretName,
+				},
+				Key: secretKey,
+			},
+			TargetServer: svr.URL,
+		},
+	}
+	r, raw, e := kdp.EvaluateQuery(context.TODO(), obj, p)
+	require.Equal(t, "", r)
+	t.Log(string(raw))
+	require.Equal(t, errorResponse, raw) //we still return the raw answer to help user debug
+	require.NotNil(t, e)
+	require.Contains(t, e.Error(), "Token is missing required scope.")
+}
+
 func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("garbage"))
@@ -197,18 +224,8 @@ func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
 			secretKey: []byte(secretValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
 
-	kdp := KeptnDynatraceProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
-	obj := metricsapi.KeptnMetric{
-		Spec: metricsapi.KeptnMetricSpec{
-			Query: "my-query",
-		},
-	}
+	kdp, obj := setupTest(apiToken)
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
 			SecretKeyRef: v1.SecretKeySelector{
@@ -222,7 +239,8 @@ func TestEvaluateQuery_WrongPayloadHandling(t *testing.T) {
 	}
 	r, raw, e := kdp.EvaluateQuery(context.TODO(), obj, p)
 	require.Equal(t, "", r)
-	require.Equal(t, []byte(nil), raw)
+	t.Log(string(raw), e)
+	require.Equal(t, []byte("garbage"), raw) //we still return the raw answer to help user debug
 	require.NotNil(t, e)
 }
 
@@ -232,18 +250,8 @@ func TestEvaluateQuery_MissingSecret(t *testing.T) {
 		require.Nil(t, err)
 	}))
 	defer svr.Close()
-	fakeClient := fake.NewClient()
+	kdp, obj := setupTest()
 
-	kdp := KeptnDynatraceProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
-	obj := metricsapi.KeptnMetric{
-		Spec: metricsapi.KeptnMetricSpec{
-			Query: "my-query",
-		},
-	}
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
 			TargetServer: svr.URL,
@@ -260,18 +268,8 @@ func TestEvaluateQuery_SecretNotFound(t *testing.T) {
 		require.Nil(t, err)
 	}))
 	defer svr.Close()
-	fakeClient := fake.NewClient()
+	kdp, obj := setupTest()
 
-	kdp := KeptnDynatraceProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
-	obj := metricsapi.KeptnMetric{
-		Spec: metricsapi.KeptnMetricSpec{
-			Query: "my-query",
-		},
-	}
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
 			SecretKeyRef: v1.SecretKeySelector{
@@ -304,18 +302,8 @@ func TestEvaluateQuery_RefNotExistingKey(t *testing.T) {
 			secretKey: []byte(secretValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
+	kdp, obj := setupTest(apiToken)
 
-	kdp := KeptnDynatraceProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
-	obj := metricsapi.KeptnMetric{
-		Spec: metricsapi.KeptnMetricSpec{
-			Query: "my-query",
-		},
-	}
 	missingKey := "key_not_found"
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
@@ -350,18 +338,8 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 			secretKey: []byte(secretValue),
 		},
 	}
-	fakeClient := fake.NewClient(apiToken)
+	kdp, obj := setupTest(apiToken)
 
-	kdp := KeptnDynatraceProvider{
-		HttpClient: http.Client{},
-		Log:        ctrl.Log.WithName("testytest"),
-		K8sClient:  fakeClient,
-	}
-	obj := metricsapi.KeptnMetric{
-		Spec: metricsapi.KeptnMetricSpec{
-			Query: "my-query",
-		},
-	}
 	p := metricsapi.KeptnMetricsProvider{
 		Spec: metricsapi.KeptnMetricsProviderSpec{
 			SecretKeyRef: v1.SecretKeySelector{
@@ -377,4 +355,48 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 	require.Nil(t, e)
 	require.Equal(t, []byte(dtpayload), raw)
 	require.Equal(t, fmt.Sprintf("%f", 50.0), r)
+}
+
+func Test_trimQuery(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "spaces and newlines",
+			query: "((builtin:kubernetes.workload.cpu_throttled: filter(eq(\"k8s.workload.name\", \"frontend\"))  :splitBy(\"k8s.namespace.name\")",
+			want:  "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\")):splitBy(\"k8s.namespace.name\")",
+		},
+		{name: "spaces and newlines",
+			query: "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\"))\n    :splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
+			want:  "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\")):splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
+		},
+		{name: "spaces and \r",
+			query: "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\"))\n\r    :splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
+			want:  "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\")):splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, trimQuery(tt.query))
+		})
+	}
+}
+
+func setupTest(objs ...client.Object) (KeptnDynatraceProvider, metricsapi.KeptnMetric) {
+
+	fakeClient := fake.NewClient(objs...)
+
+	kdp := KeptnDynatraceProvider{
+		HttpClient: http.Client{},
+		Log:        ctrl.Log.WithName("testytest"),
+		K8sClient:  fakeClient,
+	}
+	obj := metricsapi.KeptnMetric{
+		Spec: metricsapi.KeptnMetricSpec{
+			Query: "my-query",
+		},
+	}
+	return kdp, obj
 }

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go
@@ -357,33 +357,6 @@ func TestEvaluateQuery_HappyPath(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%f", 50.0), r)
 }
 
-func Test_trimQuery(t *testing.T) {
-
-	tests := []struct {
-		name  string
-		query string
-		want  string
-	}{
-		{name: "spaces and newlines",
-			query: "((builtin:kubernetes.workload.cpu_throttled: filter(eq(\"k8s.workload.name\", \"frontend\"))  :splitBy(\"k8s.namespace.name\")",
-			want:  "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\")):splitBy(\"k8s.namespace.name\")",
-		},
-		{name: "spaces and newlines",
-			query: "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\"))\n    :splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
-			want:  "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\")):splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
-		},
-		{name: "spaces and \r",
-			query: "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\"))\n\r    :splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
-			want:  "((builtin:kubernetes.workload.cpu_throttled:filter(eq(\"k8s.workload.name\",\"frontend\")):splitBy(\"k8s.namespace.name\",\"k8s.workload.kind\",\"k8s.workload.name\")",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, trimQuery(tt.query))
-		})
-	}
-}
-
 func setupTest(objs ...client.Object) (KeptnDynatraceProvider, metricsapi.KeptnMetric) {
 
 	fakeClient := fake.NewClient(objs...)

--- a/metrics-operator/controllers/common/providers/provider_test.go
+++ b/metrics-operator/controllers/common/providers/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/fake"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/datadog"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/dynatrace"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/prometheus"
@@ -24,6 +25,11 @@ func TestFactory(t *testing.T) {
 		{
 			providerType: DynatraceProviderType,
 			provider:     &dynatrace.KeptnDynatraceProvider{},
+			err:          false,
+		},
+		{
+			providerType: DynatraceDQLProviderType,
+			provider:     dynatrace.NewKeptnDynatraceDQLProvider(fake.NewClient()),
 			err:          false,
 		},
 		{

--- a/metrics-operator/controllers/metrics/controller.go
+++ b/metrics-operator/controllers/metrics/controller.go
@@ -55,10 +55,6 @@ type KeptnMetricReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the KeptnMetric object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile

--- a/metrics-operator/controllers/metrics/controller.go
+++ b/metrics-operator/controllers/metrics/controller.go
@@ -102,10 +102,10 @@ func (r *KeptnMetricReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	reconcile := ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 	value, rawValue, err := provider.EvaluateQuery(ctx, *metric, *metricProvider)
 	if err != nil {
-		r.Log.Error(err, "Failed to evaluate the query")
+		r.Log.Error(err, "Failed to evaluate the query", "Response from provider was:", (string)(rawValue))
 		metric.Status.ErrMsg = err.Error()
 		metric.Status.Value = ""
-		metric.Status.RawValue = []byte{}
+		metric.Status.RawValue = cupSize(rawValue)
 		metric.Status.LastUpdated = metav1.Time{Time: time.Now()}
 		reconcile = ctrl.Result{Requeue: false}
 	} else {
@@ -123,6 +123,9 @@ func (r *KeptnMetricReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 func cupSize(value []byte) []byte {
+	if len(value) == 0 {
+		return []byte{}
+	}
 	if len(value) > MB {
 		return value[:MB]
 	}


### PR DESCRIPTION
### This pr: 

1.  handles hidden error in the response of metrics providers 
2.  adds trim of queries from dt provider so that spaces and new lines are allowed.
3.  in case error may not be clear returns the raw value of the provider response

### How to test: 

1. pass a wrong token, API returns error that is logged and stored in the KeptnMetrics ex

`Status:              
     Err Msg:       provider api response: Token Authentication failed                       `          
![image](https://github.com/keptn/lifecycle-toolkit/assets/89971034/16a5b49a-c58e-4b97-93d0-b5482addb92d)


2. use a metric like so or change >- with | :
```
apiVersion: metrics.keptn.sh/v1alpha3
kind: KeptnMetric
metadata:
  name: podtatometric
  namespace: keptn-lifecycle-toolkit-system
spec:
  provider:
    name: "dynatrace"
  query:  >-
    (( builtin:kubernetes.workload.cpu_throttled
    :filter(eq("k8s.workload.name","frontend"))
    :splitBy("k8s.namespace.name","k8s.workload.kind","k8s.workload.name") :sum
    / builtin:kubernetes.workload.cpu_usage
    :filter(eq("k8s.deployment.name","frontend"))
    :splitBy("k8s.namespace.name","k8s.workload.kind","k8s.workload.name") :sum
    ) :default(0.0) * 100.0)
  fetchIntervalSeconds: 5
```
 