### PR TITLE
feat: add `interval` field for `kubectl get KeptnMetric`

### DIFF
--- a/metrics-operator/api/v1alpha3/keptnmetric_types.go
+++ b/metrics-operator/api/v1alpha3/keptnmetric_types.go
@@ -64,6 +64,7 @@ type RangeSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider.name`
 // +kubebuilder:printcolumn:name="Query",type=string,JSONPath=`.spec.query`
+// +kubebuilder:printcolumn:name="Interval",type=string,JSONPath=`.spec.range.interval`
 // +kubebuilder:printcolumn:name="Value",type=string,JSONPath=`.status.value`
 // +kubebuilder:storageversion
 

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetrics.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetrics.yaml
@@ -173,6 +173,9 @@ spec:
     - jsonPath: .spec.query
       name: Query
       type: string
+    - jsonPath: .spec.range.interval
+      name: Interval
+      type: string
     - jsonPath: .status.value
       name: Value
       type: string


### PR DESCRIPTION
Fixes #1677

Changes made:
- Introduced a new `interval` field for `kubectl get KeptnMetric`.
- This field has the value of `metric.spec.range.interval` field.

Some screenshots:

- With `range.interval` field defined
 
  ![Screenshot from 2023-07-06 20-04-01](https://github.com/keptn/lifecycle-toolkit/assets/98955085/2d2b04b8-1858-41f2-a72c-8601411bd2a3)

- Without a `range.interval` field defined

  ![Screenshot from 2023-07-06 20-05-08](https://github.com/keptn/lifecycle-toolkit/assets/98955085/fce2dfa6-33fd-4104-ac49-9a7d65a0df9d)
