### PR TITLE
feat: integrate python-runtime into pipelines

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -11,8 +11,8 @@ inputs:
     description: "Kubernetes that should be used"
     # renovate: datasource=github-releases depName=kubernetes/kubernetes
     default: "v1.25.3"
-  functions_runtime_tag:
-    description: "Tag for the functions runner image"
+  runtime_tag:
+    description: "Tag for the runner image"
     required: true
   cluster-name:
     required: false
@@ -61,7 +61,9 @@ runs:
       run: |
         echo "Installing KLT using manifests"
         sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/lifecycle-operator-manifest-test/release.yaml
-        sed -i 's/ghcr.io\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.functions_runtime_tag }}/g' \
+        sed -i 's/ghcr.io\/keptn\/functions-runtime:.*/localhost:5000\/keptn\/functions-runtime:${{ inputs.runtime_tag }}/g' \
+          ~/download/artifacts/lifecycle-operator-manifest-test/release.yaml
+        sed -i 's/ghcr.io\/keptn\/python-runtime:.*/localhost:5000\/keptn\/python-runtime:${{ inputs.runtime_tag }}/g' \
           ~/download/artifacts/lifecycle-operator-manifest-test/release.yaml
         kubectl create namespace keptn-lifecycle-toolkit-system
         kubectl apply -f ~/download/artifacts/lifecycle-operator-manifest-test
@@ -89,6 +91,7 @@ runs:
           --set scheduler.scheduler.imagePullPolicy=Never \
           --set lifecycleOperator.manager.imagePullPolicy=Never \
           --set metricsOperator.manager.imagePullPolicy=Never \
-          --set lifecycleOperator.manager.env.functionRunnerImage=localhost:5000/keptn/functions-runtime:${{ inputs.functions_runtime_tag }} \
+          --set lifecycleOperator.manager.env.functionRunnerImage=localhost:5000/keptn/functions-runtime:${{ inputs.runtime_tag }} \
+          --set lifecycleOperator.manager.env.pythonRunnerImage=localhost:5000/keptn/python-runtime:${{ inputs.runtime_tag }} \
           --set certificateOperator.manager.imagePullPolicy=Never \
           --debug --wait --timeout 1m

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -125,6 +125,8 @@ jobs:
             folder: "scheduler/"
           - name: "functions-runtime"
             folder: "functions-runtime/"
+          - name: "python-runtime"
+            folder: "python-runtime/"
           - name: "certificate-operator"
             folder: "klt-cert-manager/"
     steps:
@@ -174,14 +176,14 @@ jobs:
         run: make controller-gen
 
       - name: Generate release.yaml
-        if: matrix.config.name != 'functions-runtime'
+        if: matrix.config.name != 'functions-runtime' && matrix.config.name != 'python-runtime'
         working-directory: ./${{ matrix.config.folder }}
         env:
           CHART_APPVERSION: dev-${{ env.DATETIME }}
         run: make release-manifests
 
       - name: Upload release.yaml for tests
-        if: matrix.config.name != 'functions-runtime'
+        if: matrix.config.name != 'functions-runtime' && matrix.config.name != 'python-runtime'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.config.name }}-manifest-test
@@ -196,28 +198,28 @@ jobs:
     name: Integration Tests
     needs: [prepare_ci_run, build_image]
     with:
-      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
+      runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/integration-test.yml
 
   load-tests:
     name: Load Tests
     needs: [prepare_ci_run, build_image]
     with:
-      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
+      runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/load-test.yml
 
   e2e_tests:
     name: End to End Tests
     needs: [prepare_ci_run, build_image]
     with:
-      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
+      runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/e2e-test.yml
 
   performance_tests:
     name: Performance Tests
     needs: [prepare_ci_run, build_image]
     with:
-      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
+      runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/performance-test.yml
 
   helm_charts_build:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,8 +2,8 @@ name: E2E-Test
 on:
   workflow_call:
     inputs:
-      functions_runtime_tag:
-        description: "Tag for the functions runner image"
+      runtime_tag:
+        description: "Tag for the runner image"
         type: "string"
         required: true
 env:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
-          functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
+          runtime_tag: ${{ inputs.runtime_tag }}
 
       - name: Run E2E Tests ${{ matrix.config.name }}
         working-directory: ${{ matrix.config.folder }}

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -62,6 +62,8 @@ jobs:
             folder: "scheduler/"
           - name: "functions-runtime"
             folder: "functions-runtime/"
+          - name: "python-runtime"
+            folder: "python-runtime/"
           - name: "certificate-operator"
             folder: "klt-cert-manager/"
     steps:
@@ -141,6 +143,6 @@ jobs:
     name: Integration Tests
     needs: [prepare_ci_run, build_helm_chart]
     with:
-      functions_runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
+      runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       helm-install: true
     uses: ./.github/workflows/integration-test.yml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Integration-Test
 on:
   workflow_call:
     inputs:
-      functions_runtime_tag:
+      runtime_tag:
         description: "Tag for the functions runner image"
         type: "string"
         required: true
@@ -29,7 +29,7 @@ jobs:
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
-          functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
+          runtime_tag: ${{ inputs.runtime_tag }}
           helm-install: ${{ inputs.helm-install }}
 
       - name: Install and expose Prometheus

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -2,7 +2,7 @@ name: Load Tests
 on:
   workflow_call:
     inputs:
-      functions_runtime_tag:
+      runtime_tag:
         description: "Tag for the functions runner image"
         type: "string"
         required: true
@@ -25,7 +25,7 @@ jobs:
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
-          functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
+          runtime_tag: ${{ inputs.runtime_tag }}
 
       - name: Install and expose Prometheus
         uses: ./.github/actions/deploy-prometheus-on-cluster

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -2,7 +2,7 @@ name: Performance Tests
 on:
   workflow_call:
     inputs:
-      functions_runtime_tag:
+      runtime_tag:
         description: "Tag for the functions runner image"
         type: "string"
         required: true
@@ -23,7 +23,7 @@ jobs:
       - name: Setup cluster
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
-          functions_runtime_tag: ${{ inputs.functions_runtime_tag }}
+          runtime_tag: ${{ inputs.runtime_tag }}
 
       - name: Execute Performance Tests
         working-directory: operator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
             folder: "scheduler/"
           - name: "functions-runtime"
             folder: "functions-runtime/"
+          - name: "python-runtime"
+            folder: "python-runtime/"
           - name: "certificate-operator"
             folder: "klt-cert-manager/"
     runs-on: ubuntu-22.04

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -192,6 +192,7 @@ jobs:
       matrix:
         image:
           - "functions-runtime"
+          - "python-runtime"
           - "lifecycle-operator"
           - "metrics-operator"
           - "scheduler"

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -39,6 +39,7 @@ jobs:
             cert-manager
             metrics-operator
             functions-runtime
+            python-runtime
             dashboards
             examples
           # Configure that a scope must always be provided.

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -92,7 +92,7 @@ checks
 | `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                                     | `0`                                      |
 | `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                                      | `otel-collector:4317`                    |
 | `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for task runtime with Deno runner <!---x-release-please-version-->   | `ghcr.io/keptn/functions-runtime:v0.7.1` |
-| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for task runtime with python runner <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:latest`    |
+| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for task runtime with python runner <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:0.0.0`     |
 | `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                                                 | `ghcr.io/keptn/lifecycle-operator`       |
 | `lifecycleOperator.manager.image.tag`                                         | select tag for manager image <!---x-release-please-version-->                      | `v0.7.1`                                 |
 | `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                                              | `Always`                                 |

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -71,33 +71,34 @@ checks
 
 ### Keptn Lifecycle Operator controller
 
-| Name                                                                          | Description                                                     | Value                                    |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------- |
-| `lifecycleOperator.manager.containerSecurityContext`                          | Sets security context privileges                                |                                          |
-| `lifecycleOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                                 | `false`                                  |
-| `lifecycleOperator.manager.containerSecurityContext.capabilities.drop`        |                                                                 | `["ALL"]`                                |
-| `lifecycleOperator.manager.containerSecurityContext.privileged`               |                                                                 | `false`                                  |
-| `lifecycleOperator.manager.containerSecurityContext.runAsGroup`               |                                                                 | `65532`                                  |
-| `lifecycleOperator.manager.containerSecurityContext.runAsNonRoot`             |                                                                 | `true`                                   |
-| `lifecycleOperator.manager.containerSecurityContext.runAsUser`                |                                                                 | `65532`                                  |
-| `lifecycleOperator.manager.containerSecurityContext.seccompProfile.type`      |                                                                 | `RuntimeDefault`                         |
-| `lifecycleOperator.manager.env.keptnAppControllerLogLevel`                    | sets the log level of Keptn App Controller                      | `0`                                      |
-| `lifecycleOperator.manager.env.keptnAppCreationRequestControllerLogLevel`     | sets the log level of Keptn App Creation Request Controller     | `0`                                      |
-| `lifecycleOperator.manager.env.keptnAppVersionControllerLogLevel`             | sets the log level of Keptn AppVersion Controller               | `0`                                      |
-| `lifecycleOperator.manager.env.keptnEvaluationControllerLogLevel`             | sets the log level of Keptn Evaluation Controller               | `0`                                      |
-| `lifecycleOperator.manager.env.keptnTaskControllerLogLevel`                   | sets the log level of Keptn Task Controller                     | `0`                                      |
-| `lifecycleOperator.manager.env.keptnTaskDefinitionControllerLogLevel`         | sets the log level of Keptn TaskDefinition Controller           | `0`                                      |
-| `lifecycleOperator.manager.env.keptnWorkloadControllerLogLevel`               | sets the log level of Keptn Workload Controller                 | `0`                                      |
-| `lifecycleOperator.manager.env.keptnWorkloadInstanceControllerLogLevel`       | sets the log level of Keptn WorkloadInstance Controller         | `0`                                      |
-| `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                  | `0`                                      |
-| `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                   | `otel-collector:4317`                    |
-| `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for task runtime <!---x-release-please-version--> | `ghcr.io/keptn/functions-runtime:v0.7.1` |
-| `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                              | `ghcr.io/keptn/lifecycle-operator`       |
-| `lifecycleOperator.manager.image.tag`                                         | select tag for manager image <!---x-release-please-version-->   | `v0.7.1`                                 |
-| `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                           | `Always`                                 |
-| `lifecycleOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container                      |                                          |
-| `lifecycleOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container                     |                                          |
-| `lifecycleOperator.manager.resources`                                         | specify limits and requests for manager container               |                                          |
+| Name                                                                          | Description                                                                        | Value                                    |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------- |
+| `lifecycleOperator.manager.containerSecurityContext`                          | Sets security context privileges                                                   |                                          |
+| `lifecycleOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                                                    | `false`                                  |
+| `lifecycleOperator.manager.containerSecurityContext.capabilities.drop`        |                                                                                    | `["ALL"]`                                |
+| `lifecycleOperator.manager.containerSecurityContext.privileged`               |                                                                                    | `false`                                  |
+| `lifecycleOperator.manager.containerSecurityContext.runAsGroup`               |                                                                                    | `65532`                                  |
+| `lifecycleOperator.manager.containerSecurityContext.runAsNonRoot`             |                                                                                    | `true`                                   |
+| `lifecycleOperator.manager.containerSecurityContext.runAsUser`                |                                                                                    | `65532`                                  |
+| `lifecycleOperator.manager.containerSecurityContext.seccompProfile.type`      |                                                                                    | `RuntimeDefault`                         |
+| `lifecycleOperator.manager.env.keptnAppControllerLogLevel`                    | sets the log level of Keptn App Controller                                         | `0`                                      |
+| `lifecycleOperator.manager.env.keptnAppCreationRequestControllerLogLevel`     | sets the log level of Keptn App Creation Request Controller                        | `0`                                      |
+| `lifecycleOperator.manager.env.keptnAppVersionControllerLogLevel`             | sets the log level of Keptn AppVersion Controller                                  | `0`                                      |
+| `lifecycleOperator.manager.env.keptnEvaluationControllerLogLevel`             | sets the log level of Keptn Evaluation Controller                                  | `0`                                      |
+| `lifecycleOperator.manager.env.keptnTaskControllerLogLevel`                   | sets the log level of Keptn Task Controller                                        | `0`                                      |
+| `lifecycleOperator.manager.env.keptnTaskDefinitionControllerLogLevel`         | sets the log level of Keptn TaskDefinition Controller                              | `0`                                      |
+| `lifecycleOperator.manager.env.keptnWorkloadControllerLogLevel`               | sets the log level of Keptn Workload Controller                                    | `0`                                      |
+| `lifecycleOperator.manager.env.keptnWorkloadInstanceControllerLogLevel`       | sets the log level of Keptn WorkloadInstance Controller                            | `0`                                      |
+| `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                                     | `0`                                      |
+| `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                                      | `otel-collector:4317`                    |
+| `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for task runtime with Deno runner <!---x-release-please-version-->   | `ghcr.io/keptn/functions-runtime:v0.7.1` |
+| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for task runtime with python runner <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:latest`    |
+| `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                                                 | `ghcr.io/keptn/lifecycle-operator`       |
+| `lifecycleOperator.manager.image.tag`                                         | select tag for manager image <!---x-release-please-version-->                      | `v0.7.1`                                 |
+| `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                                              | `Always`                                 |
+| `lifecycleOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container                                         |                                          |
+| `lifecycleOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container                                        |                                          |
+| `lifecycleOperator.manager.resources`                                         | specify limits and requests for manager container                                  |                                          |
 
 ### Keptn Metrics Operator common
 

--- a/helm/chart/doc.yaml
+++ b/helm/chart/doc.yaml
@@ -132,7 +132,8 @@
 ## @param   lifecycleOperator.manager.env.optionsControllerLogLevel sets the log level of Keptn Options Controller
 
 ## @param   lifecycleOperator.manager.env.otelCollectorUrl Sets the URL for the open telemetry collector
-## @param   lifecycleOperator.manager.env.functionRunnerImage specify image for task runtime <!---x-release-please-version-->
+## @param   lifecycleOperator.manager.env.functionRunnerImage specify image for task runtime with Deno runner <!---x-release-please-version-->
+## @param   lifecycleOperator.manager.env.pythonRunnerImage specify image for task runtime with python runner <!---x-release-please-version-->
 
 ## @param   lifecycleOperator.manager.image.repository specify registry for manager image
 ## @param   lifecycleOperator.manager.image.tag  select tag for manager image <!---x-release-please-version-->

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -78,7 +78,7 @@ lifecycleOperator:
       keptnWorkloadInstanceControllerLogLevel: "0"
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
-      pythonRunnerImage: ghcr.io/keptn/python-runtime:latest
+      pythonRunnerImage: ghcr.io/keptn/python-runtime:0.0.0
     image:
       repository: ghcr.io/keptn/lifecycle-operator
       tag: v0.7.1

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -68,7 +68,6 @@ lifecycleOperator:
         type: RuntimeDefault
     env:
       functionRunnerImage: ghcr.io/keptn/functions-runtime:v0.7.1
-      pythonRunnerImage: ghcr.io/keptn/python-runtime:latest
       keptnAppControllerLogLevel: "0"
       keptnAppCreationRequestControllerLogLevel: "0"
       keptnAppVersionControllerLogLevel: "0"
@@ -79,6 +78,7 @@ lifecycleOperator:
       keptnWorkloadInstanceControllerLogLevel: "0"
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
+      pythonRunnerImage: ghcr.io/keptn/python-runtime:latest
     image:
       repository: ghcr.io/keptn/lifecycle-operator
       tag: v0.7.1

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -68,6 +68,7 @@ lifecycleOperator:
         type: RuntimeDefault
     env:
       functionRunnerImage: ghcr.io/keptn/functions-runtime:v0.7.1
+      pythonRunnerImage: ghcr.io/keptn/python-runtime:latest
       keptnAppControllerLogLevel: "0"
       keptnAppCreationRequestControllerLogLevel: "0"
       keptnAppVersionControllerLogLevel: "0"

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
             - name: FUNCTION_RUNNER_IMAGE
               value: ghcr.io/keptn/functions-runtime:v0.7.1 # x-release-please-version
             - name: PYTHON_RUNNER_IMAGE
-              value: ghcr.io/keptn/python-runtime:latest # x-release-please-version
+              value: ghcr.io/keptn/python-runtime:0.0.0 # x-release-please-version
             - name: OTEL_COLLECTOR_URL
               value: otel-collector:4317
             - name: KEPTN_APP_CONTROLLER_LOG_LEVEL

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -67,6 +67,8 @@ spec:
                   fieldPath: metadata.name
             - name: FUNCTION_RUNNER_IMAGE
               value: ghcr.io/keptn/functions-runtime:v0.7.1 # x-release-please-version
+            - name: PYTHON_RUNNER_IMAGE
+              value: ghcr.io/keptn/python-runtime:latest # x-release-please-version
             - name: OTEL_COLLECTOR_URL
               value: otel-collector:4317
             - name: KEPTN_APP_CONTROLLER_LOG_LEVEL

--- a/python-runtime/Dockerfile
+++ b/python-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9 AS production
+FROM python:3.9-alpine AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
     "ghcr.io/keptn/lifecycle-operator",
     "ghcr.io/keptn/scheduler",
     "ghcr.io/keptn/functions-runtime",
+    "ghcr.io/keptn/python-runtime",
     "ghcr.io/keptn/certificate-operator",
     "ghcr.io/keptn/metrics-operator"
   ],


### PR DESCRIPTION
Fixes: #1491 

## Changes
 - changed python-runtime base image from `python:3.9` to `python:3.9-alpine` to make the image size smaller
 - added python-runtime to all pipelines
 - added env variable pointing to the image into klt-operator Deployment
 - added helm value for setting up the image + updated the docs

Image available in ghrc: https://github.com/keptn/lifecycle-toolkit/pkgs/container/python-runtime