### PR TITLE
fix(helm-chart): fix Python runtime version number

### DIFF
--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -92,7 +92,7 @@ checks
 | `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                         | `0`                                      |
 | `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                          | `otel-collector:4317`                    |
 | `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for deno task runtime <!---x-release-please-version-->   | `ghcr.io/keptn/functions-runtime:v0.7.1` |
-| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for python task runtime <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:v0.7.1`    |
+| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for python task runtime <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:v0.0.0`    |
 | `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                                     | `ghcr.io/keptn/lifecycle-operator`       |
 | `lifecycleOperator.manager.image.tag`                                         | select tag for manager image <!---x-release-please-version-->          | `v0.7.1`                                 |
 | `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                                  | `Always`                                 |

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -92,7 +92,7 @@ checks
 | `lifecycleOperator.manager.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                         | `0`                                      |
 | `lifecycleOperator.manager.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                          | `otel-collector:4317`                    |
 | `lifecycleOperator.manager.env.functionRunnerImage`                           | specify image for deno task runtime <!---x-release-please-version-->   | `ghcr.io/keptn/functions-runtime:v0.7.1` |
-| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for python task runtime <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:0.0.0`     |
+| `lifecycleOperator.manager.env.pythonRunnerImage`                             | specify image for python task runtime <!---x-release-please-version--> | `ghcr.io/keptn/python-runtime:v0.7.1`    |
 | `lifecycleOperator.manager.image.repository`                                  | specify registry for manager image                                     | `ghcr.io/keptn/lifecycle-operator`       |
 | `lifecycleOperator.manager.image.tag`                                         | select tag for manager image <!---x-release-please-version-->          | `v0.7.1`                                 |
 | `lifecycleOperator.manager.imagePullPolicy`                                   | specify pull policy for manager image                                  | `Always`                                 |

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -78,7 +78,7 @@ lifecycleOperator:
       keptnWorkloadInstanceControllerLogLevel: "0"
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
-      pythonRunnerImage: ghcr.io/keptn/python-runtime:0.0.0
+      pythonRunnerImage: ghcr.io/keptn/python-runtime:v0.7.1
     image:
       repository: ghcr.io/keptn/lifecycle-operator
       tag: v0.7.1

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -78,7 +78,7 @@ lifecycleOperator:
       keptnWorkloadInstanceControllerLogLevel: "0"
       optionsControllerLogLevel: "0"
       otelCollectorUrl: otel-collector:4317
-      pythonRunnerImage: ghcr.io/keptn/python-runtime:v0.7.1
+      pythonRunnerImage: ghcr.io/keptn/python-runtime:v0.0.0
     image:
       repository: ghcr.io/keptn/lifecycle-operator
       tag: v0.7.1

--- a/klt-cert-manager/.gitignore
+++ b/klt-cert-manager/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+bin/
 testbin/*
 Dockerfile.cross
 

--- a/metrics-operator/.gitignore
+++ b/metrics-operator/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+bin/
 testbin/*
 
 # Test binary, build with `go test -c`

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
             - name: FUNCTION_RUNNER_IMAGE
               value: ghcr.io/keptn/functions-runtime:v0.7.1 # x-release-please-version
             - name: PYTHON_RUNNER_IMAGE
-              value: ghcr.io/keptn/python-runtime:0.0.0 # x-release-please-version
+              value: ghcr.io/keptn/python-runtime:v0.0.0 # x-release-please-version
             - name: OTEL_COLLECTOR_URL
               value: otel-collector:4317
             - name: KEPTN_APP_CONTROLLER_LOG_LEVEL

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
             - name: FUNCTION_RUNNER_IMAGE
               value: ghcr.io/keptn/functions-runtime:v0.7.1 # x-release-please-version
             - name: PYTHON_RUNNER_IMAGE
-              value: ghcr.io/keptn/python-runtime:v0.7.1 # x-release-please-version
+              value: ghcr.io/keptn/python-runtime:v0.0.0 # x-release-please-version
             - name: OTEL_COLLECTOR_URL
               value: otel-collector:4317
             - name: KEPTN_APP_CONTROLLER_LOG_LEVEL

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
             - name: FUNCTION_RUNNER_IMAGE
               value: ghcr.io/keptn/functions-runtime:v0.7.1 # x-release-please-version
             - name: PYTHON_RUNNER_IMAGE
-              value: ghcr.io/keptn/python-runtime:v0.0.0 # x-release-please-version
+              value: ghcr.io/keptn/python-runtime:v0.7.1 # x-release-please-version
             - name: OTEL_COLLECTOR_URL
               value: otel-collector:4317
             - name: KEPTN_APP_CONTROLLER_LOG_LEVEL


### PR DESCRIPTION
### This PR
- sets the Python runtime version to the current KLT version so that it will be updated correctly during the release
- changes some minor things in the gitignore files