### PR TITLE
docs: deployment flow architecture

### DIFF
--- a/docs/content/en/docs/concepts/architecture/components/_index.md
+++ b/docs/content/en/docs/concepts/architecture/components/_index.md
@@ -2,7 +2,7 @@
 title: Lifecycle Toolkit Components
 linktitle: Components
 description: Basic understanding of Keptn Lifecycle Toolkit Components
-weight: 80
+weight: 20
 cascade:
 ---
 

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -21,7 +21,7 @@ The execution flow goes through six main phases:
 Within each phase,
 the order of execution is determined
 by the order in which evaluations and tasks are listed in the
-[KeptnApp](../../yaml-crd-ref/app)
+[KeptnApp](../../yaml-crd-ref/app/)
 resource.
 
 ## Kubernetes events

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -171,4 +171,3 @@ Deprecated
 WorkloadDeployReconcile
 WorkloadDeployReconcileErrored
 ```
-

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -90,7 +90,7 @@ AppPreDeployTasks
 
 Pre-deployment evaluation can be used to assert the status of the cluster
 or of services the workload depends on,
-to assure it is deployed only if the specified prerequisites are met. 
+to assure it is deployed only if the specified prerequisites are met.
 
 ```shell
 AppPreDeployEvaluations

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -18,12 +18,20 @@ The execution flow goes through six main phases:
 * Post-deployment-evaluation
 * Completed
 
+Within each phase,
+the order of execution is determined
+by the order in which evaluations and tasks are listed in the
+[KeptnApp](../../../yaml-crd-ref/app.md)
+resource.
+
 A [Kubernetes Event](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
-is emitted at each phase to provide additional Observability of the execution flow.
+is emitted at each phase
+to provide additional Observability of the execution flow.
 
 The Keptn Lifecycle Toolkit implements a
 [Permit Scheduler Plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#permit)
-that blocks the binding of the pods to a node until all the pre-conditions are fulfilled.
+that blocks the binding of the pods to a node
+until all the pre-conditions are fulfilled.
 
 A Kubernetes deployment is started by the following command:
 
@@ -31,11 +39,21 @@ A Kubernetes deployment is started by the following command:
 kubectl apply -f deployment.yaml
 ```
 
+TODO: Should this mention anything
+about deployment engines like Flux?
+Maybe they just call ``kubectl apply` under the hood?
+
 The deployment is created
 but the created pods are blocked and in pending state
 until all the required pre-deployment tasks/evaluations
 defined on either the KeptnApp or KeptnWorkload level pass.
 Only then are the pods bound to a node and deployed.
+If any evaluation or task fails,
+the `KeptnApp` issues appropriate `*Errored` event
+and terminates the deployment.
+If all evaluations and tasks in a phase are successful,
+the `KeptnApp` issues the appropriate `*Succeeded` event
+and initiates the next phase.
 
 ## Summary of deployment flow
 
@@ -47,6 +65,8 @@ kubectl get events -n <namespace> .
 
 ### Pre-deployment phase
 
+TODO: Add intro statement about this phase.
+
 ```shell
 AppPreDeployTasks
   AppPreDeployTasksStarted
@@ -54,6 +74,8 @@ AppPreDeployTasks
 ```
 
 ### Pre-deployment evaluation phase
+
+TODO: Add intro statement about this phase.
 
 ```shell
 AppPreDeployEvaluations
@@ -69,10 +91,10 @@ The `KeptnApp` just observes whether
 all pre and post-deployment tasks/evaluation are successful
 and that the pods are deployed successfully.
 When all activities are successful,
-the KeptnApp issues the `AppDeploySucceeded` event
+the `KeptnApp` issues the `AppDeploySucceeded` event
 and continues to the next phase.
 If any of these activities fail,
-the KeptnApp issues the `AppDeployErrored` event
+the `KeptnApp` issues the `AppDeployErrored` event
 and terminates the deployment.
 
 ```shell
@@ -98,6 +120,8 @@ AppDeploy
 
 ### Post-deployment phase
 
+TODO: Add intro statement about this phase.
+
 ```shell
 AppPostDeployTasks
   AppPostDeployTasksStarted
@@ -105,6 +129,8 @@ AppPostDeployTasks
 ```
 
 ### Post-deployment evaluation phase
+
+TODO: Add intro statement about this phase.
 
 ```shell
 AppPostDeployEvaluations

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -88,7 +88,9 @@ AppPreDeployTasks
 
 ### Pre-deployment evaluation phase
 
-TODO: Add intro statement about this phase.
+Pre-deployment evaluation can be used to assert the status of the cluster
+or of services the workload depends on,
+to assure it is deployed only if the specified prerequisites are met. 
 
 ```shell
 AppPreDeployEvaluations

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -35,7 +35,7 @@ The Keptn Lifecycle Toolkit implements a
 that blocks the binding of the pods to a node
 until all the pre-conditions are fulfilled.
 
-A Kubernetes deployment is started by the following command:
+A Kubernetes deployment is applied to the cluster by the following command:
 
 ```shell
 kubectl apply -f deployment.yaml

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -145,6 +145,7 @@ Completed
 ```
 
 ## Events that are not part of the deployment flow
+
 Additional phases/states exist,
 such as those that describe what happens when something fails.
 
@@ -167,4 +168,5 @@ Completed
 Deprecated
 WorkloadDeployReconcile
 WorkloadDeployReconcileErrored
+```
 

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -18,16 +18,19 @@ The execution flow goes through six main phases:
 * Post-deployment-evaluation
 * Completed
 
-Within each phase,
-all tasks are executed in parallel.
+Within each phase, all tasks and evaluations for each phase
+are executed in parallel.
 They are not affected by the order
 in which evaluations and tasks are listed in the
 [KeptnApp](../../yaml-crd-ref/app.md/)
-resource.
+resource
+or in the order of the pre/post-tasks and pre/post-evaluations
+that are listed in the Workflow manifests.
 
 ## Kubernetes and Cloud Events
 
-[Kubernetes Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/) and [CloudEvents](https://cloudevents.io/)
+[Kubernetes Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
+and [CloudEvents](https://cloudevents.io/)
 are emitted at each phase
 to provide additional Observability of the execution flow.
 

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -21,7 +21,7 @@ The execution flow goes through six main phases:
 Within each phase,
 the order of execution is determined
 by the order in which evaluations and tasks are listed in the
-[KeptnApp](../../../yaml-crd-ref/app.md)
+[KeptnApp](../../../yaml-crd-ref/app/)
 resource.
 
 A [Kubernetes Event](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -25,7 +25,7 @@ in which evaluations and tasks are listed in the
 [KeptnApp](../../yaml-crd-ref/app.md/)
 resource.
 
-## Kubernetes events
+## Kubernetes and Cloud Events
 
 [Kubernetes Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
 are emitted at each phase

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -59,7 +59,7 @@ but the created pods are blocked and in pending state
 until all the required pre-deployment tasks/evaluations
 defined on either the `KeptnApp` or `KeptnWorkload` level pass.
 Only then are the pods bound to a node and deployed.
-If any evaluation or task fails,
+If any pre-deployment evaluation or task fails,
 the `KeptnApp` issues an appropriate `*Errored` event
 and terminates the deployment.
 If all evaluations and tasks in a phase are successful,

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -2,7 +2,7 @@
 title: Flow of deployment
 linktitle: Flow of deployment
 description: Understand the execution flow of a deployment
-weight: 25
+weight: 35
 ---
 
 The Keptn Lifecycle Toolkit (KLT) deploys a
@@ -21,8 +21,10 @@ The execution flow goes through six main phases:
 Within each phase,
 the order of execution is determined
 by the order in which evaluations and tasks are listed in the
-[KeptnApp](../../../yaml-crd-ref/app/)
+[KeptnApp](../../yaml-crd-ref/app)
 resource.
+
+## Kubernetes events
 
 A [Kubernetes Event](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
 is emitted at each phase
@@ -49,7 +51,7 @@ until all the required pre-deployment tasks/evaluations
 defined on either the KeptnApp or KeptnWorkload level pass.
 Only then are the pods bound to a node and deployed.
 If any evaluation or task fails,
-the `KeptnApp` issues appropriate `*Errored` event
+the `KeptnApp` issues an appropriate `*Errored` event
 and terminates the deployment.
 If all evaluations and tasks in a phase are successful,
 the `KeptnApp` issues the appropriate `*Succeeded` event

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -61,7 +61,8 @@ defined on either the `KeptnApp` or `KeptnWorkload` level pass.
 Only then are the pods bound to a node and deployed.
 If any pre-deployment evaluation or task fails,
 the `KeptnApp` issues an appropriate `*Errored` event
-and terminates the deployment.
+and the deployment remains pending indefinitely,
+until further changes or external intervention
 If all evaluations and tasks in a phase are successful,
 the `KeptnApp` issues the appropriate `*Succeeded` event
 and initiates the next phase.

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -26,8 +26,8 @@ resource.
 
 ## Kubernetes events
 
-A [Kubernetes Event](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
-is emitted at each phase
+[Kubernetes Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
+are emitted at each phase
 to provide additional Observability of the execution flow.
 
 The Keptn Lifecycle Toolkit implements a

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -77,7 +77,8 @@ kubectl get events -n <namespace> .
 
 ### Pre-deployment phase
 
-TODO: Add intro statement about this phase.
+Pre-deployment tasks can perform any kind of action needed
+to prepare for the deployment, including unit tests, load tests or other similar tests.
 
 ```shell
 AppPreDeployTasks

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -147,7 +147,10 @@ AppPostDeployTasks
 
 ### Post-deployment evaluation phase
 
-TODO: Add intro statement about this phase.
+The post-deployment evaluation can be used
+to analyze the cluster/application status after the new workload is deployed.
+The result of this phase does not revert or influence the deployment
+but can be used by other external tools, for instance, to react to a failure.
 
 ```shell
 AppPostDeployEvaluations

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -49,7 +49,7 @@ kubectl apply -f deployment.yaml
 ```
 
 KLT does not care how a deployment manifest is applied to the cluster.
-Both kubectl and Flux/Argo send the manifest to the Kubernetes API
+Both `kubectl` and Flux/Argo send the manifest to the Kubernetes API
 so KLT does not differentiate the actual deployment options.
 This also means that one Keptn Application
 can include services that are deployed with different methods.
@@ -57,7 +57,7 @@ can include services that are deployed with different methods.
 The deployment is created
 but the created pods are blocked and in pending state
 until all the required pre-deployment tasks/evaluations
-defined on either the KeptnApp or KeptnWorkload level pass.
+defined on either the `KeptnApp` or `KeptnWorkload` level pass.
 Only then are the pods bound to a node and deployed.
 If any evaluation or task fails,
 the `KeptnApp` issues an appropriate `*Errored` event

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -135,7 +135,9 @@ AppDeploy
 
 ### Post-deployment phase
 
-TODO: Add intro statement about this phase.
+The post-deployment phase is typically used
+to run tests on the freshly deployed application,
+such as gathering  performance data.
 
 ```shell
 AppPostDeployTasks

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -19,9 +19,10 @@ The execution flow goes through six main phases:
 * Completed
 
 Within each phase,
-the order of execution is determined
-by the order in which evaluations and tasks are listed in the
-[KeptnApp](../../yaml-crd-ref/app/)
+all tasks are executed in parallel.
+They are not affected by the order
+in which evaluations and tasks are listed in the
+[KeptnApp](../../yaml-crd-ref/app.md/)
 resource.
 
 ## Kubernetes events
@@ -35,15 +36,20 @@ The Keptn Lifecycle Toolkit implements a
 that blocks the binding of the pods to a node
 until all the pre-conditions are fulfilled.
 
-A Kubernetes deployment is applied to the cluster by the following command:
+A Kubernetes deployment is started by the deployment engine
+that is implemented
+(such as Flux or Argo)
+or can be started by the following command:
 
 ```shell
 kubectl apply -f deployment.yaml
 ```
 
-TODO: Should this mention anything
-about deployment engines like Flux?
-Maybe they just call ``kubectl apply` under the hood?
+KLT does not care how a deployment manifest is applied to the cluster.
+Both kubectl and Flux/Argo send the manifest to the Kubernetes API
+so KLT does not differentiate the actual deployment options.
+This also means that one Keptn Application
+can include services that are deployed with different methods.
 
 The deployment is created
 but the created pods are blocked and in pending state

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -1,0 +1,144 @@
+---
+title: Flow of deployment
+linktitle: Flow of deployment
+description: Understand the execution flow of a deployment
+weight: 25
+---
+
+The Keptn Lifecycle Toolkit (KLT) deploys a
+[Kubernetes Workload](https://kubernetes.io/docs/concepts/workloads/)
+by passing through a well-defined execution flow.
+
+The execution flow goes through six main phases:
+
+* Pre-deployments-tasks
+* Pre-deployment-evaluation
+* Deployment
+* Post-deployment-tasks
+* Post-deployment-evaluation
+* Completed
+
+A [Kubernetes Event](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
+is emitted at each phase to provide additional Observability of the execution flow.
+
+The Keptn Lifecycle Toolkit implements a
+[Permit Scheduler Plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#permit)
+that blocks the binding of the pods to a node until all the pre-conditions are fulfilled.
+
+A Kubernetes deployment is started by the following command:
+
+```shell
+kubectl apply -f deployment.yaml
+```
+
+The deployment is created
+but the created pods are blocked and in pending state
+until all the required pre-deployment tasks/evaluations
+defined on either the KeptnApp or KeptnWorkload level pass.
+Only then are the pods bound to a node and deployed.
+
+## Summary of deployment flow
+
+To view these events on your cluster, execute:
+
+```shell
+kubectl get events -n <namespace> . 
+```
+
+### Pre-deployment phase
+
+```shell
+AppPreDeployTasks
+  AppPreDeployTasksStarted
+  AppPreDeployTasksSucceeded OR AppPreDeployTasksErrored
+```
+
+### Pre-deployment evaluation phase
+
+```shell
+AppPreDeployEvaluations
+  AppPreDeployEvaluationsStarted
+  AppPreDeployEvaluationsSucceeded OR AppPreDeployEvaluationsErrored
+```
+
+### Deployment phase
+
+The `AppDeploy` phase basically covers
+the entire deployment and check phase of the workloads.
+The `KeptnApp` just observes whether
+all pre and post-deployment tasks/evaluation are successful
+and that the pods are deployed successfully.
+When all activities are successful,
+the KeptnApp issues the `AppDeploySucceeded` event
+and continues to the next phase.
+If any of these activities fail,
+the KeptnApp issues the `AppDeployErrored` event
+and terminates the deployment.
+
+```shell
+AppDeploy
+  AppDeployStarted
+  WorkloadPreDeployTasks
+    WorkloadPreDeployTasksStarted
+    WorkloadPreDeployTasksSucceeded OR WorkloadPreDeployTasksErrored 
+  WorkloadPreDeployEvaluations
+    WorkloadPreDeployEvaluationsStarted
+    WorkloadPreDeployEvaluationsSucceeded OR WorkloadPreDeployErrored
+  WorkloadDeploy
+    WorkloadDeployStarted
+    WorkloadDeploySucceeded OR WorkloadDeployErrored
+  WorkloadPostDeployTasks
+    WorkloadPostDeployTasksStarted
+    WorkloadPostDeployTasksSucceeded OR WorkloadPostDeployTasksErrored 
+  WorkloadPostDeployEvaluations
+    WorkloadPostDeployEvaluationsStarted
+    WorkloadPostDeployEvaluationsSucceeded OR WorkloadPostDeployEvaluationsErrored
+  AppDeploySucceeded OR AppDeployErrored
+  ```
+
+### Post-deployment phase
+
+```shell
+AppPostDeployTasks
+  AppPostDeployTasksStarted
+  AppPostDeployTasksSucceeded OR AppPostDeployTasksErrored
+```
+
+### Post-deployment evaluation phase
+
+```shell
+AppPostDeployEvaluations
+  AppPostDeployEvaluationsStarted
+  AppPostDeployEvaluationsSucceeded OR AppPostDeployEvaluationsErrored
+```
+
+### Completed phase
+
+```shell
+Completed
+```
+
+## Events that are not part of the deployment flow
+Additional phases/states exist,
+such as those that describe what happens when something fails.
+
+Whenever something in the system happens (we create a new resource, etc.)
+a Kubernetes event is generated.
+The following events are defined as part of the Keptn Lifecycle Toolkit
+but they are not part of the deployment flow.
+These include:
+
+```shell
+CreateEvaluation
+ReconcileEvaluation
+ReconcileTask
+CreateTask
+CreateApp
+CreateAppVersion
+CreateWorkload
+CreateWorkloadInstance
+Completed
+Deprecated
+WorkloadDeployReconcile
+WorkloadDeployReconcileErrored
+

--- a/docs/content/en/docs/concepts/architecture/deployment-flow.md
+++ b/docs/content/en/docs/concepts/architecture/deployment-flow.md
@@ -27,7 +27,7 @@ resource.
 
 ## Kubernetes and Cloud Events
 
-[Kubernetes Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
+[Kubernetes Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/) and [CloudEvents](https://cloudevents.io/)
 are emitted at each phase
 to provide additional Observability of the execution flow.
 

--- a/docs/content/en/docs/concepts/architecture/working/_index.md
+++ b/docs/content/en/docs/concepts/architecture/working/_index.md
@@ -2,7 +2,7 @@
 title: Lifecycle Toolkit Working
 linktitle: How it works
 description: Understand How Keptn Lifecycle Toolkit Works
-weight: 80
+weight: 30
 cascade:
 ---
 


### PR DESCRIPTION
This pulls together the basic information from the slack discussion.  

Closes #689 
Epic: #770 

Replaces https://github.com/keptn/lifecycle-toolkit/pull/1342 , which replaced https://github.com/keptn/lifecycle-toolkit/pull/828 , which is totally corrupted but contains a lot of interesting comments and history