### PR TITLE
fix(cert-manager): avoid index-out-of-bounds error when updating webhook configs

### DIFF
--- a/klt-cert-manager/controllers/keptnwebhookcontroller/keptnwebhookcertificate_controller.go
+++ b/klt-cert-manager/controllers/keptnwebhookcontroller/keptnwebhookcertificate_controller.go
@@ -180,7 +180,7 @@ func (r *KeptnWebhookCertificateReconciler) updateConfigurations(ctx context.Con
 	}
 
 	for i := range validatingWebhookConfigurationList.Items {
-		r.Log.Info("injecting certificate into validating webhook config", "vwc", mutatingWebhookConfigurationList.Items[i].Name)
+		r.Log.Info("injecting certificate into validating webhook config", "vwc", validatingWebhookConfigurationList.Items[i].Name)
 		if err := r.updateClientConfigurations(ctx, bundle, validatingWebhookConfigs, &validatingWebhookConfigurationList.Items[i]); err != nil {
 			return err
 		}

--- a/klt-cert-manager/controllers/keptnwebhookcontroller/webhook_cert_controller_test.go
+++ b/klt-cert-manager/controllers/keptnwebhookcontroller/webhook_cert_controller_test.go
@@ -146,7 +146,8 @@ func TestReconcile(t *testing.T) {
 	t.Run(`reconcile successfully with mutatingwebhookconfiguration`, func(t *testing.T) {
 		fakeClient := fake.NewClient(crd1, crd2, crd3, &admissionregistrationv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-mutating-webhook-config",
+				Name:   "my-mutating-webhook-config",
+				Labels: getMatchLabel(),
 			},
 			Webhooks: []admissionregistrationv1.MutatingWebhook{
 				{
@@ -167,7 +168,8 @@ func TestReconcile(t *testing.T) {
 	t.Run(`reconcile successfully with validatingwebhookconfiguration`, func(t *testing.T) {
 		fakeClient := fake.NewClient(crd1, crd2, crd3, &admissionregistrationv1.ValidatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "my-validating-webhook-config",
+				Name:   "my-validating-webhook-config",
+				Labels: getMatchLabel(),
 			},
 			Webhooks: []admissionregistrationv1.ValidatingWebhook{
 				{


### PR DESCRIPTION
This PR fixes a copy paste error that can potentially lead to index out of bounds errors when iterating through the list of matching `ValidatingWebhookConfigurations`. 