### PR TITLE
fix(python-runtime): install curl to execute scripts referenced via url

### DIFF
--- a/python-runtime/Dockerfile
+++ b/python-runtime/Dockerfile
@@ -6,6 +6,9 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolki
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.licenses="Apache-2.0"
 
+
+RUN apk --no-cache add curl
+
 RUN pip install -q --disable-pip-version-check pyyaml GitPython requests
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The missing curl binary in the ython runtime image was preventing scripts referenced via url to be executed. This PR resolves that