### PR TITLE
docs: fix </details> ending under watch pods in _index.md

### DIFF
--- a/docs/content/en/docs/getting-started/generic-gs/_index.md
+++ b/docs/content/en/docs/getting-started/generic-gs/_index.md
@@ -166,6 +166,7 @@ You can watch the state of the pods using:
 ```shell
 kubectl get pods -n podtato-kubectl
 ```
+
 </details>
 
 Furthermore, you can port-forward the podtato-head service

--- a/docs/content/en/docs/getting-started/generic-gs/_index.md
+++ b/docs/content/en/docs/getting-started/generic-gs/_index.md
@@ -166,6 +166,7 @@ You can watch the state of the pods using:
 ```shell
 kubectl get pods -n podtato-kubectl
 ```
+</details>
 
 Furthermore, you can port-forward the podtato-head service
 to your local machine and access the application via your browser:


### PR DESCRIPTION
fixed an issue with collapsible caret/arrow ending page text was hiding under "watch pods" section