### PR TITLE
test(metrics-operator): wait for go routine to be finished before doing assertions

### DIFF
--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
@@ -199,10 +199,8 @@ func TestGetDQLTimeout(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	mockClock.Add(retryFetchInterval * (maxRetries + 1))
-
-	require.Len(t, mockClient.DoCalls(), maxRetries+1)
-
 	wg.Wait()
+	require.Len(t, mockClient.DoCalls(), maxRetries+1)
 }
 
 func TestGetDQLCannotPostQuery(t *testing.T) {


### PR DESCRIPTION
This should fix a flaky test that failed on rare occasions, such as here: https://github.com/keptn/lifecycle-toolkit/actions/runs/5144102713/jobs/9259970240?pr=1482