### PR TITLE
chore: bump release-please base commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "separate-pull-requests": true,
-  "last-release-sha": "d5000da9b2aa8c02ae0b10129b7066ddd9a573fb",
+  "last-release-sha": "b37aed920eb766c33ae765ed740bc5e508ac430a",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "pull-request-title-pattern": "chore: release${component} ${version}",


### PR DESCRIPTION
### This PR
- bumps the `last-release-sha` in the release-please config to the 0.8.0 release commit so that changelogs for the new split artifacts start from there and not earlier