### PR TITLE
docs: migration strategy

### DIFF
--- a/docs/content/en/docs/migrate/_index.md
+++ b/docs/content/en/docs/migrate/_index.md
@@ -20,8 +20,9 @@ and questions that you have.
 
 This section currently includes the following topics:
 
-* [Evolution of KLT](../evolution-klt)
+* Evolution of KLT --
   Understand the paradigm of KLT and how it evolved from Keptn v1.
   Also see whether migrating to KLT is appropriate for your deployments
 
-* [Migration strategy](../strategy)
+* Migration strategy -- Summary of the steps, in a suggested order,
+  for migrating your projects from Keptn v1 to KLT

--- a/docs/content/en/docs/migrate/_index.md
+++ b/docs/content/en/docs/migrate/_index.md
@@ -1,0 +1,27 @@
+---
+title: Migrating to the Keptn Lifecycle Toolkit
+description: Notes to help you migrate from Keptn v1 to KLT
+weight: 20
+hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
+---
+
+The Keptn Lifecycle Toolkit uses a different paradigm
+than that used for Keptn v1
+and so migration from Keptn v1 will not be a straight-forward process.
+In this section, we will assemble information to help people
+who want to move from Keptn v1 as it becomes available.
+
+> **Note**
+This section is under development.
+Information that is published here has been reviewed for technical accuracy
+but the format and content is still evolving.
+We hope you will contribute your experiences
+and questions that you have.
+
+This section currently includes the following topics:
+
+* [Evolution of KLT](../evolution-klt)
+  Understand the paradigm of KLT and how it evolved from Keptn v1.
+  Also see whether migrating to KLT is appropriate for your deployments
+
+* [Migration strategy](../strategy)

--- a/docs/content/en/docs/migrate/strategy/_index.md
+++ b/docs/content/en/docs/migrate/strategy/_index.md
@@ -1,0 +1,60 @@
+---
+title: Migration strategy
+description: General guidelines for migrating your deployment to KLT
+weight: 10
+hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
+---
+
+> **Note**
+This section is under development.
+Information that is published here has been reviewed for technical accuracy
+but the format and content is still evolving.
+We hope you will contribute your experiences
+and questions that you have.
+
+No two migrations are alike but these are some general guidelines
+for how to approach the project:
+
+1. Create a new Kubernetes cluster that is not running anything else
+   and use that to build out your deployment environment.
+1. Install and configure the deployment tool(s) you want to use
+   to deploy the components of your software.
+   You can use different deployment tools for different components.
+1. Install KLT.
+
+TODO: For migration, is it best to try to do all the applications at once
+or should they do one application then move onto the next?
+
+TODO: Similarly, would they start out doing one pre-deployment evaluation,
+then one post-deployment evaluation, then one pre-deployment task,
+then one post-deployment task?  Or would you just dig in and do them all?
+
+1. Integrate KLT with your applications:
+   - If you are only using Custom Metrics and Observability,
+     you only need to do basic annotations.
+   - If you want to do pre- and post-deployment evaluations and tasks,
+     include those annotations as well.
+   - In all cases, define a KeptnApp resource
+     for each application you are deploying.
+     You can do this manually but the easiest approach
+     is to use the Keptn automatic app discovery feature
+     to create the basic KeptnApp resource.
+     You can then manually modify that resource as needed
+     but easily create the basic structure.
+     
+1. Install and configure OpenTelemetry.
+1. Install and configure the data providers you want to use.
+   Prometheus, Dynatrace, and Datadog are currently supported.
+   KLT can access multiple data providers
+   and multiple copies of each data provider.
+1. Populate a KeptnMetricsProvider for each copy
+   of each data provider you are using.
+1. <Other steps>
+1. Convert "simple" quality gates into KeptnMetric
+   and KeptnEvaluation resources.
+   TODO: Yeah, this will be a big section!
+   - TODO: Is there a way to modify queries on the data provider
+     or maybe implement a task that compares some values and
+     does some math to migrate more complex quality gates?
+1. Convert Keptn v1 remediation sequences into "Day 2"
+   KeptnEvaluations and KeptnTaskDefinition resources.

--- a/docs/content/en/docs/migrate/strategy/_index.md
+++ b/docs/content/en/docs/migrate/strategy/_index.md
@@ -42,14 +42,19 @@ Or would you just dig in and do them all?
      to create the basic KeptnApp resource.
      You can then manually modify that resource as needed
      but easily create the basic structure.
-1. Install and configure OpenTelemetry.
-1. Install and configure the data providers you want to use.
-   Prometheus, Dynatrace, and Datadog are currently supported.
-   KLT can access multiple data providers
-   and multiple copies of each data provider.
-1. Populate a KeptnMetricsProvider for each copy
-   of each data provider you are using.
-1. Other steps
+
+1. Set up Keptn Metrics and Observability.
+   - Configure your data sources as `KeptnMetricProviders`.
+   - Install and configure OpenTelemetry.
+   - Install and configure the data providers you want to use.
+     Prometheus, Dynatrace, and Datadog are currently supported.
+     KLT can access multiple data providers
+     and multiple copies of each data provider.
+   - Populate a KeptnMetricsProvider for each copy
+     of each data provider you are using.
+   - Run some deployments and use the metrics and observability features
+     to monitor the process
+1. Set up CI/CD tasks
 1. Convert "simple" quality gates into KeptnMetric
    and KeptnEvaluation resources.
    TODO: Yeah, this will be a big section!

--- a/docs/content/en/docs/migrate/strategy/_index.md
+++ b/docs/content/en/docs/migrate/strategy/_index.md
@@ -27,7 +27,8 @@ or should they do one application then move onto the next?
 
 TODO: Similarly, would they start out doing one pre-deployment evaluation,
 then one post-deployment evaluation, then one pre-deployment task,
-then one post-deployment task?  Or would you just dig in and do them all?
+then one post-deployment task?
+Or would you just dig in and do them all?
 
 1. Integrate KLT with your applications:
    - If you are only using Custom Metrics and Observability,
@@ -41,7 +42,6 @@ then one post-deployment task?  Or would you just dig in and do them all?
      to create the basic KeptnApp resource.
      You can then manually modify that resource as needed
      but easily create the basic structure.
-     
 1. Install and configure OpenTelemetry.
 1. Install and configure the data providers you want to use.
    Prometheus, Dynatrace, and Datadog are currently supported.
@@ -49,7 +49,7 @@ then one post-deployment task?  Or would you just dig in and do them all?
    and multiple copies of each data provider.
 1. Populate a KeptnMetricsProvider for each copy
    of each data provider you are using.
-1. <Other steps>
+1. Other steps
 1. Convert "simple" quality gates into KeptnMetric
    and KeptnEvaluation resources.
    TODO: Yeah, this will be a big section!


### PR DESCRIPTION
This creates the migrate directory and includes the beginnings of an _index.md file plus the strategy section.

It would be nice to get this merged so that other PRs could be generated for sub-sections but this should be part of the 0.9.0 release; it is not ready to be included in the 0.8.0 release