### PR TITLE
ci: remove requirement for semantic commit in single-commit PRs

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -48,7 +48,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           # Configure additional validation for the subject based on a regex.
           # This ensures the subject doesn't start with an uppercase character.
           subjectPattern: ^(?![A-Z]).+$


### PR DESCRIPTION
### This PR
- disables the semantic PR check for single commit PRs preventing PRs to be merged that have a single commit that is not semantic. This is not needed anymore since github introduced a setting to always use the PR title as the commit message during squash and merge.