### PR TITLE
fix(operator): provide the right app version for single-service applications

### DIFF
--- a/operator/controllers/common/otel_utils.go
+++ b/operator/controllers/common/otel_utils.go
@@ -100,12 +100,6 @@ func GetOTelTracerProviderOptions(oTelCollectorUrl string) ([]trace.TracerProvid
 	var tracerProviderOptions []trace.TracerProviderOption
 	var otelExporter trace.SpanExporter
 
-	stdOutExp, err := newStdOutExporter()
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not create stdout OTel exporter: %w", err)
-	}
-	tracerProviderOptions = append(tracerProviderOptions, trace.WithBatcher(stdOutExp))
-
 	if oTelCollectorUrl != "" {
 		// try to set OTel exporter for Jaeger
 		otelExporter, err := newOTelExporter(oTelCollectorUrl)
@@ -116,6 +110,13 @@ func GetOTelTracerProviderOptions(oTelCollectorUrl string) ([]trace.TracerProvid
 		} else if otelExporter != nil {
 			tracerProviderOptions = append(tracerProviderOptions, trace.WithBatcher(otelExporter))
 		}
+	} else {
+		// if no collector is set, we use std::out to print trace info
+		stdOutExp, err := newStdOutExporter()
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not create stdout OTel exporter: %w", err)
+		}
+		tracerProviderOptions = append(tracerProviderOptions, trace.WithBatcher(stdOutExp))
 	}
 	tracerProviderOptions = append(tracerProviderOptions, trace.WithResource(newResource()))
 

--- a/operator/controllers/common/otel_utils_test.go
+++ b/operator/controllers/common/otel_utils_test.go
@@ -59,7 +59,7 @@ func TestGetOTelTracerProviderOptions(t *testing.T) {
 			args: args{
 				oTelCollectorUrl: "localhost:9000",
 			},
-			wantArrayLength: 3,
+			wantArrayLength: 2,
 		},
 	}
 	for _, tt := range tests {

--- a/operator/controllers/lifecycle/keptnappcreationrequest/controller.go
+++ b/operator/controllers/lifecycle/keptnappcreationrequest/controller.go
@@ -268,6 +268,11 @@ func (r *KeptnAppCreationRequestReconciler) createKeptnApp(ctx context.Context, 
 }
 
 func computeVersionFromWorkloads(workloads []lifecycle.KeptnWorkload) string {
+	// for single workload applications, the workload version is the application version
+	if len(workloads) == 1 {
+		return workloads[0].Spec.Version
+	}
+
 	versionString := ""
 
 	// iterate over all workloads and add their names + version

--- a/operator/controllers/lifecycle/keptnappcreationrequest/controller_test.go
+++ b/operator/controllers/lifecycle/keptnappcreationrequest/controller_test.go
@@ -46,7 +46,7 @@ func TestKeptnAppCreationRequestReconciler_CreateAppAfterTimeout_SingleWorkload(
 		},
 		Spec: klcv1alpha3.KeptnWorkloadSpec{
 			AppName: appName,
-			Version: "1.0",
+			Version: "1.0+rc0",
 		},
 	}
 
@@ -83,6 +83,7 @@ func TestKeptnAppCreationRequestReconciler_CreateAppAfterTimeout_SingleWorkload(
 	require.NotEmpty(t, kApp)
 
 	require.NotEmpty(t, kApp.Spec.Version)
+	// the App version is the same of the single workload
 	require.Equal(t, workload1.Spec.Version, kApp.Spec.Version)
 	require.Len(t, kApp.Spec.Workloads, 1)
 	require.Contains(t, kApp.Spec.Workloads, klcv1alpha3.KeptnWorkloadRef{

--- a/operator/controllers/lifecycle/keptnappcreationrequest/controller_test.go
+++ b/operator/controllers/lifecycle/keptnappcreationrequest/controller_test.go
@@ -20,6 +20,84 @@ import (
 	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestKeptnAppCreationRequestReconciler_CreateAppAfterTimeout_SingleWorkload(t *testing.T) {
+	r, fakeClient, theClock := setupReconcilerAndClient(t)
+
+	const namespace = "my-namespace"
+	const appName = "my-app"
+	kacr := &klcv1alpha3.KeptnAppCreationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-kacr",
+			Namespace:         namespace,
+			CreationTimestamp: metav1.Time{Time: theClock.Now()},
+		},
+		Spec: klcv1alpha3.KeptnAppCreationRequestSpec{
+			AppName: appName,
+		},
+	}
+
+	err := fakeClient.Create(context.TODO(), kacr)
+	require.Nil(t, err)
+
+	workload1 := &klcv1alpha3.KeptnWorkload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "w1",
+			Namespace: namespace,
+		},
+		Spec: klcv1alpha3.KeptnWorkloadSpec{
+			AppName: appName,
+			Version: "1.0",
+		},
+	}
+
+	err = fakeClient.Create(context.TODO(), workload1)
+	require.Nil(t, err)
+
+	request := controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: kacr.Namespace,
+			Name:      kacr.Name,
+		},
+	}
+	// invoke the first reconciliation
+	res, err := r.Reconcile(context.TODO(), request)
+
+	require.Nil(t, err)
+	require.Equal(t, 30*time.Second, res.RequeueAfter)
+
+	// turn the clock forward
+	theClock.Add(1 * time.Minute)
+
+	// reconcile again - now we should get a KeptnApp as a result
+	res, err = r.Reconcile(context.TODO(), request)
+
+	require.Nil(t, err)
+	require.False(t, res.Requeue)
+	require.Zero(t, res.RequeueAfter)
+
+	kApp := &klcv1alpha3.KeptnApp{}
+
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: kacr.Spec.AppName, Namespace: kacr.Namespace}, kApp)
+
+	require.Nil(t, err)
+	require.NotEmpty(t, kApp)
+
+	require.NotEmpty(t, kApp.Spec.Version)
+	require.Equal(t, workload1.Spec.Version, kApp.Spec.Version)
+	require.Len(t, kApp.Spec.Workloads, 1)
+	require.Contains(t, kApp.Spec.Workloads, klcv1alpha3.KeptnWorkloadRef{
+		Name:    workload1.Name,
+		Version: workload1.Spec.Version,
+	})
+
+	// verify that the creationRequest has been deleted
+	cr := &klcv1alpha3.KeptnAppCreationRequest{}
+
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: kacr.Name, Namespace: kacr.Namespace}, cr)
+
+	require.True(t, errors.IsNotFound(err))
+}
+
 func TestKeptnAppCreationRequestReconciler_CreateAppAfterTimeout(t *testing.T) {
 	r, fakeClient, theClock := setupReconcilerAndClient(t)
 

--- a/test/integration/container-runtime/00-assert.yaml
+++ b/test/integration/container-runtime/00-assert.yaml
@@ -1,17 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: test
-  name: test
-status:
-  readyReplicas: 1
----
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnWorkload
-metadata:
-  name: waiter-waiter
----
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnWorkloadInstance
 metadata:
@@ -26,19 +12,6 @@ status:
   preDeploymentTaskStatus:
     - definitionName: pre-deployment-sleep
       status: Succeeded
-  status: Succeeded
----
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnApp
-metadata:
-  name: waiter
----
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnAppVersion
-metadata:
-  name: waiter-1b899b6ce1-6b86b273
-status:
-  currentPhase: Completed
   status: Succeeded
 ---
 apiVersion: lifecycle.keptn.sh/v1alpha3

--- a/test/integration/simple-deployment-python-runtime/00-assert.yaml
+++ b/test/integration/simple-deployment-python-runtime/00-assert.yaml
@@ -1,17 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: test
-  name: test
-status:
-  readyReplicas: 1
----
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnWorkload
-metadata:
-  name: waiter-waiter
----
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnWorkloadInstance
 metadata:
@@ -26,19 +12,6 @@ status:
   preDeploymentTaskStatus:
     - definitionName: pre-deployment-hello
       status: Succeeded
-  status: Succeeded
----
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnApp
-metadata:
-  name: waiter
----
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnAppVersion
-metadata:
-  name: waiter-1b899b6ce1-6b86b273
-status:
-  currentPhase: Completed
   status: Succeeded
 ---
 apiVersion: lifecycle.keptn.sh/v1alpha3

--- a/test/integration/simple-deployment-recursive-task/01-assert.yaml
+++ b/test/integration/simple-deployment-recursive-task/01-assert.yaml
@@ -1,43 +1,3 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnWorkload
-metadata:
-  name: waiter-waiter
-
----
-
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnWorkloadInstance
-metadata:
-  name: waiter-waiter-0.4
-status:
-  currentPhase: Completed
-  deploymentStatus: Succeeded
-  postDeploymentEvaluationStatus: Succeeded
-  postDeploymentStatus: Succeeded
-  postDeploymentTaskStatus:
-    - status: Succeeded
-      definitionName: pre-deployment-parent
-  preDeploymentEvaluationStatus: Succeeded
-  preDeploymentStatus: Succeeded
-  preDeploymentTaskStatus:
-    - status: Succeeded
-      definitionName: pre-deployment-hello
-
----
-
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnApp
-metadata:
-  name: waiter
-
----
-
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnAppVersion
-metadata:
-  name: waiter-1b899b6ce1-6b86b273
-
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -67,7 +27,6 @@ spec:
           name: function-mount
 status:
   succeeded: 1
-
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test/integration/simple-deployment-sanitize-version-number/01-assert.yaml
+++ b/test/integration/simple-deployment-sanitize-version-number/01-assert.yaml
@@ -29,4 +29,4 @@ metadata:
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnAppVersion
 metadata:
-  name: waiter-0.4-6b86b273
+  name: waiter-0.4.0-1-6b86b273

--- a/test/integration/simple-deployment-sanitize-version-number/01-assert.yaml
+++ b/test/integration/simple-deployment-sanitize-version-number/01-assert.yaml
@@ -2,9 +2,7 @@ apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnWorkload
 metadata:
   name: waiter-waiter
-
 ---
-
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnWorkloadInstance
 metadata:
@@ -22,17 +20,13 @@ status:
   preDeploymentTaskStatus:
     - status: Succeeded
       definitionName: pre-deployment-hello
-
 ---
-
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnApp
 metadata:
   name: waiter
-
 ---
-
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnAppVersion
 metadata:
-  name: waiter-62c130d876-6b86b273
+  name: waiter-0.4-6b86b273

--- a/test/integration/simple-deployment/01-assert.yaml
+++ b/test/integration/simple-deployment/01-assert.yaml
@@ -2,9 +2,7 @@ apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnWorkload
 metadata:
   name: waiter-waiter
-
 ---
-
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnWorkloadInstance
 metadata:
@@ -22,17 +20,13 @@ status:
   preDeploymentTaskStatus:
     - status: Succeeded
       definitionName: pre-deployment-hello
-
 ---
-
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnApp
 metadata:
   name: waiter
-
 ---
-
 apiVersion: lifecycle.keptn.sh/v1alpha3
 kind: KeptnAppVersion
 metadata:
-  name: waiter-1b899b6ce1-6b86b273
+  name: waiter-0.4-6b86b273


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(operator): provide the right app version for single-service applications
chore(operator): print trace in the logs only if the collector is not enabled
END_COMMIT_OVERRIDE


fixes #1667 