### PR TITLE
chore(operator): standardize k8s Events on lifecycle path

### DIFF
--- a/operator/apis/lifecycle/v1alpha3/common/phases.go
+++ b/operator/apis/lifecycle/v1alpha3/common/phases.go
@@ -34,7 +34,6 @@ var phases = []KeptnPhaseType{
 	PhaseCreateWorkload,
 	PhaseCreateWorklodInstance,
 	PhaseCreateAppVersion,
-	PhaseCompleted,
 	PhaseAppCompleted,
 	PhaseWorkloadCompleted,
 	PhaseDeprecateAppVersion,
@@ -103,7 +102,6 @@ var (
 	PhaseCreateWorklodInstance  = KeptnPhaseType{LongName: "Create WorkloadInstance", ShortName: "CreateWorkloadInstance"}
 	PhaseCreateAppVersion       = KeptnPhaseType{LongName: "Create AppVersion", ShortName: "CreateAppVersion"}
 	PhaseDeprecateAppVersion    = KeptnPhaseType{LongName: "Deprecate AppVersion", ShortName: "DeprecateAppVersion"}
-	PhaseCompleted              = KeptnPhaseType{LongName: "Completed", ShortName: "Completed"}
 	PhaseAppCompleted           = KeptnPhaseType{LongName: "App Completed", ShortName: "AppCompleted"}
 	PhaseWorkloadCompleted      = KeptnPhaseType{LongName: "Workload Completed", ShortName: "WorkloadCompleted"}
 	PhaseDeprecated             = KeptnPhaseType{LongName: "Deprecated", ShortName: "Deprecated"}

--- a/operator/apis/lifecycle/v1alpha3/common/phases.go
+++ b/operator/apis/lifecycle/v1alpha3/common/phases.go
@@ -26,6 +26,8 @@ var phases = []KeptnPhaseType{
 	PhaseAppDeployment,
 	PhaseReconcileEvaluation,
 	PhaseReconcileTask,
+	PhaseReconcileWorkload,
+	PhaseUpdateWorkload,
 	PhaseCreateEvaluation,
 	PhaseCreateTask,
 	PhaseCreateApp,
@@ -33,6 +35,9 @@ var phases = []KeptnPhaseType{
 	PhaseCreateWorklodInstance,
 	PhaseCreateAppVersion,
 	PhaseCompleted,
+	PhaseAppCompleted,
+	PhaseWorkloadCompleted,
+	PhaseDeprecateAppVersion,
 	PhaseDeprecated,
 }
 
@@ -89,13 +94,18 @@ var (
 	PhaseAppDeployment          = KeptnPhaseType{LongName: "App Deployment", ShortName: "AppDeploy"}
 	PhaseReconcileEvaluation    = KeptnPhaseType{LongName: "Reconcile Evaluation", ShortName: "ReconcileEvaluation"}
 	PhaseReconcileTask          = KeptnPhaseType{LongName: "Reconcile Task", ShortName: "ReconcileTask"}
+	PhaseReconcileWorkload      = KeptnPhaseType{LongName: "Reconcile Workloads", ShortName: "ReconcileWorkload"}
 	PhaseCreateEvaluation       = KeptnPhaseType{LongName: "Create Evaluation", ShortName: "CreateEvaluation"}
 	PhaseCreateTask             = KeptnPhaseType{LongName: "Create Task", ShortName: "CreateTask"}
 	PhaseCreateApp              = KeptnPhaseType{LongName: "Create App", ShortName: "CreateApp"}
 	PhaseCreateWorkload         = KeptnPhaseType{LongName: "Create Workload", ShortName: "CreateWorkload"}
+	PhaseUpdateWorkload         = KeptnPhaseType{LongName: "Update Workload", ShortName: "UpdateWorkload"}
 	PhaseCreateWorklodInstance  = KeptnPhaseType{LongName: "Create WorkloadInstance", ShortName: "CreateWorkloadInstance"}
 	PhaseCreateAppVersion       = KeptnPhaseType{LongName: "Create AppVersion", ShortName: "CreateAppVersion"}
+	PhaseDeprecateAppVersion    = KeptnPhaseType{LongName: "Deprecate AppVersion", ShortName: "DeprecateAppVersion"}
 	PhaseCompleted              = KeptnPhaseType{LongName: "Completed", ShortName: "Completed"}
+	PhaseAppCompleted           = KeptnPhaseType{LongName: "App Completed", ShortName: "AppCompleted"}
+	PhaseWorkloadCompleted      = KeptnPhaseType{LongName: "Workload Completed", ShortName: "WorkloadCompleted"}
 	PhaseDeprecated             = KeptnPhaseType{LongName: "Deprecated", ShortName: "Deprecated"}
 )
 
@@ -111,7 +121,12 @@ func (pid PhaseTraceID) GetPhaseTraceID(phase string) propagation.MapCarrier {
 }
 
 var (
-	PhaseStateFinished = "Finished"
-	PhaseStateStarted  = "Started"
-	PhaseStateFailed   = "Failed"
+	PhaseStateFinished         = "Finished"
+	PhaseStateStarted          = "Started"
+	PhaseStateFailed           = "Failed"
+	PhaseStateStatusChanged    = "StatusChanged"
+	PhaseStateSucceeded        = "Succeeded"
+	PhaseStateReconcileError   = "ReconcileError"
+	PhaseStateReconcileTimeout = "ReconcileTimeout"
+	PhaseStateNotFound         = "NotFound"
 )

--- a/operator/apis/lifecycle/v1alpha3/common/phases.go
+++ b/operator/apis/lifecycle/v1alpha3/common/phases.go
@@ -38,6 +38,7 @@ var phases = []KeptnPhaseType{
 	PhaseWorkloadCompleted,
 	PhaseDeprecateAppVersion,
 	PhaseDeprecated,
+	PhaseAppCompleted,
 }
 
 func (p KeptnPhaseType) IsEvaluation() bool {
@@ -104,6 +105,7 @@ var (
 	PhaseDeprecateAppVersion      = KeptnPhaseType{LongName: "Deprecate AppVersion", ShortName: "DeprecateAppVersion"}
 	PhaseAppCompleted             = KeptnPhaseType{LongName: "App Completed", ShortName: "AppCompleted"}
 	PhaseWorkloadCompleted        = KeptnPhaseType{LongName: "Workload Completed", ShortName: "WorkloadCompleted"}
+	PhaseCompleted                = KeptnPhaseType{LongName: "Completed", ShortName: "Completed"}
 	PhaseDeprecated               = KeptnPhaseType{LongName: "Deprecated", ShortName: "Deprecated"}
 )
 

--- a/operator/apis/lifecycle/v1alpha3/common/phases.go
+++ b/operator/apis/lifecycle/v1alpha3/common/phases.go
@@ -30,7 +30,7 @@ var phases = []KeptnPhaseType{
 	PhaseUpdateWorkload,
 	PhaseCreateEvaluation,
 	PhaseCreateTask,
-	PhaseCreateApp,
+	PhaseCreateAppCreationRequest,
 	PhaseCreateWorkload,
 	PhaseCreateWorklodInstance,
 	PhaseCreateAppVersion,
@@ -81,30 +81,30 @@ func GetShortPhaseName(phase string) string {
 }
 
 var (
-	PhaseWorkloadPreDeployment  = KeptnPhaseType{LongName: "Workload Pre-Deployment Tasks", ShortName: "WorkloadPreDeployTasks"}
-	PhaseWorkloadPostDeployment = KeptnPhaseType{LongName: "Workload Post-Deployment Tasks", ShortName: "WorkloadPostDeployTasks"}
-	PhaseWorkloadPreEvaluation  = KeptnPhaseType{LongName: "Workload Pre-Deployment Evaluations", ShortName: "WorkloadPreDeployEvaluations"}
-	PhaseWorkloadPostEvaluation = KeptnPhaseType{LongName: "Workload Post-Deployment Evaluations", ShortName: "WorkloadPostDeployEvaluations"}
-	PhaseWorkloadDeployment     = KeptnPhaseType{LongName: "Workload Deployment", ShortName: "WorkloadDeploy"}
-	PhaseAppPreDeployment       = KeptnPhaseType{LongName: "App Pre-Deployment Tasks", ShortName: "AppPreDeployTasks"}
-	PhaseAppPostDeployment      = KeptnPhaseType{LongName: "App Post-Deployment Tasks", ShortName: "AppPostDeployTasks"}
-	PhaseAppPreEvaluation       = KeptnPhaseType{LongName: "App Pre-Deployment Evaluations", ShortName: "AppPreDeployEvaluations"}
-	PhaseAppPostEvaluation      = KeptnPhaseType{LongName: "App Post-Deployment Evaluations", ShortName: "AppPostDeployEvaluations"}
-	PhaseAppDeployment          = KeptnPhaseType{LongName: "App Deployment", ShortName: "AppDeploy"}
-	PhaseReconcileEvaluation    = KeptnPhaseType{LongName: "Reconcile Evaluation", ShortName: "ReconcileEvaluation"}
-	PhaseReconcileTask          = KeptnPhaseType{LongName: "Reconcile Task", ShortName: "ReconcileTask"}
-	PhaseReconcileWorkload      = KeptnPhaseType{LongName: "Reconcile Workloads", ShortName: "ReconcileWorkload"}
-	PhaseCreateEvaluation       = KeptnPhaseType{LongName: "Create Evaluation", ShortName: "CreateEvaluation"}
-	PhaseCreateTask             = KeptnPhaseType{LongName: "Create Task", ShortName: "CreateTask"}
-	PhaseCreateApp              = KeptnPhaseType{LongName: "Create App", ShortName: "CreateApp"}
-	PhaseCreateWorkload         = KeptnPhaseType{LongName: "Create Workload", ShortName: "CreateWorkload"}
-	PhaseUpdateWorkload         = KeptnPhaseType{LongName: "Update Workload", ShortName: "UpdateWorkload"}
-	PhaseCreateWorklodInstance  = KeptnPhaseType{LongName: "Create WorkloadInstance", ShortName: "CreateWorkloadInstance"}
-	PhaseCreateAppVersion       = KeptnPhaseType{LongName: "Create AppVersion", ShortName: "CreateAppVersion"}
-	PhaseDeprecateAppVersion    = KeptnPhaseType{LongName: "Deprecate AppVersion", ShortName: "DeprecateAppVersion"}
-	PhaseAppCompleted           = KeptnPhaseType{LongName: "App Completed", ShortName: "AppCompleted"}
-	PhaseWorkloadCompleted      = KeptnPhaseType{LongName: "Workload Completed", ShortName: "WorkloadCompleted"}
-	PhaseDeprecated             = KeptnPhaseType{LongName: "Deprecated", ShortName: "Deprecated"}
+	PhaseWorkloadPreDeployment    = KeptnPhaseType{LongName: "Workload Pre-Deployment Tasks", ShortName: "WorkloadPreDeployTasks"}
+	PhaseWorkloadPostDeployment   = KeptnPhaseType{LongName: "Workload Post-Deployment Tasks", ShortName: "WorkloadPostDeployTasks"}
+	PhaseWorkloadPreEvaluation    = KeptnPhaseType{LongName: "Workload Pre-Deployment Evaluations", ShortName: "WorkloadPreDeployEvaluations"}
+	PhaseWorkloadPostEvaluation   = KeptnPhaseType{LongName: "Workload Post-Deployment Evaluations", ShortName: "WorkloadPostDeployEvaluations"}
+	PhaseWorkloadDeployment       = KeptnPhaseType{LongName: "Workload Deployment", ShortName: "WorkloadDeploy"}
+	PhaseAppPreDeployment         = KeptnPhaseType{LongName: "App Pre-Deployment Tasks", ShortName: "AppPreDeployTasks"}
+	PhaseAppPostDeployment        = KeptnPhaseType{LongName: "App Post-Deployment Tasks", ShortName: "AppPostDeployTasks"}
+	PhaseAppPreEvaluation         = KeptnPhaseType{LongName: "App Pre-Deployment Evaluations", ShortName: "AppPreDeployEvaluations"}
+	PhaseAppPostEvaluation        = KeptnPhaseType{LongName: "App Post-Deployment Evaluations", ShortName: "AppPostDeployEvaluations"}
+	PhaseAppDeployment            = KeptnPhaseType{LongName: "App Deployment", ShortName: "AppDeploy"}
+	PhaseReconcileEvaluation      = KeptnPhaseType{LongName: "Reconcile Evaluation", ShortName: "ReconcileEvaluation"}
+	PhaseReconcileTask            = KeptnPhaseType{LongName: "Reconcile Task", ShortName: "ReconcileTask"}
+	PhaseReconcileWorkload        = KeptnPhaseType{LongName: "Reconcile Workloads", ShortName: "ReconcileWorkload"}
+	PhaseCreateEvaluation         = KeptnPhaseType{LongName: "Create Evaluation", ShortName: "CreateEvaluation"}
+	PhaseCreateTask               = KeptnPhaseType{LongName: "Create Task", ShortName: "CreateTask"}
+	PhaseCreateAppCreationRequest = KeptnPhaseType{LongName: "Create AppCreationRequest", ShortName: "CreateAppCreationRequest"}
+	PhaseCreateWorkload           = KeptnPhaseType{LongName: "Create Workload", ShortName: "CreateWorkload"}
+	PhaseUpdateWorkload           = KeptnPhaseType{LongName: "Update Workload", ShortName: "UpdateWorkload"}
+	PhaseCreateWorklodInstance    = KeptnPhaseType{LongName: "Create WorkloadInstance", ShortName: "CreateWorkloadInstance"}
+	PhaseCreateAppVersion         = KeptnPhaseType{LongName: "Create AppVersion", ShortName: "CreateAppVersion"}
+	PhaseDeprecateAppVersion      = KeptnPhaseType{LongName: "Deprecate AppVersion", ShortName: "DeprecateAppVersion"}
+	PhaseAppCompleted             = KeptnPhaseType{LongName: "App Completed", ShortName: "AppCompleted"}
+	PhaseWorkloadCompleted        = KeptnPhaseType{LongName: "Workload Completed", ShortName: "WorkloadCompleted"}
+	PhaseDeprecated               = KeptnPhaseType{LongName: "Deprecated", ShortName: "Deprecated"}
 )
 
 type PhaseTraceID map[string]propagation.MapCarrier
@@ -123,7 +123,6 @@ var (
 	PhaseStateStarted          = "Started"
 	PhaseStateFailed           = "Failed"
 	PhaseStateStatusChanged    = "StatusChanged"
-	PhaseStateSucceeded        = "Succeeded"
 	PhaseStateReconcileError   = "ReconcileError"
 	PhaseStateReconcileTimeout = "ReconcileTimeout"
 	PhaseStateNotFound         = "NotFound"

--- a/operator/apis/lifecycle/v1alpha3/common/phases.go
+++ b/operator/apis/lifecycle/v1alpha3/common/phases.go
@@ -109,3 +109,9 @@ func (pid PhaseTraceID) SetPhaseTraceID(phase string, carrier propagation.MapCar
 func (pid PhaseTraceID) GetPhaseTraceID(phase string) propagation.MapCarrier {
 	return pid[GetShortPhaseName(phase)]
 }
+
+var (
+	PhaseStateFinished = "Finished"
+	PhaseStateStarted  = "Started"
+	PhaseStateFailed   = "Failed"
+)

--- a/operator/controllers/common/evaluationhandler.go
+++ b/operator/controllers/common/evaluationhandler.go
@@ -129,7 +129,6 @@ func (r EvaluationHandler) CreateKeptnEvaluation(ctx context.Context, namespace 
 		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, apicommon.PhaseStateFailed, "could not create KeptnEvaluation", piWrapper.GetVersion())
 		return "", err
 	}
-	r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, apicommon.PhaseStateSucceeded, "created", piWrapper.GetVersion())
 
 	return newEvaluation.Name, nil
 }
@@ -188,7 +187,6 @@ func (r EvaluationHandler) handleEvaluationExists(phaseCtx context.Context, piWr
 		if evaluationStatus.Status.IsSucceeded() {
 			spanEvaluationTrace.AddEvent(evaluation.Name + " has finished")
 			spanEvaluationTrace.SetStatus(codes.Ok, "Finished")
-			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Normal", evaluation, apicommon.PhaseStateSucceeded, "evaluation succeeded", piWrapper.GetVersion())
 		} else {
 			spanEvaluationTrace.AddEvent(evaluation.Name + " has failed")
 			r.emitEvaluationFailureEvents(evaluation, spanEvaluationTrace, piWrapper)

--- a/operator/controllers/common/evaluationhandler_test.go
+++ b/operator/controllers/common/evaluationhandler_test.go
@@ -248,9 +248,6 @@ func TestEvaluationHandler(t *testing.T) {
 			wantErr:         nil,
 			getSpanCalls:    1,
 			unbindSpanCalls: 1,
-			events: []string{
-				"ReconcileEvaluationSucceeded",
-			},
 		},
 	}
 

--- a/operator/controllers/common/evaluationhandler_test.go
+++ b/operator/controllers/common/evaluationhandler_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+//nolint:dupl
 func TestEvaluationHandler(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/operator/controllers/common/phasehandler.go
+++ b/operator/controllers/common/phasehandler.go
@@ -43,7 +43,6 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxTrace context.Context,
 		piWrapper.SetCurrentPhase(phase.ShortName)
 	}
 
-	r.Log.Info(phase.LongName + " not finished")
 	spanPhaseCtx, spanPhaseTrace, err := r.SpanHandler.GetSpan(ctxTrace, tracer, reconcileObject, phase.ShortName)
 	if err != nil {
 		r.Log.Error(err, "could not get span")
@@ -52,7 +51,7 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxTrace context.Context,
 	state, err := reconcilePhase(spanPhaseCtx)
 	if err != nil {
 		spanPhaseTrace.AddEvent(phase.LongName + " could not get reconciled")
-		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, "ReconcileErrored", "could not get reconciled", piWrapper.GetVersion())
+		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, apicommon.PhaseStateReconcileError, "could not get reconciled", piWrapper.GetVersion())
 		span.SetStatus(codes.Error, err.Error())
 		return &PhaseResult{Continue: false, Result: requeueResult}, err
 	}
@@ -71,7 +70,6 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxTrace context.Context,
 	}
 
 	piWrapper.SetState(apicommon.StateProgressing)
-	r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, "NotFinished", "has not finished", piWrapper.GetVersion())
 
 	return &PhaseResult{Continue: false, Result: requeueResult}, nil
 }

--- a/operator/controllers/common/phasehandler.go
+++ b/operator/controllers/common/phasehandler.go
@@ -38,7 +38,10 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxTrace context.Context,
 	if shouldAbortPhase(oldStatus) {
 		return &PhaseResult{Continue: false, Result: ctrl.Result{}}, nil
 	}
-	piWrapper.SetCurrentPhase(phase.ShortName)
+	if oldPhase != phase.ShortName {
+		r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, apicommon.PhaseStateStarted, "has started", piWrapper.GetVersion())
+		piWrapper.SetCurrentPhase(phase.ShortName)
+	}
 
 	r.Log.Info(phase.LongName + " not finished")
 	spanPhaseCtx, spanPhaseTrace, err := r.SpanHandler.GetSpan(ctxTrace, tracer, reconcileObject, phase.ShortName)
@@ -52,10 +55,6 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxTrace context.Context,
 		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, "ReconcileErrored", "could not get reconciled", piWrapper.GetVersion())
 		span.SetStatus(codes.Error, err.Error())
 		return &PhaseResult{Continue: false, Result: requeueResult}, err
-	}
-
-	if state.IsPending() {
-		state = apicommon.StateProgressing
 	}
 
 	defer func(ctx context.Context, oldStatus apicommon.KeptnState, oldPhase string, reconcileObject client.Object) {
@@ -91,7 +90,7 @@ func (r PhaseHandler) handleCompletedPhase(state apicommon.KeptnState, piWrapper
 		if err := r.SpanHandler.UnbindSpan(reconcileObject, phase.ShortName); err != nil {
 			r.Log.Error(err, controllererrors.ErrCouldNotUnbindSpan, reconcileObject.GetName())
 		}
-		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, "Failed", "has failed", piWrapper.GetVersion())
+		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, apicommon.PhaseStateFailed, "has failed", piWrapper.GetVersion())
 		piWrapper.DeprecateRemainingPhases(phase)
 		return &PhaseResult{Continue: false, Result: ctrl.Result{}}, nil
 	}
@@ -103,7 +102,7 @@ func (r PhaseHandler) handleCompletedPhase(state apicommon.KeptnState, piWrapper
 	if err := r.SpanHandler.UnbindSpan(reconcileObject, phase.ShortName); err != nil {
 		r.Log.Error(err, controllererrors.ErrCouldNotUnbindSpan, reconcileObject.GetName())
 	}
-	r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, "Succeeded", "has succeeded", piWrapper.GetVersion())
+	r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, apicommon.PhaseStateFinished, "has finished", piWrapper.GetVersion())
 
 	return &PhaseResult{Continue: true, Result: ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}}, nil
 }

--- a/operator/controllers/common/taskhandler.go
+++ b/operator/controllers/common/taskhandler.go
@@ -57,7 +57,7 @@ func (r TaskHandler) ReconcileTasks(ctx context.Context, phaseCtx context.Contex
 		taskExists := false
 
 		if oldstatus != taskStatus.Status {
-			r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, "TaskStatusChanged", fmt.Sprintf("task status changed from %s to %s", oldstatus, taskStatus.Status), piWrapper.GetVersion())
+			r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, apicommon.PhaseStateStatusChanged, fmt.Sprintf("task status changed from %s to %s", oldstatus, taskStatus.Status), piWrapper.GetVersion())
 		}
 
 		// Check if task has already succeeded or failed
@@ -109,9 +109,7 @@ func (r TaskHandler) ReconcileTasks(ctx context.Context, phaseCtx context.Contex
 	for _, ns := range newStatus {
 		summary = apicommon.UpdateStatusSummary(ns.Status, summary)
 	}
-	if apicommon.GetOverallState(summary) != apicommon.StateSucceeded {
-		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, "NotFinished", "has not finished", piWrapper.GetVersion())
-	}
+
 	return newStatus, summary, nil
 }
 
@@ -132,10 +130,10 @@ func (r TaskHandler) CreateKeptnTask(ctx context.Context, namespace string, reco
 	err = r.Client.Create(ctx, &newTask)
 	if err != nil {
 		r.Log.Error(err, "could not create KeptnTask")
-		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, "CreateFailed", "could not create KeptnTask", piWrapper.GetVersion())
+		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, apicommon.PhaseStateFailed, "could not create KeptnTask", piWrapper.GetVersion())
 		return "", err
 	}
-	r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, "Created", "created", piWrapper.GetVersion())
+	r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, apicommon.PhaseStateSucceeded, "created", piWrapper.GetVersion())
 
 	return newTask.Name, nil
 }

--- a/operator/controllers/common/taskhandler.go
+++ b/operator/controllers/common/taskhandler.go
@@ -133,7 +133,6 @@ func (r TaskHandler) CreateKeptnTask(ctx context.Context, namespace string, reco
 		r.EventSender.SendK8sEvent(phase, "Warning", reconcileObject, apicommon.PhaseStateFailed, "could not create KeptnTask", piWrapper.GetVersion())
 		return "", err
 	}
-	r.EventSender.SendK8sEvent(phase, "Normal", reconcileObject, apicommon.PhaseStateSucceeded, "created", piWrapper.GetVersion())
 
 	return newTask.Name, nil
 }

--- a/operator/controllers/lifecycle/keptnapp/controller.go
+++ b/operator/controllers/lifecycle/keptnapp/controller.go
@@ -171,7 +171,7 @@ func (r *KeptnAppReconciler) handleGenerationBump(ctx context.Context, app *klcv
 	if app.Generation != 1 {
 		if err := r.deprecateAppVersions(ctx, app); err != nil {
 			r.Log.Error(err, "could not deprecate appVersions for appVersion %s", app.GetAppVersionName())
-			r.EventSender.SendK8sEvent(common.PhaseDeprecateAppVersion, "Warning", app, common.PhaseStateFailed, fmt.Sprintf("could not deprecate KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
+			r.EventSender.SendK8sEvent(common.PhaseDeprecateAppVersion, "Warning", app, common.PhaseStateFailed, fmt.Sprintf("could not deprecate outdated revisions of KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
 			return err
 		}
 	}

--- a/operator/controllers/lifecycle/keptnapp/controller.go
+++ b/operator/controllers/lifecycle/keptnapp/controller.go
@@ -108,7 +108,6 @@ func (r *KeptnAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Warning", appVersion, common.PhaseStateFailed, "Could not create KeptnAppVersion", appVersion.Spec.Version)
 			return ctrl.Result{}, err
 		}
-		r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Normal", appVersion, common.PhaseStateSucceeded, "created KeptnAppVersion", appVersion.Spec.Version)
 
 		app.Status.CurrentVersion = app.Spec.Version
 		if err := r.Client.Status().Update(ctx, app); err != nil {
@@ -175,7 +174,6 @@ func (r *KeptnAppReconciler) handleGenerationBump(ctx context.Context, app *klcv
 			r.EventSender.SendK8sEvent(common.PhaseDeprecateAppVersion, "Warning", app, common.PhaseStateFailed, fmt.Sprintf("could not deprecate KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
 			return err
 		}
-		r.EventSender.SendK8sEvent(common.PhaseDeprecateAppVersion, "Normal", app, common.PhaseStateSucceeded, fmt.Sprintf("deprecated KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
 	}
 	return nil
 }

--- a/operator/controllers/lifecycle/keptnapp/controller.go
+++ b/operator/controllers/lifecycle/keptnapp/controller.go
@@ -105,10 +105,10 @@ func (r *KeptnAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if err != nil {
 			r.Log.Error(err, "could not create AppVersion")
 			span.SetStatus(codes.Error, err.Error())
-			r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Warning", appVersion, "AppVersionNotCreated", "Could not create KeptnAppVersion", appVersion.Spec.Version)
+			r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Warning", appVersion, common.PhaseStateFailed, "Could not create KeptnAppVersion", appVersion.Spec.Version)
 			return ctrl.Result{}, err
 		}
-		r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Normal", appVersion, "AppVersionCreated", "created KeptnAppVersion", appVersion.Spec.Version)
+		r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Normal", appVersion, common.PhaseStateSucceeded, "created KeptnAppVersion", appVersion.Spec.Version)
 
 		app.Status.CurrentVersion = app.Spec.Version
 		if err := r.Client.Status().Update(ctx, app); err != nil {
@@ -172,10 +172,10 @@ func (r *KeptnAppReconciler) handleGenerationBump(ctx context.Context, app *klcv
 	if app.Generation != 1 {
 		if err := r.deprecateAppVersions(ctx, app); err != nil {
 			r.Log.Error(err, "could not deprecate appVersions for appVersion %s", app.GetAppVersionName())
-			r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Warning", app, "AppVersionNotDeprecated", fmt.Sprintf("could not deprecate KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
+			r.EventSender.SendK8sEvent(common.PhaseDeprecateAppVersion, "Warning", app, common.PhaseStateFailed, fmt.Sprintf("could not deprecate KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
 			return err
 		}
-		r.EventSender.SendK8sEvent(common.PhaseCreateAppVersion, "Normal", app, "AppVersionDeprecated", fmt.Sprintf("deprecated KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
+		r.EventSender.SendK8sEvent(common.PhaseDeprecateAppVersion, "Normal", app, common.PhaseStateSucceeded, fmt.Sprintf("deprecated KeptnAppVersions for KeptnAppVersion: %s", app.GetAppVersionName()), app.Spec.Version)
 	}
 	return nil
 }

--- a/operator/controllers/lifecycle/keptnapp/controller_test.go
+++ b/operator/controllers/lifecycle/keptnapp/controller_test.go
@@ -90,7 +90,7 @@ func TestKeptnAppReconciler_reconcile(t *testing.T) {
 				},
 			},
 			wantErr: nil,
-			event:   `Normal CreateAppVersionAppVersionCreated Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-6b86b273, Version: 1.0.0`,
+			event:   `Normal CreateAppVersionSucceeded Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-6b86b273, Version: 1.0.0`,
 		},
 		{
 			name: "test simple notfound should not return error nor event",
@@ -167,7 +167,7 @@ func TestKeptnAppReconciler_deprecateAppVersions(t *testing.T) {
 	require.Nil(t, err)
 
 	event := <-eventChannel
-	assert.Matches(t, event, `Normal CreateAppVersionAppVersionCreated Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-6b86b273, Version: 1.0.0`)
+	assert.Matches(t, event, `Normal CreateAppVersionSucceeded Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-6b86b273, Version: 1.0.0`)
 
 	err = controllercommon.UpdateAppRevision(r.Client, "myapp", 2)
 	require.Nil(t, err)
@@ -182,10 +182,10 @@ func TestKeptnAppReconciler_deprecateAppVersions(t *testing.T) {
 	require.Nil(t, err)
 
 	event = <-eventChannel
-	assert.Matches(t, event, `Normal CreateAppVersionAppVersionCreated Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-d4735e3a, Version: 1.0.0`)
+	assert.Matches(t, event, `Normal CreateAppVersionSucceeded Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-d4735e3a, Version: 1.0.0`)
 
 	event = <-eventChannel
-	assert.Matches(t, event, `Normal CreateAppVersionAppVersionDeprecated Create AppVersion: deprecated KeptnAppVersions for KeptnAppVersion: myapp-1.0.0-d4735e3a / Namespace: default, Name: myapp, Version: 1.0.0`)
+	assert.Matches(t, event, `Normal DeprecateAppVersionSucceeded Deprecate AppVersion: deprecated KeptnAppVersions for KeptnAppVersion: myapp-1.0.0-d4735e3a / Namespace: default, Name: myapp, Version: 1.0.0`)
 }
 
 func setupReconciler() (*KeptnAppReconciler, chan string, *fake.ITracerMock) {

--- a/operator/controllers/lifecycle/keptnapp/controller_test.go
+++ b/operator/controllers/lifecycle/keptnapp/controller_test.go
@@ -73,13 +73,13 @@ func TestKeptnAppReconciler_createAppVersionWithLongName(t *testing.T) {
 
 func TestKeptnAppReconciler_reconcile(t *testing.T) {
 
-	r, eventChannel, tracer := setupReconciler()
+	r, _, tracer := setupReconciler()
 
 	tests := []struct {
-		name    string
-		req     ctrl.Request
-		wantErr error
-		event   string //check correct events are generated
+		name           string
+		req            ctrl.Request
+		wantErr        error
+		appVersionName string
 	}{
 		{
 			name: "test simple create appVersion",
@@ -90,7 +90,6 @@ func TestKeptnAppReconciler_reconcile(t *testing.T) {
 				},
 			},
 			wantErr: nil,
-			event:   `Normal CreateAppVersionSucceeded Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-6b86b273, Version: 1.0.0`,
 		},
 		{
 			name: "test simple notfound should not return error nor event",
@@ -131,13 +130,13 @@ func TestKeptnAppReconciler_reconcile(t *testing.T) {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if tt.event != "" {
-				event := <-eventChannel
-				assert.Matches(t, event, tt.event)
+			if tt.appVersionName != "" {
+				keptnappversion := &lfcv1alpha3.KeptnAppVersion{}
+				err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "myapp-1.0.0-6b86b273"}, keptnappversion)
+				require.Nil(t, err)
 			}
 
 		})
-
 	}
 
 	// check correct traces
@@ -152,7 +151,7 @@ func TestKeptnAppReconciler_reconcile(t *testing.T) {
 }
 
 func TestKeptnAppReconciler_deprecateAppVersions(t *testing.T) {
-	r, eventChannel, _ := setupReconciler()
+	r, _, _ := setupReconciler()
 
 	err := controllercommon.AddApp(r.Client, "myapp")
 	require.Nil(t, err)
@@ -166,8 +165,9 @@ func TestKeptnAppReconciler_deprecateAppVersions(t *testing.T) {
 
 	require.Nil(t, err)
 
-	event := <-eventChannel
-	assert.Matches(t, event, `Normal CreateAppVersionSucceeded Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-6b86b273, Version: 1.0.0`)
+	keptnappversion := &lfcv1alpha3.KeptnAppVersion{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "myapp-1.0.0-6b86b273"}, keptnappversion)
+	require.Nil(t, err)
 
 	err = controllercommon.UpdateAppRevision(r.Client, "myapp", 2)
 	require.Nil(t, err)
@@ -181,11 +181,12 @@ func TestKeptnAppReconciler_deprecateAppVersions(t *testing.T) {
 
 	require.Nil(t, err)
 
-	event = <-eventChannel
-	assert.Matches(t, event, `Normal CreateAppVersionSucceeded Create AppVersion: created KeptnAppVersion / Namespace: default, Name: myapp-1.0.0-d4735e3a, Version: 1.0.0`)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "myapp-1.0.0-d4735e3a"}, keptnappversion)
+	require.Nil(t, err)
 
-	event = <-eventChannel
-	assert.Matches(t, event, `Normal DeprecateAppVersionSucceeded Deprecate AppVersion: deprecated KeptnAppVersions for KeptnAppVersion: myapp-1.0.0-d4735e3a / Namespace: default, Name: myapp, Version: 1.0.0`)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "default", Name: "myapp-1.0.0-6b86b273"}, keptnappversion)
+	require.Nil(t, err)
+	require.Equal(t, apicommon.StateDeprecated, keptnappversion.Status.Status)
 }
 
 func setupReconciler() (*KeptnAppReconciler, chan string, *fake.ITracerMock) {

--- a/operator/controllers/lifecycle/keptnappversion/controller.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller.go
@@ -172,7 +172,7 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *KeptnAppVersionReconciler) finishKeptnAppVersionReconcile(ctx context.Context, appVersion *klcv1alpha3.KeptnAppVersion, spanAppTrace trace.Span) (ctrl.Result, error) {
 
 	if !appVersion.IsEndTimeSet() {
-		appVersion.Status.CurrentPhase = apicommon.PhaseAppCompleted.ShortName
+		appVersion.Status.CurrentPhase = apicommon.PhaseCompleted.ShortName
 		appVersion.SetEndTime()
 	}
 

--- a/operator/controllers/lifecycle/keptnappversion/controller.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller.go
@@ -181,7 +181,7 @@ func (r *KeptnAppVersionReconciler) finishKeptnAppVersionReconcile(ctx context.C
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	r.EventSender.SendK8sEvent(apicommon.PhaseCompleted, "Normal", appVersion, "Finished", "is finished", appVersion.GetVersion())
+	r.EventSender.SendK8sEvent(apicommon.PhaseAppCompleted, "Normal", appVersion, apicommon.PhaseStateFinished, "is finished", appVersion.GetVersion())
 
 	attrs := appVersion.GetMetricsAttributes()
 

--- a/operator/controllers/lifecycle/keptnappversion/controller.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller.go
@@ -103,7 +103,6 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if appVersion.Status.CurrentPhase == "" {
 		appVersion.SetSpanAttributes(spanAppTrace)
 		spanAppTrace.AddEvent("App Version Pre-Deployment Tasks started", trace.WithTimestamp(time.Now()))
-		r.EventSender.SendK8sEvent(phase, "Normal", appVersion, "Started", "have started", appVersion.GetVersion())
 	}
 
 	if !appVersion.IsPreDeploymentSucceeded() {
@@ -160,7 +159,6 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	r.EventSender.SendK8sEvent(phase, "Normal", appVersion, "Finished", "is finished", appVersion.GetVersion())
 	err = r.Client.Status().Update(ctx, appVersion)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -182,6 +180,8 @@ func (r *KeptnAppVersionReconciler) finishKeptnAppVersionReconcile(ctx context.C
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}
+
+	r.EventSender.SendK8sEvent(apicommon.PhaseCompleted, "Normal", appVersion, "Finished", "is finished", appVersion.GetVersion())
 
 	attrs := appVersion.GetMetricsAttributes()
 

--- a/operator/controllers/lifecycle/keptnappversion/controller.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller.go
@@ -172,7 +172,7 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *KeptnAppVersionReconciler) finishKeptnAppVersionReconcile(ctx context.Context, appVersion *klcv1alpha3.KeptnAppVersion, spanAppTrace trace.Span) (ctrl.Result, error) {
 
 	if !appVersion.IsEndTimeSet() {
-		appVersion.Status.CurrentPhase = apicommon.PhaseCompleted.ShortName
+		appVersion.Status.CurrentPhase = apicommon.PhaseAppCompleted.ShortName
 		appVersion.SetEndTime()
 	}
 

--- a/operator/controllers/lifecycle/keptnappversion/controller.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller.go
@@ -181,7 +181,7 @@ func (r *KeptnAppVersionReconciler) finishKeptnAppVersionReconcile(ctx context.C
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	r.EventSender.SendK8sEvent(apicommon.PhaseAppCompleted, "Normal", appVersion, apicommon.PhaseStateFinished, "is finished", appVersion.GetVersion())
+	r.EventSender.SendK8sEvent(apicommon.PhaseAppCompleted, "Normal", appVersion, apicommon.PhaseStateFinished, "has finished", appVersion.GetVersion())
 
 	attrs := appVersion.GetMetricsAttributes()
 

--- a/operator/controllers/lifecycle/keptnappversion/controller_test.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller_test.go
@@ -232,7 +232,7 @@ func TestKeptnAppVersionReconciler_ReconcileReachCompletion(t *testing.T) {
 
 func createFinishedAppVersionStatus() lfcv1alpha3.KeptnAppVersionStatus {
 	return lfcv1alpha3.KeptnAppVersionStatus{
-		CurrentPhase:                       apicommon.PhaseCompleted.ShortName,
+		CurrentPhase:                       apicommon.PhaseAppCompleted.ShortName,
 		PreDeploymentStatus:                apicommon.StateSucceeded,
 		PostDeploymentStatus:               apicommon.StateSucceeded,
 		PreDeploymentEvaluationStatus:      apicommon.StateSucceeded,

--- a/operator/controllers/lifecycle/keptnappversion/controller_test.go
+++ b/operator/controllers/lifecycle/keptnappversion/controller_test.go
@@ -232,7 +232,7 @@ func TestKeptnAppVersionReconciler_ReconcileReachCompletion(t *testing.T) {
 
 func createFinishedAppVersionStatus() lfcv1alpha3.KeptnAppVersionStatus {
 	return lfcv1alpha3.KeptnAppVersionStatus{
-		CurrentPhase:                       apicommon.PhaseAppCompleted.ShortName,
+		CurrentPhase:                       apicommon.PhaseCompleted.ShortName,
 		PreDeploymentStatus:                apicommon.StateSucceeded,
 		PostDeploymentStatus:               apicommon.StateSucceeded,
 		PreDeploymentEvaluationStatus:      apicommon.StateSucceeded,

--- a/operator/controllers/lifecycle/keptnappversion/reconcile_workloadsstate.go
+++ b/operator/controllers/lifecycle/keptnappversion/reconcile_workloadsstate.go
@@ -2,6 +2,7 @@ package keptnappversion
 
 import (
 	"context"
+	"fmt"
 
 	klcv1alpha3 "github.com/keptn/lifecycle-toolkit/operator/apis/lifecycle/v1alpha3"
 	apicommon "github.com/keptn/lifecycle-toolkit/operator/apis/lifecycle/v1alpha3/common"

--- a/operator/controllers/lifecycle/keptnappversion/reconcile_workloadsstate.go
+++ b/operator/controllers/lifecycle/keptnappversion/reconcile_workloadsstate.go
@@ -40,7 +40,7 @@ func (r *KeptnAppVersionReconciler) reconcileWorkloads(ctx context.Context, appV
 		}
 
 		if !found {
-			r.EventSender.SendK8sEvent(phase, "Warning", appVersion, apicommon.PhaseStateNotFound, "workloadInstance not found", appVersion.GetVersion())
+			r.EventSender.SendK8sEvent(phase, "Warning", appVersion, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnWorkloadInstance for KeptnWorkload: %s ", w.Name), appVersion.GetVersion())
 		}
 
 		newStatus = append(newStatus, klcv1alpha3.WorkloadStatus{

--- a/operator/controllers/lifecycle/keptnappversion/reconcile_workloadsstate.go
+++ b/operator/controllers/lifecycle/keptnappversion/reconcile_workloadsstate.go
@@ -14,10 +14,7 @@ func (r *KeptnAppVersionReconciler) reconcileWorkloads(ctx context.Context, appV
 	var summary apicommon.StatusSummary
 	summary.Total = len(appVersion.Spec.Workloads)
 
-	phase := apicommon.KeptnPhaseType{
-		ShortName: "ReconcileWorkload",
-		LongName:  "Reconcile Workloads",
-	}
+	phase := apicommon.PhaseReconcileWorkload
 
 	workloadInstanceList, err := r.getWorkloadInstanceList(ctx, appVersion.Namespace, appVersion.Spec.AppName)
 	if err != nil {
@@ -43,7 +40,7 @@ func (r *KeptnAppVersionReconciler) reconcileWorkloads(ctx context.Context, appV
 		}
 
 		if !found {
-			r.EventSender.SendK8sEvent(phase, "Warning", appVersion, "NotFound", "workloadInstance not found", appVersion.GetVersion())
+			r.EventSender.SendK8sEvent(phase, "Warning", appVersion, apicommon.PhaseStateNotFound, "workloadInstance not found", appVersion.GetVersion())
 		}
 
 		newStatus = append(newStatus, klcv1alpha3.WorkloadStatus{

--- a/operator/controllers/lifecycle/keptnevaluation/controller.go
+++ b/operator/controllers/lifecycle/keptnevaluation/controller.go
@@ -138,19 +138,17 @@ func (r *KeptnEvaluationReconciler) handleEvaluationIncomplete(ctx context.Conte
 	// Evaluation is uncompleted, update status anyway this avoids updating twice in case of completion
 	err := r.Client.Status().Update(ctx, evaluation)
 	if err != nil {
-		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Warning", evaluation, "ReconcileErrored", "could not update status", "")
+		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Warning", evaluation, apicommon.PhaseStateReconcileError, "could not update status", "")
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
-
-	r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Normal", evaluation, "NotFinished", "has not finished", "")
 
 	return nil
 
 }
 
 func (r *KeptnEvaluationReconciler) handleEvaluationExceededRetries(ctx context.Context, evaluation *klcv1alpha3.KeptnEvaluation, span trace.Span) {
-	r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Warning", evaluation, "ReconcileTimeOut", "retryCount exceeded", "")
+	r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Warning", evaluation, apicommon.PhaseStateReconcileTimeout, "retryCount exceeded", "")
 	err := controllererrors.ErrRetryCountExceeded
 	span.SetStatus(codes.Error, err.Error())
 	evaluation.Status.OverallStatus = apicommon.StateFailed
@@ -239,7 +237,7 @@ func (r *KeptnEvaluationReconciler) updateFinishedEvaluationMetrics(ctx context.
 	err := r.Client.Status().Update(ctx, evaluation)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Warning", evaluation, "ReconcileErrored", "could not update status", "")
+		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileEvaluation, "Warning", evaluation, apicommon.PhaseStateReconcileError, "could not update status", "")
 		return err
 	}
 

--- a/operator/controllers/lifecycle/keptntask/job_utils.go
+++ b/operator/controllers/lifecycle/keptntask/job_utils.go
@@ -20,7 +20,7 @@ func (r *KeptnTaskReconciler) createJob(ctx context.Context, req ctrl.Request, t
 	jobName := ""
 	definition, err := controllercommon.GetTaskDefinition(r.Client, r.Log, ctx, task.Spec.TaskDefinition, req.Namespace)
 	if err != nil {
-		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, "TaskDefinitionNotFound", fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition), "")
+		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition), "")
 		return err
 	}
 
@@ -46,11 +46,11 @@ func (r *KeptnTaskReconciler) createFunctionJob(ctx context.Context, req ctrl.Re
 	err = r.Client.Create(ctx, job)
 	if err != nil {
 		r.Log.Error(err, "could not create job")
-		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, "JobNotCreated", fmt.Sprintf("could not create Job: %s ", task.Name), "")
+		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, apicommon.PhaseStateFailed, fmt.Sprintf("could not create Job: %s ", task.Name), "")
 		return job.Name, err
 	}
 
-	r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", task, "JobCreated", fmt.Sprintf("created Job: %s ", task.Name), "")
+	r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", task, apicommon.PhaseStateSucceeded, fmt.Sprintf("created Job: %s ", task.Name), "")
 	return job.Name, nil
 }
 

--- a/operator/controllers/lifecycle/keptntask/job_utils.go
+++ b/operator/controllers/lifecycle/keptntask/job_utils.go
@@ -20,6 +20,7 @@ func (r *KeptnTaskReconciler) createJob(ctx context.Context, req ctrl.Request, t
 	jobName := ""
 	definition, err := controllercommon.GetTaskDefinition(r.Client, r.Log, ctx, task.Spec.TaskDefinition, req.Namespace)
 	if err != nil {
+		fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition)
 		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition), "")
 		return err
 	}
@@ -45,12 +46,11 @@ func (r *KeptnTaskReconciler) createFunctionJob(ctx context.Context, req ctrl.Re
 	}
 	err = r.Client.Create(ctx, job)
 	if err != nil {
-		r.Log.Error(err, "could not create job")
+		r.Log.Error(err, "could not create Job")
 		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, apicommon.PhaseStateFailed, fmt.Sprintf("could not create Job: %s ", task.Name), "")
 		return job.Name, err
 	}
 
-	r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", task, apicommon.PhaseStateSucceeded, fmt.Sprintf("created Job: %s ", task.Name), "")
 	return job.Name, nil
 }
 

--- a/operator/controllers/lifecycle/keptntask/job_utils.go
+++ b/operator/controllers/lifecycle/keptntask/job_utils.go
@@ -20,7 +20,7 @@ func (r *KeptnTaskReconciler) createJob(ctx context.Context, req ctrl.Request, t
 	jobName := ""
 	definition, err := controllercommon.GetTaskDefinition(r.Client, r.Log, ctx, task.Spec.TaskDefinition, req.Namespace)
 	if err != nil {
-		fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition)
+		r.Log.Error(err, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition))
 		r.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", task.Spec.TaskDefinition), "")
 		return err
 	}

--- a/operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -157,6 +157,7 @@ func (fb *RuntimeBuilder) getParams(ctx context.Context) (*RuntimeExecutionParam
 	if len(fb.options.task.Spec.Parameters.Inline) > 0 {
 		err = mergo.Merge(&params.Parameters, fb.options.task.Spec.Parameters.Inline)
 		if err != nil {
+			fb.options.Log.Error(err, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition))
 			fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 			return nil, err
 		}
@@ -211,6 +212,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	var parentJobParams RuntimeExecutionParams
 	parentDefinition, err := controllercommon.GetTaskDefinition(fb.options.Client, fb.options.Log, ctx, fb.options.funcSpec.FunctionReference.Name, fb.options.req.Namespace)
 	if err != nil {
+		fmt.Sprintf("could not finc KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition)
 		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
@@ -223,6 +225,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	// merge parameter to make sure we use child task data for env var and secrets
 	err = mergo.Merge(params, parentJobParams)
 	if err != nil {
+		fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition)
 		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}

--- a/operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -212,7 +212,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	var parentJobParams RuntimeExecutionParams
 	parentDefinition, err := controllercommon.GetTaskDefinition(fb.options.Client, fb.options.Log, ctx, fb.options.funcSpec.FunctionReference.Name, fb.options.req.Namespace)
 	if err != nil {
-		fmt.Sprintf("could not finc KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition)
+		fb.options.Log.Error(err, fmt.Sprintf("could not finc KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition))
 		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
@@ -225,7 +225,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	// merge parameter to make sure we use child task data for env var and secrets
 	err = mergo.Merge(params, parentJobParams)
 	if err != nil {
-		fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition)
+		fb.options.Log.Error(err, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition))
 		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}

--- a/operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -157,7 +157,6 @@ func (fb *RuntimeBuilder) getParams(ctx context.Context) (*RuntimeExecutionParam
 	if len(fb.options.task.Spec.Parameters.Inline) > 0 {
 		err = mergo.Merge(&params.Parameters, fb.options.task.Spec.Parameters.Inline)
 		if err != nil {
-			fb.options.Log.Error(err, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition))
 			fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 			return nil, err
 		}
@@ -212,7 +211,6 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	var parentJobParams RuntimeExecutionParams
 	parentDefinition, err := controllercommon.GetTaskDefinition(fb.options.Client, fb.options.Log, ctx, fb.options.funcSpec.FunctionReference.Name, fb.options.req.Namespace)
 	if err != nil {
-		fb.options.Log.Error(err, fmt.Sprintf("could not finc KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition))
 		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
@@ -225,7 +223,6 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	// merge parameter to make sure we use child task data for env var and secrets
 	err = mergo.Merge(params, parentJobParams)
 	if err != nil {
-		fb.options.Log.Error(err, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition))
 		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}

--- a/operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -157,7 +157,11 @@ func (fb *RuntimeBuilder) getParams(ctx context.Context) (*RuntimeExecutionParam
 	if len(fb.options.task.Spec.Parameters.Inline) > 0 {
 		err = mergo.Merge(&params.Parameters, fb.options.task.Spec.Parameters.Inline)
 		if err != nil {
+<<<<<<< HEAD
 			fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+=======
+			fb.options.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+>>>>>>> normalize all k8s Events in the system; remove duplicates
 			return nil, err
 		}
 	}
@@ -211,7 +215,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	var parentJobParams RuntimeExecutionParams
 	parentDefinition, err := controllercommon.GetTaskDefinition(fb.options.Client, fb.options.Log, ctx, fb.options.funcSpec.FunctionReference.Name, fb.options.req.Namespace)
 	if err != nil {
-		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionNotFound", fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateNotFound, fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
 	parSpec := controllercommon.GetRuntimeSpec(parentDefinition)
@@ -223,7 +227,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	// merge parameter to make sure we use child task data for env var and secrets
 	err = mergo.Merge(params, parentJobParams)
 	if err != nil {
-		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
 

--- a/operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -157,11 +157,7 @@ func (fb *RuntimeBuilder) getParams(ctx context.Context) (*RuntimeExecutionParam
 	if len(fb.options.task.Spec.Parameters.Inline) > 0 {
 		err = mergo.Merge(&params.Parameters, fb.options.task.Spec.Parameters.Inline)
 		if err != nil {
-<<<<<<< HEAD
-			fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
-=======
-			fb.options.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
->>>>>>> normalize all k8s Events in the system; remove duplicates
+			fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, apicommon.PhaseStateFailed, fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 			return nil, err
 		}
 	}

--- a/operator/controllers/lifecycle/keptntaskdefinition/reconcile_function.go
+++ b/operator/controllers/lifecycle/keptntaskdefinition/reconcile_function.go
@@ -39,7 +39,7 @@ func (r *KeptnTaskDefinitionReconciler) reconcileConfigMap(ctx context.Context, 
 		err := r.Client.Update(ctx, functionCm)
 		if err != nil {
 			r.Log.Error(err, "could not update ConfigMap")
-			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, apicommon.PhaseStateFailed, "uould not update configmap", "")
+			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, apicommon.PhaseStateFailed, "could not update configmap", "")
 			return
 		}
 	}

--- a/operator/controllers/lifecycle/keptntaskdefinition/reconcile_function.go
+++ b/operator/controllers/lifecycle/keptntaskdefinition/reconcile_function.go
@@ -31,18 +31,18 @@ func (r *KeptnTaskDefinitionReconciler) reconcileConfigMap(ctx context.Context, 
 	if (cm == nil || reflect.DeepEqual(cm, &corev1.ConfigMap{})) && functionCm != nil { //cm does not exist or new taskdef with inline func
 		err := r.Client.Create(ctx, functionCm)
 		if err != nil {
-			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, "ConfigMapNotCreated", "could not create configmap", "")
+			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, apicommon.PhaseStateFailed, "could not create configmap", "")
 			return
 		}
-		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", functionCm, "ConfigMapCreated", "created configmap", "")
+		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", functionCm, apicommon.PhaseStateSucceeded, "created configmap", "")
 
 	} else if !reflect.DeepEqual(cm, functionCm) && functionCm != nil { //cm and inline func exists but differ
 		err := r.Client.Update(ctx, functionCm)
 		if err != nil {
-			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, "ConfigMapNotUpdated", "uould not update configmap", "")
+			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, apicommon.PhaseStateFailed, "uould not update configmap", "")
 			return
 		}
-		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", functionCm, "ConfigMapUpdated", "updated configmap", "")
+		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", functionCm, apicommon.PhaseStateSucceeded, "updated configmap", "")
 	}
 	//nothing changed
 }

--- a/operator/controllers/lifecycle/keptntaskdefinition/reconcile_function.go
+++ b/operator/controllers/lifecycle/keptntaskdefinition/reconcile_function.go
@@ -31,18 +31,17 @@ func (r *KeptnTaskDefinitionReconciler) reconcileConfigMap(ctx context.Context, 
 	if (cm == nil || reflect.DeepEqual(cm, &corev1.ConfigMap{})) && functionCm != nil { //cm does not exist or new taskdef with inline func
 		err := r.Client.Create(ctx, functionCm)
 		if err != nil {
+			r.Log.Error(err, "could not create ConfigMap")
 			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, apicommon.PhaseStateFailed, "could not create configmap", "")
 			return
 		}
-		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", functionCm, apicommon.PhaseStateSucceeded, "created configmap", "")
-
 	} else if !reflect.DeepEqual(cm, functionCm) && functionCm != nil { //cm and inline func exists but differ
 		err := r.Client.Update(ctx, functionCm)
 		if err != nil {
+			r.Log.Error(err, "could not update ConfigMap")
 			r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Warning", functionCm, apicommon.PhaseStateFailed, "uould not update configmap", "")
 			return
 		}
-		r.EventSender.SendK8sEvent(apicommon.PhaseReconcileTask, "Normal", functionCm, apicommon.PhaseStateSucceeded, "updated configmap", "")
 	}
 	//nothing changed
 }

--- a/operator/controllers/lifecycle/keptnworkload/controller.go
+++ b/operator/controllers/lifecycle/keptnworkload/controller.go
@@ -102,12 +102,11 @@ func (r *KeptnWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		err = r.Client.Create(ctx, workloadInstance)
 		if err != nil {
-			r.Log.Error(err, "could not create Workload Instance")
+			r.Log.Error(err, "could not create WorkloadInstance")
 			span.SetStatus(codes.Error, err.Error())
 			r.EventSender.SendK8sEvent(apicommon.PhaseCreateWorklodInstance, "Warning", workloadInstance, apicommon.PhaseStateFailed, "could not create KeptnWorkloadInstance ", workloadInstance.Spec.Version)
 			return ctrl.Result{}, err
 		}
-		r.EventSender.SendK8sEvent(apicommon.PhaseCreateWorklodInstance, "Normal", workloadInstance, apicommon.PhaseStateSucceeded, "created KeptnWorkloadInstance ", workloadInstance.Spec.Version)
 		workload.Status.CurrentVersion = workload.Spec.Version
 		if err := r.Client.Status().Update(ctx, workload); err != nil {
 			r.Log.Error(err, "could not update Current Version of Workload")
@@ -116,7 +115,7 @@ func (r *KeptnWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 	if err != nil {
-		r.Log.Error(err, "could not get Workload Instance")
+		r.Log.Error(err, "could not get WorkloadInstance")
 		span.SetStatus(codes.Error, err.Error())
 		return ctrl.Result{}, err
 	}

--- a/operator/controllers/lifecycle/keptnworkload/controller.go
+++ b/operator/controllers/lifecycle/keptnworkload/controller.go
@@ -104,10 +104,10 @@ func (r *KeptnWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err != nil {
 			r.Log.Error(err, "could not create Workload Instance")
 			span.SetStatus(codes.Error, err.Error())
-			r.EventSender.SendK8sEvent(apicommon.PhaseCreateWorklodInstance, "Warning", workloadInstance, "WorkloadInstanceNotCreated", "could not create KeptnWorkloadInstance ", workloadInstance.Spec.Version)
+			r.EventSender.SendK8sEvent(apicommon.PhaseCreateWorklodInstance, "Warning", workloadInstance, apicommon.PhaseStateFailed, "could not create KeptnWorkloadInstance ", workloadInstance.Spec.Version)
 			return ctrl.Result{}, err
 		}
-		r.EventSender.SendK8sEvent(apicommon.PhaseCreateWorklodInstance, "Normal", workloadInstance, "WorkloadInstanceCreated", "created KeptnWorkloadInstance ", workloadInstance.Spec.Version)
+		r.EventSender.SendK8sEvent(apicommon.PhaseCreateWorklodInstance, "Normal", workloadInstance, apicommon.PhaseStateSucceeded, "created KeptnWorkloadInstance ", workloadInstance.Spec.Version)
 		workload.Status.CurrentVersion = workload.Spec.Version
 		if err := r.Client.Status().Update(ctx, workload); err != nil {
 			r.Log.Error(err, "could not update Current Version of Workload")

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -179,7 +179,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 
 func (r *KeptnWorkloadInstanceReconciler) finishKeptnWorkloadInstanceReconcile(ctx context.Context, workloadInstance *klcv1alpha3.KeptnWorkloadInstance, spanWorkloadTrace trace.Span, span trace.Span, phase apicommon.KeptnPhaseType) (ctrl.Result, error) {
 	if !workloadInstance.IsEndTimeSet() {
-		workloadInstance.Status.CurrentPhase = apicommon.PhaseCompleted.ShortName
+		workloadInstance.Status.CurrentPhase = apicommon.PhaseWorkloadCompleted.ShortName
 		workloadInstance.Status.Status = apicommon.StateSucceeded
 		workloadInstance.SetEndTime()
 	}

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -72,7 +72,7 @@ type KeptnWorkloadInstanceReconciler struct {
 //
 //nolint:gocyclo
 func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Info("Searching for Keptn Workload Instance")
+	r.Log.Info("Searching for KeptnWorkloadInstance")
 
 	// retrieve workload instance
 	workloadInstance := &klcv1alpha3.KeptnWorkloadInstance{}
@@ -82,7 +82,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	if err != nil {
-		r.Log.Error(err, "Workload Instance not found")
+		r.Log.Error(err, "WorkloadInstance not found")
 		return reconcile.Result{}, fmt.Errorf(controllererrors.ErrCannotRetrieveWorkloadInstancesMsg, err)
 	}
 

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -190,7 +190,7 @@ func (r *KeptnWorkloadInstanceReconciler) finishKeptnWorkloadInstanceReconcile(c
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	r.EventSender.SendK8sEvent(apicommon.PhaseCompleted, "Normal", workloadInstance, "Finished", "is finished", workloadInstance.GetVersion())
+	r.EventSender.SendK8sEvent(apicommon.PhaseWorkloadCompleted, "Normal", workloadInstance, apicommon.PhaseStateFinished, "is finished", workloadInstance.GetVersion())
 
 	attrs := workloadInstance.GetMetricsAttributes()
 
@@ -224,9 +224,8 @@ func (r *KeptnWorkloadInstanceReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 func (r *KeptnWorkloadInstanceReconciler) sendUnfinishedPreEvaluationEvents(appPreEvalStatus apicommon.KeptnState, phase apicommon.KeptnPhaseType, workloadInstance *klcv1alpha3.KeptnWorkloadInstance) {
 	if appPreEvalStatus.IsFailed() {
-		r.EventSender.SendK8sEvent(phase, "Warning", workloadInstance, "Failed", "has failed since app has failed", workloadInstance.GetVersion())
+		r.EventSender.SendK8sEvent(phase, "Warning", workloadInstance, apicommon.PhaseStateFailed, "has failed since app has failed", workloadInstance.GetVersion())
 	}
-	r.EventSender.SendK8sEvent(phase, "Normal", workloadInstance, "NotFinished", "Pre evaluations tasks for app not finished", workloadInstance.GetVersion())
 }
 
 func (r *KeptnWorkloadInstanceReconciler) setupSpansContexts(ctx context.Context, workloadInstance *klcv1alpha3.KeptnWorkloadInstance) (context.Context, trace.Span, func(span trace.Span, workloadInstance *klcv1alpha3.KeptnWorkloadInstance)) {
@@ -274,8 +273,6 @@ func (r *KeptnWorkloadInstanceReconciler) checkPreEvaluationStatusOfApp(ctx cont
 		r.sendUnfinishedPreEvaluationEvents(appPreEvalStatus, phase, workloadInstance)
 		return true, nil
 	}
-
-	r.EventSender.SendK8sEvent(phase, "Normal", workloadInstance, "FinishedSuccess", "Pre evaluations tasks for app have finished successfully", workloadInstance.GetVersion())
 
 	// set the App trace id if not already set
 	if len(workloadInstance.Spec.TraceId) < 1 {

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -179,7 +179,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 
 func (r *KeptnWorkloadInstanceReconciler) finishKeptnWorkloadInstanceReconcile(ctx context.Context, workloadInstance *klcv1alpha3.KeptnWorkloadInstance, spanWorkloadTrace trace.Span, span trace.Span, phase apicommon.KeptnPhaseType) (ctrl.Result, error) {
 	if !workloadInstance.IsEndTimeSet() {
-		workloadInstance.Status.CurrentPhase = apicommon.PhaseWorkloadCompleted.ShortName
+		workloadInstance.Status.CurrentPhase = apicommon.PhaseCompleted.ShortName
 		workloadInstance.Status.Status = apicommon.StateSucceeded
 		workloadInstance.SetEndTime()
 	}

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -113,7 +113,6 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 
 	if workloadInstance.Status.CurrentPhase == "" {
 		spanWorkloadTrace.AddEvent("WorkloadInstance Pre-Deployment Tasks started", trace.WithTimestamp(time.Now()))
-		r.EventSender.SendK8sEvent(phase, "Normal", workloadInstance, "Started", "have started", workloadInstance.GetVersion())
 	}
 
 	if !workloadInstance.IsPreDeploymentSucceeded() {
@@ -191,6 +190,8 @@ func (r *KeptnWorkloadInstanceReconciler) finishKeptnWorkloadInstanceReconcile(c
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	r.EventSender.SendK8sEvent(apicommon.PhaseCompleted, "Normal", workloadInstance, "Finished", "is finished", workloadInstance.GetVersion())
+
 	attrs := workloadInstance.GetMetricsAttributes()
 
 	// metrics: add deployment duration
@@ -203,8 +204,6 @@ func (r *KeptnWorkloadInstanceReconciler) finishKeptnWorkloadInstanceReconcile(c
 	if err := r.SpanHandler.UnbindSpan(workloadInstance, ""); err != nil {
 		r.Log.Error(err, controllererrors.ErrCouldNotUnbindSpan, workloadInstance.Name)
 	}
-
-	r.EventSender.SendK8sEvent(phase, "Normal", workloadInstance, "Finished", "is finished", workloadInstance.GetVersion())
 
 	return ctrl.Result{}, nil
 }

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller.go
@@ -190,7 +190,7 @@ func (r *KeptnWorkloadInstanceReconciler) finishKeptnWorkloadInstanceReconcile(c
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	r.EventSender.SendK8sEvent(apicommon.PhaseWorkloadCompleted, "Normal", workloadInstance, apicommon.PhaseStateFinished, "is finished", workloadInstance.GetVersion())
+	r.EventSender.SendK8sEvent(apicommon.PhaseWorkloadCompleted, "Normal", workloadInstance, apicommon.PhaseStateFinished, "has finished", workloadInstance.GetVersion())
 
 	attrs := workloadInstance.GetMetricsAttributes()
 

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller_test.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller_test.go
@@ -801,72 +801,6 @@ func TestKeptnWorkloadInstanceReconciler_ReconcileNoActionRequired(t *testing.T)
 	require.NotNil(t, result)
 }
 
-func TestKeptnWorkloadInstanceReconciler_ReconcileDoNotStartBeforeAppPreEvaluationIsDone(t *testing.T) {
-	r, eventChannel, _ := setupReconciler()
-
-	testNamespace := "some-ns"
-
-	wi := &klcv1alpha3.KeptnWorkloadInstance{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "some-wi",
-			Namespace: testNamespace,
-		},
-		Spec: klcv1alpha3.KeptnWorkloadInstanceSpec{
-			KeptnWorkloadSpec: klcv1alpha3.KeptnWorkloadSpec{
-				AppName: "some-app",
-				Version: "1.0.0",
-			},
-			WorkloadName:    "some-app-some-workload",
-			PreviousVersion: "",
-			TraceId:         nil,
-		},
-		Status: klcv1alpha3.KeptnWorkloadInstanceStatus{},
-	}
-
-	err := r.Client.Create(context.TODO(), wi)
-
-	require.Nil(t, err)
-
-	err = controllercommon.AddAppVersion(
-		r.Client,
-		testNamespace,
-		"some-app",
-		"1.0.0",
-		[]klcv1alpha3.KeptnWorkloadRef{
-			{
-				Name:    "some-workload",
-				Version: "1.0.0",
-			},
-		},
-		klcv1alpha3.KeptnAppVersionStatus{},
-	)
-	require.Nil(t, err)
-
-	req := ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: testNamespace,
-			Name:      "some-wi",
-		},
-	}
-
-	result, err := r.Reconcile(context.TODO(), req)
-
-	require.Nil(t, err)
-	require.True(t, result.Requeue)
-
-	expectedEvents := []string{
-		"AppPreDeployEvaluationsNotFinished",
-	}
-
-	for _, e := range expectedEvents {
-		event := <-eventChannel
-		assert.Equal(t, strings.Contains(event, req.Name), true, "wrong appversion")
-		assert.Equal(t, strings.Contains(event, req.Namespace), true, "wrong namespace")
-		assert.Equal(t, strings.Contains(event, e), true, fmt.Sprintf("no %s found in %s", e, event))
-	}
-}
-
 func TestKeptnWorkloadInstanceReconciler_ReconcileReachCompletion(t *testing.T) {
 	r, eventChannel, _ := setupReconciler()
 
@@ -943,9 +877,99 @@ func TestKeptnWorkloadInstanceReconciler_ReconcileReachCompletion(t *testing.T) 
 
 	for _, e := range expectedEvents {
 		event := <-eventChannel
-		assert.Equal(t, strings.Contains(event, req.Name), true, "wrong appversion")
+		assert.Equal(t, strings.Contains(event, req.Name), true, "wrong workloadinstance")
 		assert.Equal(t, strings.Contains(event, req.Namespace), true, "wrong namespace")
 		assert.Equal(t, strings.Contains(event, e), true, fmt.Sprintf("no %s found in %s", e, event))
+	}
+}
+
+func TestKeptnWorkloadInstanceReconciler_ReconcileFailed(t *testing.T) {
+	r, eventChannel, _ := setupReconciler()
+
+	testNamespace := "some-ns"
+
+	wi := &klcv1alpha3.KeptnWorkloadInstance{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-wi",
+			Namespace: testNamespace,
+		},
+		Spec: klcv1alpha3.KeptnWorkloadInstanceSpec{
+			KeptnWorkloadSpec: klcv1alpha3.KeptnWorkloadSpec{
+				AppName: "some-app",
+				Version: "1.0.0",
+				PreDeploymentTasks: []string{
+					"task",
+				},
+			},
+			WorkloadName:    "some-app-some-workload",
+			PreviousVersion: "",
+			TraceId:         nil,
+		},
+		Status: klcv1alpha3.KeptnWorkloadInstanceStatus{
+			DeploymentStatus:               apicommon.StatePending,
+			PreDeploymentStatus:            apicommon.StateProgressing,
+			PostDeploymentStatus:           apicommon.StatePending,
+			PreDeploymentEvaluationStatus:  apicommon.StatePending,
+			PostDeploymentEvaluationStatus: apicommon.StatePending,
+			CurrentPhase:                   apicommon.PhaseWorkloadPreDeployment.ShortName,
+			Status:                         apicommon.StateProgressing,
+			PreDeploymentTaskStatus: []klcv1alpha3.ItemStatus{
+				{
+					Name:           "pre-task",
+					DefinitionName: "task",
+					Status:         apicommon.StateFailed,
+				},
+			},
+		},
+	}
+
+	err := r.Client.Create(context.TODO(), wi)
+
+	require.Nil(t, err)
+
+	err = controllercommon.AddAppVersion(
+		r.Client,
+		testNamespace,
+		"some-app",
+		"1.0.0",
+		[]klcv1alpha3.KeptnWorkloadRef{
+			{
+				Name:    "some-workload",
+				Version: "1.0.0",
+			},
+		},
+		klcv1alpha3.KeptnAppVersionStatus{
+			PreDeploymentEvaluationStatus: apicommon.StateSucceeded,
+		},
+	)
+	require.Nil(t, err)
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "some-wi",
+		},
+	}
+
+	result, err := r.Reconcile(context.TODO(), req)
+
+	require.Nil(t, err)
+
+	// do not requeue since we reached completion
+	require.False(t, result.Requeue)
+
+	// here we do not expect an event about the application preEvaluation being finished since that  will have been sent in
+	// one of the previous reconciliation loops that lead to the first phase being reached
+	expectedEvents := []string{
+		"WorkloadPreDeployTasksFailed",
+	}
+
+	for _, e := range expectedEvents {
+		event := <-eventChannel
+		require.Equal(t, strings.Contains(event, req.Name), true, "wrong workloadinstance")
+		require.Equal(t, strings.Contains(event, req.Namespace), true, "wrong namespace")
+		require.Equal(t, strings.Contains(event, e), true, fmt.Sprintf("no %s found in %s", e, event))
 	}
 }
 

--- a/operator/controllers/lifecycle/keptnworkloadinstance/controller_test.go
+++ b/operator/controllers/lifecycle/keptnworkloadinstance/controller_test.go
@@ -938,7 +938,7 @@ func TestKeptnWorkloadInstanceReconciler_ReconcileReachCompletion(t *testing.T) 
 	// here we do not expect an event about the application preEvaluation being finished since that  will have been sent in
 	// one of the previous reconciliation loops that lead to the first phase being reached
 	expectedEvents := []string{
-		"WorkloadPostDeployEvaluationsFinished",
+		"CompletedFinished",
 	}
 
 	for _, e := range expectedEvents {

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook.go
@@ -288,12 +288,12 @@ func (a *PodMutatingWebhook) handleWorkload(ctx context.Context, logger logr.Log
 		err = a.Client.Create(ctx, workload)
 		if err != nil {
 			logger.Error(err, "Could not create Workload")
-			a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Warning", workload, "WorkloadNotCreated", "could not create KeptnWorkload", workload.Spec.Version)
+			a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Warning", workload, apicommon.PhaseStateFailed, "could not create KeptnWorkload", workload.Spec.Version)
 			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 
-		a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Normal", workload, "WorkloadCreated", "created KeptnWorkload", workload.Spec.Version)
+		a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Normal", workload, apicommon.PhaseStateSucceeded, "created KeptnWorkload", workload.Spec.Version)
 		return nil
 	}
 
@@ -313,12 +313,12 @@ func (a *PodMutatingWebhook) handleWorkload(ctx context.Context, logger logr.Log
 	err = a.Client.Update(ctx, workload)
 	if err != nil {
 		logger.Error(err, "Could not update Workload")
-		a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Warning", workload, "WorkloadNotUpdated", "could not update KeptnWorkload", workload.Spec.Version)
+		a.EventSender.SendK8sEvent(apicommon.PhaseUpdateWorkload, "Warning", workload, apicommon.PhaseStateFailed, "could not update KeptnWorkload", workload.Spec.Version)
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 
-	a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Normal", workload, "WorkloadUpdated", "updated KeptnWorkload", workload.Spec.Version)
+	a.EventSender.SendK8sEvent(apicommon.PhaseUpdateWorkload, "Normal", workload, apicommon.PhaseStateSucceeded, "updated KeptnWorkload", workload.Spec.Version)
 
 	return nil
 }
@@ -343,12 +343,12 @@ func (a *PodMutatingWebhook) handleApp(ctx context.Context, logger logr.Logger, 
 		err = a.Client.Create(ctx, appCreationRequest)
 		if err != nil {
 			logger.Error(err, "Could not create App")
-			a.EventSender.SendK8sEvent(apicommon.PhaseCreateApp, "Warning", appCreationRequest, "AppCreationRequestNotCreated", "could not create KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
+			a.EventSender.SendK8sEvent(apicommon.PhaseCreateApp, "Warning", appCreationRequest, apicommon.PhaseStateFailed, "could not create KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
 			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 
-		a.EventSender.SendK8sEvent(apicommon.PhaseCreateApp, "Normal", appCreationRequest, "AppCreationRequestCreated", "created KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
+		a.EventSender.SendK8sEvent(apicommon.PhaseCreateApp, "Normal", appCreationRequest, apicommon.PhaseStateSucceeded, "created KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
 		return nil
 	}
 

--- a/operator/webhooks/pod_mutator/pod_mutating_webhook.go
+++ b/operator/webhooks/pod_mutator/pod_mutating_webhook.go
@@ -293,7 +293,6 @@ func (a *PodMutatingWebhook) handleWorkload(ctx context.Context, logger logr.Log
 			return err
 		}
 
-		a.EventSender.SendK8sEvent(apicommon.PhaseCreateWorkload, "Normal", workload, apicommon.PhaseStateSucceeded, "created KeptnWorkload", workload.Spec.Version)
 		return nil
 	}
 
@@ -318,8 +317,6 @@ func (a *PodMutatingWebhook) handleWorkload(ctx context.Context, logger logr.Log
 		return err
 	}
 
-	a.EventSender.SendK8sEvent(apicommon.PhaseUpdateWorkload, "Normal", workload, apicommon.PhaseStateSucceeded, "updated KeptnWorkload", workload.Spec.Version)
-
 	return nil
 }
 
@@ -342,13 +339,12 @@ func (a *PodMutatingWebhook) handleApp(ctx context.Context, logger logr.Logger, 
 		appCreationRequest = newAppCreationRequest
 		err = a.Client.Create(ctx, appCreationRequest)
 		if err != nil {
-			logger.Error(err, "Could not create App")
-			a.EventSender.SendK8sEvent(apicommon.PhaseCreateApp, "Warning", appCreationRequest, apicommon.PhaseStateFailed, "could not create KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
+			logger.Error(err, "Could not create AppCreationRequest")
+			a.EventSender.SendK8sEvent(apicommon.PhaseCreateAppCreationRequest, "Warning", appCreationRequest, apicommon.PhaseStateFailed, "could not create KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
 			span.SetStatus(codes.Error, err.Error())
 			return err
 		}
 
-		a.EventSender.SendK8sEvent(apicommon.PhaseCreateApp, "Normal", appCreationRequest, apicommon.PhaseStateSucceeded, "created KeptnAppCreationRequest", appCreationRequest.Spec.AppName)
 		return nil
 	}
 


### PR DESCRIPTION
Fixes: #1683 

## Changes
- standardize k8s Events on lifecycle path - introduce started, finished and failed events
- introduce PhaseStates of Phases and make use of them in the code
- remove k8s Events creating big noise and having no big value for the end users (not finished Events, ...)
- add more tests
- normalize all Events to use the same pattern
