### PR TITLE
chore: remove decoder injector interface from webhook

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -343,7 +343,7 @@ func main() {
 
 		setupLog.Info("starting webhook and manager")
 
-		decoder := admission.NewDecoder(mgr.GetScheme())
+		decoder, _ := admission.NewDecoder(mgr.GetScheme())
 		if err := webhookBuilder.Run(mgr, map[string]*ctrlWebhook.Admission{
 			"/mutate-v1-pod": {
 				Handler: &pod_mutator.PodMutatingWebhook{

--- a/operator/main.go
+++ b/operator/main.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlWebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var (
@@ -341,12 +342,15 @@ func main() {
 			)
 
 		setupLog.Info("starting webhook and manager")
+
+		decoder := admission.NewDecoder(mgr.GetScheme())
 		if err := webhookBuilder.Run(mgr, map[string]*ctrlWebhook.Admission{
 			"/mutate-v1-pod": {
 				Handler: &pod_mutator.PodMutatingWebhook{
 					Client:   mgr.GetClient(),
 					Tracer:   otel.Tracer("keptn/webhook"),
 					Recorder: mgr.GetEventRecorderFor("keptn/webhook"),
+					Decoder:  decoder,
 					Log:      ctrl.Log.WithName("Mutating Webhook"),
 				},
 			},

--- a/operator/main.go
+++ b/operator/main.go
@@ -343,7 +343,12 @@ func main() {
 
 		setupLog.Info("starting webhook and manager")
 
-		decoder, _ := admission.NewDecoder(mgr.GetScheme())
+		decoder, err := admission.NewDecoder(mgr.GetScheme())
+		if err != nil {
+			setupLog.Error(err, "unable to initialize decoder")
+			os.Exit(1)
+		}
+
 		if err := webhookBuilder.Run(mgr, map[string]*ctrlWebhook.Admission{
 			"/mutate-v1-pod": {
 				Handler: &pod_mutator.PodMutatingWebhook{

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook.go
@@ -123,9 +123,6 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }
 
-// PodMutatingWebhook implements admission.DecoderInjector.
-// A decoder will be automatically injected.
-
 func (a *PodMutatingWebhook) isPodAnnotated(pod *corev1.Pod) bool {
 	_, gotWorkloadAnnotation := getLabelOrAnnotation(&pod.ObjectMeta, apicommon.WorkloadAnnotation, apicommon.K8sRecommendedWorkloadAnnotations)
 	_, gotVersionAnnotation := getLabelOrAnnotation(&pod.ObjectMeta, apicommon.VersionAnnotation, apicommon.K8sRecommendedVersionAnnotations)

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook.go
@@ -126,12 +126,6 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 // PodMutatingWebhook implements admission.DecoderInjector.
 // A decoder will be automatically injected.
 
-// InjectDecoder injects the decoder.
-func (a *PodMutatingWebhook) InjectDecoder(d *admission.Decoder) error {
-	a.decoder = d
-	return nil
-}
-
 func (a *PodMutatingWebhook) isPodAnnotated(pod *corev1.Pod) bool {
 	_, gotWorkloadAnnotation := getLabelOrAnnotation(&pod.ObjectMeta, apicommon.WorkloadAnnotation, apicommon.K8sRecommendedWorkloadAnnotations)
 	_, gotVersionAnnotation := getLabelOrAnnotation(&pod.ObjectMeta, apicommon.VersionAnnotation, apicommon.K8sRecommendedVersionAnnotations)

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook.go
@@ -39,7 +39,7 @@ import (
 type PodMutatingWebhook struct {
 	Client   client.Client
 	Tracer   trace.Tracer
-	decoder  *admission.Decoder
+	Decoder  *admission.Decoder
 	Recorder record.EventRecorder
 	Log      logr.Logger
 }
@@ -65,7 +65,7 @@ func (a *PodMutatingWebhook) Handle(ctx context.Context, req admission.Request) 
 
 	pod := &corev1.Pod{}
 
-	err := a.decoder.Decode(req, pod)
+	err := a.Decoder.Decode(req, pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook_test.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook_test.go
@@ -28,7 +28,7 @@ func TestPodMutatingWebhook_getOwnerReference(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -86,7 +86,7 @@ func TestPodMutatingWebhook_getOwnerReference(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -101,7 +101,7 @@ func TestPodMutatingWebhook_getAppName(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -162,7 +162,7 @@ func TestPodMutatingWebhook_getAppName(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -177,7 +177,7 @@ func TestPodMutatingWebhook_getWorkloadName(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -242,7 +242,7 @@ func TestPodMutatingWebhook_getWorkloadName(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -367,7 +367,7 @@ func TestPodMutatingWebhook_isPodAnnotated(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -450,7 +450,7 @@ func TestPodMutatingWebhook_isPodAnnotated(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -538,7 +538,7 @@ func TestPodMutatingWebhook_copyAnnotationsIfParentAnnotated(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -692,7 +692,7 @@ func TestPodMutatingWebhook_copyAnnotationsIfParentAnnotated(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -708,7 +708,7 @@ func TestPodMutatingWebhook_copyResourceLabelsIfPresent(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -851,7 +851,7 @@ func TestPodMutatingWebhook_copyResourceLabelsIfPresent(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -870,7 +870,7 @@ func TestPodMutatingWebhook_isAppAnnotationPresent(t *testing.T) {
 	type fields struct {
 		Client   client.Client
 		Tracer   trace.Tracer
-		decoder  *admission.Decoder
+		Decoder  *admission.Decoder
 		Recorder record.EventRecorder
 		Log      logr.Logger
 	}
@@ -931,7 +931,7 @@ func TestPodMutatingWebhook_isAppAnnotationPresent(t *testing.T) {
 			a := &PodMutatingWebhook{
 				Client:   tt.fields.Client,
 				Tracer:   tt.fields.Tracer,
-				decoder:  tt.fields.decoder,
+				Decoder:  tt.fields.Decoder,
 				Recorder: tt.fields.Recorder,
 				Log:      tt.fields.Log,
 			}
@@ -965,7 +965,7 @@ func TestPodMutatingWebhook_Handle_DisabledNamespace(t *testing.T) {
 	wh := &PodMutatingWebhook{
 		Client:   fakeClient,
 		Tracer:   tr,
-		decoder:  decoder,
+		Decoder:  decoder,
 		Recorder: recorder,
 		Log:      testr.New(t),
 	}
@@ -1030,7 +1030,7 @@ func TestPodMutatingWebhook_Handle_SingleService(t *testing.T) {
 	wh := &PodMutatingWebhook{
 		Client:   fakeClient,
 		Tracer:   tr,
-		decoder:  decoder,
+		Decoder:  decoder,
 		Recorder: recorder,
 		Log:      testr.New(t),
 	}
@@ -1153,7 +1153,7 @@ func TestPodMutatingWebhook_Handle_SingleService_AppCreationRequestAlreadyPresen
 	wh := &PodMutatingWebhook{
 		Client:   fakeClient,
 		Tracer:   tr,
-		decoder:  decoder,
+		Decoder:  decoder,
 		Recorder: recorder,
 		Log:      testr.New(t),
 	}
@@ -1263,7 +1263,7 @@ func TestPodMutatingWebhook_Handle_MultiService(t *testing.T) {
 	wh := &PodMutatingWebhook{
 		Client:   fakeClient,
 		Tracer:   tr,
-		decoder:  decoder,
+		Decoder:  decoder,
 		Recorder: recorder,
 		Log:      testr.New(t),
 	}


### PR DESCRIPTION
Fixes #1445 Removed Decoder Injector interface from webhook and explicitly initialized the decoder in the operator main
Signed-off-by: geoffrey1330 <israelgeoffrey13@gmail.com>