### PR TITLE
ci: add check for latest version and fix cache path

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -31,6 +31,7 @@ runs:
         go-version: ${{ env.GO_VERSION }}
         cache: true
         cache-dependency-path: '**/go.sum'
+        check-latest: true
 
     - name: Download artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -94,6 +94,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: '${{ matrix.config.folder }}go.sum'
+          check-latest: true
 
       - name: Unit Test ${{ matrix.config.name }}
         working-directory: ./${{ matrix.config.folder }}

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -20,6 +20,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
           cache-dependency-path: 'operator/go.sum'
+          check-latest: true
 
       - name: Execute Component Tests
         working-directory: operator

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Copy old docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Create manifests
         env:

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -107,6 +107,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -228,7 +229,9 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
+          cache-dependency-path: ${{ matrix.artifact }}/go.sum
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
### This PR
- adds the `check-latest` option to all `setup-go` actions so that the latest go version within the defined version constraint will be used even if the cache has a different/older but valid version
- will partly solve #1545