### PR TITLE
chore(operator): unexport EventSender in BuilderOptions

### DIFF
--- a/operator/controllers/lifecycle/keptntask/job_runner_builder.go
+++ b/operator/controllers/lifecycle/keptntask/job_runner_builder.go
@@ -20,7 +20,7 @@ type JobRunnerBuilder interface {
 // BuilderOptions contains everything needed to build the current job
 type BuilderOptions struct {
 	client.Client
-	EventSender   controllercommon.EventSender
+	eventSender   controllercommon.EventSender
 	req           ctrl.Request
 	Log           logr.Logger
 	task          *klcv1alpha3.KeptnTask

--- a/operator/controllers/lifecycle/keptntask/job_utils.go
+++ b/operator/controllers/lifecycle/keptntask/job_utils.go
@@ -127,7 +127,7 @@ func (r *KeptnTaskReconciler) generateJob(ctx context.Context, task *klcv1alpha3
 		task:          task,
 		containerSpec: definition.Spec.Container,
 		funcSpec:      controllercommon.GetRuntimeSpec(definition),
-		EventSender:   r.EventSender,
+		eventSender:   r.EventSender,
 		Image:         controllercommon.GetRuntimeImage(definition),
 		MountPath:     controllercommon.GetRuntimeMountPath(definition),
 		ConfigMap:     definition.Status.Function.ConfigMap,

--- a/operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -157,7 +157,7 @@ func (fb *RuntimeBuilder) getParams(ctx context.Context) (*RuntimeExecutionParam
 	if len(fb.options.task.Spec.Parameters.Inline) > 0 {
 		err = mergo.Merge(&params.Parameters, fb.options.task.Spec.Parameters.Inline)
 		if err != nil {
-			fb.options.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+			fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 			return nil, err
 		}
 	}
@@ -211,7 +211,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	var parentJobParams RuntimeExecutionParams
 	parentDefinition, err := controllercommon.GetTaskDefinition(fb.options.Client, fb.options.Log, ctx, fb.options.funcSpec.FunctionReference.Name, fb.options.req.Namespace)
 	if err != nil {
-		fb.options.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionNotFound", fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionNotFound", fmt.Sprintf("could not find KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
 	parSpec := controllercommon.GetRuntimeSpec(parentDefinition)
@@ -223,7 +223,7 @@ func (fb *RuntimeBuilder) handleParent(ctx context.Context, params *RuntimeExecu
 	// merge parameter to make sure we use child task data for env var and secrets
 	err = mergo.Merge(params, parentJobParams)
 	if err != nil {
-		fb.options.EventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
+		fb.options.eventSender.SendK8sEvent(apicommon.PhaseCreateTask, "Warning", fb.options.task, "TaskDefinitionMergeFailure", fmt.Sprintf("could not merge KeptnTaskDefinition: %s ", fb.options.task.Spec.TaskDefinition), "")
 		return err
 	}
 

--- a/operator/controllers/lifecycle/keptntask/runtime_builder_test.go
+++ b/operator/controllers/lifecycle/keptntask/runtime_builder_test.go
@@ -60,7 +60,7 @@ func TestJSBuilder_handleParent(t *testing.T) {
 			name: "no definition",
 			options: BuilderOptions{
 				Client:      fake.NewClient(),
-				EventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
+				eventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{Namespace: "default"},
 				},
@@ -76,7 +76,7 @@ func TestJSBuilder_handleParent(t *testing.T) {
 			name: "definition exists, recursive",
 			options: BuilderOptions{
 				Client:      fake.NewClient(def),
-				EventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
+				eventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{Namespace: "default"},
 				},
@@ -91,7 +91,7 @@ func TestJSBuilder_handleParent(t *testing.T) {
 			name: "definition exists, with parameters and secrets",
 			options: BuilderOptions{
 				Client:      fake.NewClient(paramDef, def),
-				EventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
+				eventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{Namespace: "default"},
 				},
@@ -207,7 +207,7 @@ func TestJSBuilder_getParams(t *testing.T) {
 			name: "definition exists, no parent",
 			options: BuilderOptions{
 				Client:      fake.NewClient(def),
-				EventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
+				eventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{Namespace: "default"},
 				},
@@ -238,7 +238,7 @@ func TestJSBuilder_getParams(t *testing.T) {
 			name: "definition exists, parent with parameters and secrets",
 			options: BuilderOptions{
 				Client:      fake.NewClient(paramDef, def),
-				EventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
+				eventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{Namespace: "default"},
 				},
@@ -270,7 +270,7 @@ func TestJSBuilder_getParams(t *testing.T) {
 			name: "definition exists, parent is of a different runtime",
 			options: BuilderOptions{
 				Client:      fake.NewClient(parentPy, defJS),
-				EventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
+				eventSender: controllercommon.NewEventSender(record.NewFakeRecorder(100)),
 				req: ctrl.Request{
 					NamespacedName: types.NamespacedName{Namespace: "default"},
 				},


### PR DESCRIPTION
There is no need to export EventSender in BuilderOptions, therefore we can hide it

Failing helm-chart validation check will be fixed with https://github.com/keptn/lifecycle-toolkit/pull/1697