### PR TITLE
docs: document container-runtime feature

### DIFF
--- a/docs/content/en/docs/implementing/container.md
+++ b/docs/content/en/docs/implementing/container.md
@@ -1,0 +1,37 @@
+---
+title: Working with container runtimes
+description: How to run tasks in container runtimes
+weight: 95
+---
+
+Container runtimes allow the Keptn Lifecycle Toolkit
+to execute tasks in Kubernetes containers.
+This is similar to the Keptn v1 Job Executor Service.
+
+This is a new feature introduced in v0.8.0
+that is useful for:
+
+- Running load/performance testing tools
+- Running tasks expressed in other languages such as Python
+- [TODO] What else?
+- Running SLO validations
+
+To implement this feature:
+
+- Define a
+  [KeptnTaskDefinition](../yaml-crd-ref/taskdefinition.md)
+  resource that defines the container
+- Populate a [KeptnApp](../yaml-crd-ref/app.md)
+  resource that associates that container definition
+  with the pre- and post-deployment tasks
+  that should run in it
+
+## Using containers for SLO validation
+
+One special use case for container runtimes
+is to implement SLO (Service-Level Objectives) validation coming from
+OpenTelementry workload traces.
+Basically, you define OpenTelemetry traces
+as SLIs (Service-Level Indicators)
+that can be queried from the OpenTelemetry backend using tools such as
+[Grafana Tempo](https://grafana.com/oss/tempo/).

--- a/docs/content/en/docs/yaml-crd-ref/app.md
+++ b/docs/content/en/docs/yaml-crd-ref/app.md
@@ -6,10 +6,15 @@ weight: 10
 
 `KeptnApp` defines a list of workloads
 that together constitute a logical application.
-It contains information about all workloads and checks
-that are associated with a Keptn application
-and a list of tasks and evaluations to be executed
-pre- and post-deployment.
+It contains information about:
+
+- All workloads and checks
+  that are associated with a Keptn application
+- A list of tasks and evaluations to be executed
+  pre- and post-deployment.
+- Tasks referenced by `KeptnApp` are defined in a
+  [KeptnTaskDefinition](taskdefinition.md) resource,
+  which can define either an executable task or a container.
 
 ## Synopsis
 
@@ -58,7 +63,8 @@ spec:
     to trigger another deployment of a `KeptnApp` of the same version.
     For example, increment this number to restart a `KeptnApp` version
     that failed to deploy, perhaps because a
-    `preDeploymentEvaluation` or `preDeploymentTask` failed.
+    `preDeploymentEvaluation` or `preDeploymentTask` failed
+    for reasons that may be transient.
   * **workloads**
     * **name** - name of this Kubernetes
       [workload](https://kubernetes.io/docs/concepts/workloads/).
@@ -67,13 +73,14 @@ spec:
       associated with this Keptn application.
     * **version** -- version number for this workload.
       Changing this number causes a new execution
-      of checks for the Keptn application and the new version of the workload.
-  * **preDeploymentTasks** -- list each task to be run
-    as part of the pre-deployment stage.
-    Task names must match the value of the `name` field
+      of checks for this workload only,
+      not the entire application.
+  * **preDeploymentTasks** -- list each task or container
+    to be run as part of the pre-deployment stage.
+    Task names must match the value of the `metadata.name` field
     for the associated [KeptnTaskDefinition](taskdefinition.md) resource.
-  * **postDeploymentTasks** -- list each task to be run
-    as part of the post-deployment stage.
+  * **postDeploymentTasks** -- list each task or container
+    to be run as part of the post-deployment stage.
     Task names must match the value of the `name` field
     for the associated [KeptnTaskDefinition](taskdefinition.md) resource.
   * **preDeploymentEvaluations** -- list each evaluation to be run
@@ -107,7 +114,9 @@ based on Keptn or [recommended Kubernetes labels](https://kubernetes.io/docs/con
 This allows you to use the KLT observability features for existing resources
 without manually populating any Keptn related resources.
 
-## Example
+## Examples
+
+### Example 1: referencing Deno tasks
 
 ```yaml
 apiVersion: lifecycle.keptn.sh/v1alpha3
@@ -128,6 +137,27 @@ spec:
   - my-prometheus-definition
 ```
 
+### Referencing containers
+
+For an example of a `KeptnApp` resource definition
+that references a container, see
+[app.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-3/app.yaml).
+The `spec` includes:
+
+```yaml
+spec:
+  version: "0.1.2"
+  workloads:
+    - name: podtato-head-left-arm
+      version: 0.1.1
+    ...
+  preDeploymentTasks:
+    - container-sleep
+```
+
+This container is defined in
+[container-task.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/container-task.yaml).
+
 ## Files
 
 ## Differences between versions
@@ -136,4 +166,9 @@ The `spec.Revision` field is introduced in v1alpha2.
 
 ## See also
 
+* [KeptnTaskDefinition](taskdefinition.md)
+* [Working with tasks](../implementing/tasks)
+* [Working with container runtimes](../implementing/container.md)
+* [Pre- and post-deployment tasks](../implementing/integrate/#pre--and-post-deployment-checks)
+* [Orchestrate deployment checks](../getting-started/orchestrate)
 [Use Keptn automatic app discovery](../implementing/integrate/#use-keptn-automatic-app-discovery)


### PR DESCRIPTION
Document the container-runtime feature as implemented in https://github.com/keptn/lifecycle-toolkit/pull/1493.
This satisfies https://github.com/keptn/lifecycle-toolkit/issues/1489.

This PR includes:
* Updates to the `KeptnTaskDefinition` page to show containers in Synopsis, Field definitions, and examples
* Updates to the `KeptnApp` page to show that a task can be referenced as a container and show examples
* Draft a new guide chapter in the "Implementing" section about working with containers