### PR TITLE
feat: cert-manager monorepo setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,12 @@ jobs:
   release-please:
     runs-on: ubuntu-22.04
     outputs:
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      klt-release-created: ${{ steps.release.outputs.release_created }}
+      klt-tag-name: ${{ steps.release.outputs.tag_name }}
+      cert-manager-release-created: ${{ steps.release.outputs.klt-cert-manager--release_created }}
+      cert-manager-tag-name: ${{ steps.release.outputs.klt-cert-manager--tag_name }}
+      releases-created: ${{ steps.release.outputs.releases_created }}
+      build-matrix: ${{ steps.build-matrix.outputs.result }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,25 +40,76 @@ jobs:
           default-branch: main
           signoff: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
 
+      - name: Release Info
+        run: |
+          echo "Release KLT:              ${{ steps.release.outputs.release_created }}"
+          echo "Release KLT Cert Manager: ${{ steps.release.outputs.klt-cert-manager--release_created }}"
+          echo "Anything to release:      ${{ steps.release.outputs.releases_created }}"
+          echo "Paths to be released:     ${{ steps.release.outputs.paths_released }}"
+
+      - name: Create build matrix
+        id: build-matrix
+        uses: actions/github-script@v6
+        env:
+          RELEASE_KLT: ${{ steps.release.outputs.release_created }}
+          RELEASE_CERT_MANAGER: ${{ steps.release.outputs.klt-cert-manager--release_created }}
+          KLT_TAG: ${{ steps.release.outputs.tag_name }}
+          CERT_MANAGER_TAG: ${{ steps.release.outputs.klt-cert-manager--tag_name }}
+        with:
+          script: |
+            const { RELEASE_KLT, RELEASE_CERT_MANAGER, KLT_TAG, CERT_MANAGER_TAG } = process.env
+            const kltMatrix = [
+              {
+                  name: "lifecycle-operator",
+                  folder: "operator/",
+                  tagName: KLT_TAG
+              },
+              {
+                  name: "metrics-operator",
+                  folder: "metrics-operator/",
+                  tagName: KLT_TAG
+              },
+              {
+                  name: "scheduler",
+                  folder: "scheduler/",
+                  tagName: KLT_TAG
+              },
+              {
+                  name: "functions-runtime",
+                  folder: "functions-runtime/",
+                  tagName: KLT_TAG
+              },
+              {
+                  name: "python-runtime",
+                  folder: "python-runtime/",
+                  tagName: KLT_TAG
+              }
+            ]
+
+            const certManagerMatrix = [
+              {
+                  name: "certificate-operator",
+                  folder: "klt-cert-manager/",
+                  tagName: CERT_MANAGER_TAG
+              }
+            ]
+
+            let result = {}
+            if (RELEASE_KLT === "true" && RELEASE_CERT_MANAGER === "true") {
+                result = { config: [...kltMatrix, ...certManagerMatrix]}
+            } else if (RELEASE_KLT === "true") {
+                result = { config: kltMatrix }
+            } else if (RELEASE_CERT_MANAGER === "true") {
+                result = { config: certManagerMatrix }
+            }
+            return result
+
   build-release:
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: needs.release-please.outputs.releases-created == 'true'
     needs:
       - release-please
     strategy:
-      matrix:
-        config:
-          - name: "lifecycle-operator"
-            folder: "operator/"
-          - name: "metrics-operator"
-            folder: "metrics-operator/"
-          - name: "scheduler"
-            folder: "scheduler/"
-          - name: "functions-runtime"
-            folder: "functions-runtime/"
-          - name: "python-runtime"
-            folder: "python-runtime/"
-          - name: "certificate-operator"
-            folder: "klt-cert-manager/"
+      matrix: ${{ fromJson(needs.release-please.outputs.build-matrix) }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -62,7 +117,6 @@ jobs:
       id-token: write
     env:
       IMAGE_NAME: ghcr.io/keptn/${{ matrix.config.name }}
-      IMAGE_TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,6 +137,15 @@ jobs:
       - name: Set up Cosign
         uses: sigstore/cosign-installer@v3.0.5
 
+      - name: Clean up image tag
+        id: clean-image-tag
+        env:
+          IMAGE_TAG: ${{ matrix.config.tagName }}
+        run: |
+          # Remove artifact prefix from tag so that we get clean image tags
+          temp="${IMAGE_TAG##klt-}"
+          echo "IMAGE_TAG=${temp##cert-manager-}" >> "$GITHUB_OUTPUT"
+
       - name: Build Docker Image
         id: docker_build_image
         uses: docker/build-push-action@v4
@@ -91,7 +154,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           target: production
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ env.IMAGE_NAME }}:${{ steps.clean-image-tag.outputs.IMAGE_TAG }}
           build-args: |
             GIT_HASH=${{ env.GIT_SHA }}
             RELEASE_VERSION=dev-${{ env.DATETIME }}
@@ -116,18 +179,18 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0.14.2
         with:
-          image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          image: ${{ env.IMAGE_NAME }}:${{ steps.clean-image-tag.outputs.IMAGE_TAG }}
           artifact-name: sbom-${{ matrix.config.name }}
           output-file: ./sbom-${{ matrix.config.name }}.spdx.json
 
       - name: Attach SBOM to release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          tag_name: ${{ matrix.config.tagName }}
           files: ./sbom-${{ matrix.config.name }}.spdx.json
 
   release-manifests:
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: needs.release-please.outputs.releases-created == 'true'
     needs:
       - release-please
       - build-release
@@ -137,13 +200,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache build tools operator
+        if: needs.release-please.outputs.klt-release-created == 'true'
         id: cache-build-tools-operator
         uses: actions/cache@v3
         with:
           path: ./operator/bin
           key: build-tools-${{ github.ref_name }}
 
+      - name: Cache build tools metrics-operator
+        if: needs.release-please.outputs.klt-release-created == 'true'
+        id: cache-build-tools-metrics-operator
+        uses: actions/cache@v3
+        with:
+          path: ./metrics-operator/bin
+          key: build-tools-${{ github.ref_name }}
+
       - name: Cache build tools scheduler
+        if: needs.release-please.outputs.klt-release-created == 'true'
         id: cache-build-tools-scheduler
         uses: actions/cache@v3
         with:
@@ -151,6 +224,7 @@ jobs:
           key: build-tools-${{ github.ref_name }}
 
       - name: Cache build tools cert-manager
+        if: needs.release-please.outputs.cert-manager-release-created == 'true'
         id: cache-build-tools-klt-cert-manager
         uses: actions/cache@v3
         with:
@@ -163,10 +237,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
-      - name: Create manifests
+      - name: Create KLT manifest
+        if: needs.release-please.outputs.klt-release-created == 'true'
         env:
           RELEASE_REGISTRY: ghcr.io/keptn
-          CHART_APPVERSION: ${{ needs.release-please.outputs.tag_name }}
+          CHART_APPVERSION: ${{ needs.release-please.outputs.klt-tag-name }}
         run: |
           cd scheduler
           make release-manifests
@@ -189,24 +264,44 @@ jobs:
           ---
           EOF
           cat namespace.yaml \
-              operator/config/rendered/release.yaml \
-              scheduler/config/rendered/release.yaml \
-              klt-cert-manager/config/rendered/release.yaml \
-              metrics-operator/config/rendered/release.yaml > manifest.yaml
+            operator/config/rendered/release.yaml \
+            scheduler/config/rendered/release.yaml \
+            klt-cert-manager/config/rendered/release.yaml \
+            metrics-operator/config/rendered/release.yaml > klt-manifest.yaml
 
-      - name: Attach release assets
+      - name: Create Cert-Manager manifest
+        if: needs.release-please.outputs.cert-manager-release-created == 'true'
+        env:
+          RELEASE_REGISTRY: ghcr.io/keptn
+          CHART_APPVERSION: ${{ needs.release-please.outputs.cert-manager-tag-name }}
+        run: |
+          cd klt-cert-manager
+          make controller-gen release-manifests
+          cd ..
+          echo "---" >> klt-cert-manager/config/rendered/release.yaml
+          cat klt-cert-manager/config/rendered/release.yaml > cert-manager-manifest.yaml
+
+      - name: Attach KLT release assets
+        if: needs.release-please.outputs.klt-release-created == 'true'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: manifest.yaml
+          tag_name: ${{ needs.release-please.outputs.klt-tag-name }}
+          files: klt-manifest.yaml
+
+      - name: Attach Cert-Manager release assets
+        if: needs.release-please.outputs.cert-manager-release-created == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release-please.outputs.cert-manager-tag-name }}
+          files: cert-manager-manifest.yaml
 
   update-docs:
     name: Update Documentation
     needs:
       - release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: needs.release-please.outputs.klt-release-created == 'true'
     with:
-      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      tag_name: ${{ needs.release-please.outputs.klt-tag-name }}
     uses: keptn/docs-tooling/.github/workflows/release-docs.yml@v0.1.2
     secrets: inherit
 
@@ -214,8 +309,8 @@ jobs:
     name: Update examples
     needs:
       - release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: needs.release-please.outputs.klt-release-created == 'true'
     with:
-      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      tag_name: ${{ needs.release-please.outputs.klt-tag-name }}
     uses: ./.github/workflows/release-examples.yml
     secrets: inherit

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -15,6 +15,6 @@ customRules:
   - "./docs/rules/max-one-sentence-per-line.js"
 
 ignores:
-  - "CHANGELOG.md"
+  - "**/CHANGELOG.md"
   - "node_modules"
   - "docs/tmp"

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -15,7 +15,7 @@ certificateOperator:
       labelSelectorValue: "true"
     image:
       repository: ghcr.io/keptn/certificate-operator
-      tag: v0.7.1
+      tag: v0.8.0
     imagePullPolicy: Always
     livenessProbe:
       httpGet:
@@ -67,7 +67,7 @@ lifecycleOperator:
       seccompProfile:
         type: RuntimeDefault
     env:
-      functionRunnerImage: ghcr.io/keptn/functions-runtime:v0.7.1
+      functionRunnerImage: ghcr.io/keptn/functions-runtime:v0.8.0
       keptnAppControllerLogLevel: "0"
       keptnAppCreationRequestControllerLogLevel: "0"
       keptnAppVersionControllerLogLevel: "0"
@@ -78,10 +78,10 @@ lifecycleOperator:
       keptnWorkloadInstanceControllerLogLevel: "0"
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
-      pythonRunnerImage: ghcr.io/keptn/python-runtime:v0.0.0
+      pythonRunnerImage: ghcr.io/keptn/python-runtime:v0.8.0
     image:
       repository: ghcr.io/keptn/lifecycle-operator
-      tag: v0.7.1
+      tag: v0.8.0
     imagePullPolicy: Always
     livenessProbe:
       httpGet:
@@ -148,7 +148,7 @@ metricsOperator:
       metricsControllerLogLevel: "0"
     image:
       repository: ghcr.io/keptn/metrics-operator
-      tag: v0.7.1
+      tag: v0.8.0
     livenessProbe:
       httpGet:
         path: /healthz
@@ -211,7 +211,7 @@ scheduler:
       otelCollectorUrl: otel-collector:4317
     image:
       repository: ghcr.io/keptn/scheduler
-      tag: v0.7.1
+      tag: v0.8.0
     imagePullPolicy: Always
     livenessProbe:
       httpGet:

--- a/klt-cert-manager/Dockerfile
+++ b/klt-cert-manager/Dockerfile
@@ -36,7 +36,7 @@ FROM gcr.io/distroless/static-debian11:debug-nonroot AS debug
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \
-    org.opencontainers.image.title="Keptn Lifecycle Certificate Manager" \
+    org.opencontainers.image.title="Keptn Lifecycle Toolkit Certificate Manager" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.licenses="Apache-2.0"
 
@@ -49,7 +49,7 @@ FROM gcr.io/distroless/static-debian11:nonroot AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit/klt-cert-manager" \
     org.opencontainers.image.url="https://keptn.sh" \
-    org.opencontainers.image.title="Keptn Lifecycle Certificate Manager" \
+    org.opencontainers.image.title="Keptn Lifecycle Toolkit Certificate Manager" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.licenses="Apache-2.0"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,18 @@
 {
+  "separate-pull-requests": true,
+  "last-release-sha": "d5000da9b2aa8c02ae0b10129b7066ddd9a573fb",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "packages": {
     ".": {
+      "package-name": "klt",
       "changelog-path": "CHANGELOG.md",
       "release-type": "go",
       "prerelease": false,
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "pull-request-title-pattern": "chore: release${component} ${version}",
+      "monorepo-tags": "klt",
       "draft": false,
+      "exclude-paths": ["klt-cert-manager"],
       "extra-files": [
         "README.md",
         "operator/config/manager/manager.yaml",
@@ -15,68 +20,78 @@
         "Makefile",
         "operator/Makefile",
         "scheduler/Makefile",
-        "klt-cert-manager/Makefile",
         "metrics-operator/Makefile",
         "docs/content/en/docs/snippets/tasks/install.md",
         "helm/chart/values.yaml",
         "helm/chart/README.md"
-      ],
-      "changelog-sections": [
-        {
-          "type": "feat",
-          "section": "Features"
-        },
-        {
-          "type": "fix",
-          "section": "Bug Fixes"
-        },
-        {
-          "type": "chore",
-          "section": "Other"
-        },
-        {
-          "type": "docs",
-          "section": "Docs"
-        },
-        {
-          "type": "perf",
-          "section": "Performance"
-        },
-        {
-          "type": "build",
-          "hidden": true,
-          "section": "Build"
-        },
-        {
-          "type": "deps",
-          "section": "Dependency Updates"
-        },
-        {
-          "type": "ci",
-          "hidden": true,
-          "section": "CI"
-        },
-        {
-          "type": "refactor",
-          "section": "Refactoring"
-        },
-        {
-          "type": "revert",
-          "hidden": true,
-          "section": "Reverts"
-        },
-        {
-          "type": "style",
-          "hidden": true,
-          "section": "Styling"
-        },
-        {
-          "type": "test",
-          "hidden": true,
-          "section": "Tests"
-        }
+      ]
+    },
+    "klt-cert-manager": {
+      "package-name": "cert-manager",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "go",
+      "monorepo-tags": "cert-manager",
+      "prerelease": false,
+      "draft": false,
+      "extra-files": [
+        "Makefile"
       ]
     }
   },
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "chore",
+      "section": "Other"
+    },
+    {
+      "type": "docs",
+      "section": "Docs"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "build",
+      "hidden": true,
+      "section": "Build"
+    },
+    {
+      "type": "deps",
+      "section": "Dependency Updates"
+    },
+    {
+      "type": "ci",
+      "hidden": true,
+      "section": "CI"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring"
+    },
+    {
+      "type": "revert",
+      "hidden": true,
+      "section": "Reverts"
+    },
+    {
+      "type": "style",
+      "hidden": true,
+      "section": "Styling"
+    },
+    {
+      "type": "test",
+      "hidden": true,
+      "section": "Tests"
+    }
+  ],
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
### This PR
- sets up release please to work with the KLT repo as a monorepo with separate releases for KLT and KLT cert-manager
- Separate release PRs will be created for the 2 artifacts that can be merged separately. Release Please will create separate git tags and github releases for 2 artifacts as well

Fixes: #1139