### PR TITLE
docs: fix edit links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
     if: needs.release-please.outputs.releases_created == 'true'
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
-    uses: keptn/docs-tooling/.github/workflows/release-docs.yml@v0.0.2-beta1
+    uses: keptn/docs-tooling/.github/workflows/release-docs.yml@v0.1.2
     secrets: inherit
 
   update-examples:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 VOLUMES := -v $(ROOT_DIR):/src 
 # renovate: datasource=docker depName=klakegg/hugo
-HUGO_VERSION := 0.107.0
+HUGO_VERSION := 0.111.3
 IMAGE := klakegg/hugo:$(HUGO_VERSION)-ext
 PORT := 1314
 DOCKER_CMD := docker run --rm -t -e HUGO_CACHEDIR=/src/tmp/.hugo -e HUGOxPARAMSxGITHUB_REPO=""

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 VOLUMES := -v $(ROOT_DIR):/src 
 # renovate: datasource=docker depName=klakegg/hugo
-HUGO_VERSION := 0.107.0
+HUGO_VERSION:=0.111.3
 IMAGE := klakegg/hugo:$(HUGO_VERSION)-ext
 PORT := 1314
 DOCKER_CMD := docker run --rm -t -e HUGO_CACHEDIR=/src/tmp/.hugo -e HUGOxPARAMSxGITHUB_REPO=""

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 VOLUMES := -v $(ROOT_DIR):/src 
 # renovate: datasource=docker depName=klakegg/hugo
-HUGO_VERSION:=0.111.3
+HUGO_VERSION := 0.107.0
 IMAGE := klakegg/hugo:$(HUGO_VERSION)-ext
 PORT := 1314
 DOCKER_CMD := docker run --rm -t -e HUGO_CACHEDIR=/src/tmp/.hugo -e HUGOxPARAMSxGITHUB_REPO=""

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,7 +3,7 @@ module github.com/keptn/keptn-lifecycle-toolkit/docs
 go 1.20
 
 require (
-	github.com/google/docsy/dependencies v0.6.0 // indirect
-	github.com/keptn/community v0.0.0-20230429154843-72d65a6e2b39 // indirect
-	github.com/keptn/docs-tooling v0.1.1 // indirect
+	github.com/google/docsy/dependencies v0.7.0 // indirect
+	github.com/keptn/community v0.0.0-20230615192024-1cadfa6b2ad0 // indirect
+	github.com/keptn/docs-tooling v0.1.2 // indirect
 )

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,7 +3,7 @@ module github.com/keptn/keptn-lifecycle-toolkit/docs
 go 1.20
 
 require (
-	github.com/google/docsy/dependencies v0.7.0 // indirect
+	github.com/google/docsy/dependencies v0.6.0 // indirect
 	github.com/keptn/community v0.0.0-20230615192024-1cadfa6b2ad0 // indirect
 	github.com/keptn/docs-tooling v0.1.2 // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,9 +1,8 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
-github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
-github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
-github.com/keptn/community v0.0.0-20230429154843-72d65a6e2b39 h1:cexkJyNwTSwU+XgNKbu3ttr71rK/W9AwuyqUdefzPfc=
-github.com/keptn/community v0.0.0-20230429154843-72d65a6e2b39/go.mod h1:0G5nUhSv7ch9BgIFXiY7+U+cV5SbVmneysNGQwQkH8s=
-github.com/keptn/docs-tooling v0.1.1 h1:IuI0Fgs0JrtffLN05iaRZVkRMbPu6h9bxR4C8q1ApGU=
-github.com/keptn/docs-tooling v0.1.1/go.mod h1:x0iT5YsJosz6wzjQke/YaLgiXF6PV+N8QzxSAc2MY/4=
-github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy/dependencies v0.7.0 h1:/xUlWCZOSMDubHfrhIz1YtaRn2Oc/swfJ7OUfglXE8U=
+github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/keptn/community v0.0.0-20230615192024-1cadfa6b2ad0 h1:gT4CJA5fM9HlF8AGghB7YlS7Yj8wsrBPfpuW22Rc+WU=
+github.com/keptn/community v0.0.0-20230615192024-1cadfa6b2ad0/go.mod h1:0G5nUhSv7ch9BgIFXiY7+U+cV5SbVmneysNGQwQkH8s=
+github.com/keptn/docs-tooling v0.1.2 h1:qKu4U6ugnF7+uQ4buDqYuCehFsGF4bunJYsQWv8MenI=
+github.com/keptn/docs-tooling v0.1.2/go.mod h1:x0iT5YsJosz6wzjQke/YaLgiXF6PV+N8QzxSAc2MY/4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,8 +1,14 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/google/docsy/dependencies v0.7.0 h1:/xUlWCZOSMDubHfrhIz1YtaRn2Oc/swfJ7OUfglXE8U=
 github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/keptn/community v0.0.0-20230615192024-1cadfa6b2ad0 h1:gT4CJA5fM9HlF8AGghB7YlS7Yj8wsrBPfpuW22Rc+WU=
 github.com/keptn/community v0.0.0-20230615192024-1cadfa6b2ad0/go.mod h1:0G5nUhSv7ch9BgIFXiY7+U+cV5SbVmneysNGQwQkH8s=
+github.com/keptn/docs-tooling v0.1.1 h1:IuI0Fgs0JrtffLN05iaRZVkRMbPu6h9bxR4C8q1ApGU=
+github.com/keptn/docs-tooling v0.1.1/go.mod h1:x0iT5YsJosz6wzjQke/YaLgiXF6PV+N8QzxSAc2MY/4=
 github.com/keptn/docs-tooling v0.1.2 h1:qKu4U6ugnF7+uQ4buDqYuCehFsGF4bunJYsQWv8MenI=
 github.com/keptn/docs-tooling v0.1.2/go.mod h1:x0iT5YsJosz6wzjQke/YaLgiXF6PV+N8QzxSAc2MY/4=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@ HUGO_ENABLEGITINFO = "true"
 # On netlify our branch will always be the one we are currently building for
 # important information regarding naming 
 # https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
-HUGOxPARAMSxGITHUB_BRANCH="$BRANCH"
+HUGOxPARAMSxGITHUB_BRANCH="$HEAD"
 
 [context.deploy-preview.environment]
 HUGO_ENV = "development"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 [build.environment]
 # added specifically a docker image, so the versions within makefile and netlify documentation match
 # renovate: datasource=docker depName=klakegg/hugo
-HUGO_VERSION = "0.107.0"
+HUGO_VERSION = "0.111.3"
 HUGO_ENABLEGITINFO = "true"
 
 # On netlify our branch will always be the one we are currently building for

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 base = "docs/"
 publish = "public/"
-command = "HUGOxPARAMSxGITHUB_BRANCH=$BRANCH hugo -b $DEPLOY_PRIME_URL"
+command = "HUGOxPARAMSxGITHUB_BRANCH=$HEAD hugo -b $DEPLOY_PRIME_URL"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 base = "docs/"
 publish = "public/"
-command = "HUGOxPARAMSxGITHUB_BRANCH=$HEAD hugo -b $DEPLOY_PRIME_URL"
+command = "HUGOxPARAMSxGITHUB_BRANCH=$BRANCH hugo -b $DEPLOY_PRIME_URL"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 base = "docs/"
 publish = "public/"
-command = "hugo -b $DEPLOY_PRIME_URL"
+command = "HUGOxPARAMSxGITHUB_BRANCH=$BRANCH hugo -b $DEPLOY_PRIME_URL"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
 [build.environment]
@@ -13,7 +13,7 @@ HUGO_ENABLEGITINFO = "true"
 # On netlify our branch will always be the one we are currently building for
 # important information regarding naming 
 # https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
-HUGOxPARAMSxGITHUB_BRANCH="page"
+HUGOxPARAMSxGITHUB_BRANCH="$BRANCH"
 
 [context.deploy-preview.environment]
 HUGO_ENV = "development"

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@ HUGO_ENABLEGITINFO = "true"
 # On netlify our branch will always be the one we are currently building for
 # important information regarding naming 
 # https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
-HUGOxPARAMSxGITHUB_BRANCH="$HEAD"
+HUGOxPARAMSxGITHUB_BRANCH="page"
 
 [context.deploy-preview.environment]
 HUGO_ENV = "development"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,10 @@
 [build]
 base = "docs/"
 publish = "public/"
+
+# On netlify our branch will always be the one we are currently building for
+# important information regarding naming
+# https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
 command = "HUGOxPARAMSxGITHUB_BRANCH=$BRANCH hugo -b $DEPLOY_PRIME_URL"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 
@@ -9,11 +13,6 @@ ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 # renovate: datasource=docker depName=klakegg/hugo
 HUGO_VERSION = "0.111.3"
 HUGO_ENABLEGITINFO = "true"
-
-# On netlify our branch will always be the one we are currently building for
-# important information regarding naming 
-# https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
-HUGOxPARAMSxGITHUB_BRANCH="$BRANCH"
 
 [context.deploy-preview.environment]
 HUGO_ENV = "development"
@@ -25,4 +24,7 @@ HUGO_ENV = "staging"
 HUGO_ENV = "production"
 
 [context.production]
-command = "hugo -b $URL"
+# On netlify our branch will always be the one we are currently building for
+# important information regarding naming
+# https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
+command = "HUGOxPARAMSxGITHUB_BRANCH=$BRANCH hugo -b $URL"

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,10 @@ HUGO_ENABLEGITINFO = "true"
 # https://gohugo.io/getting-started/configuration/#configure-with-environment-variables
 HUGOxPARAMSxGITHUB_BRANCH="$BRANCH"
 
-[context.deploy-preview]
+[context.deploy-preview.environment]
 HUGO_ENV = "development"
 
-[context.branch-deploy]
+[context.branch-deploy.environment]
 HUGO_ENV = "staging"
 
 [context.production.environment]


### PR DESCRIPTION
### This PR
- updates the docs-tooling version to v0.1.2
- updates the keptn/community import to the latest master commit hash
- fixes the edit links on the KLT docs page by injecting the branch name differently in the `netlify.toml` file
- updates hugo to `0.111.3`