### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,16 +23,16 @@ jobs:
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
   stale1:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/stale@v8
-         with:
-           days-before-stale: 21
-           stale-issue-message: |
-             This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
-           include-only-assigned: true
-           remove-stale-when-updated: true
-           only-issue-labels: 'good first issue'  
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 21
+          stale-issue-message: |
+            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+          include-only-assigned: true
+          remove-stale-when-updated: true
+          only-issue-labels: 'good first issue'  
 
   stale2:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,28 @@ jobs:
           stale-pr-message: |
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 21
+          stale-issue-message: |
+            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+          include-only-assigned: true
+          remove-stale-when-updated: true
+          only-issue-labels: 'good first issue'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 28
+          stale-issue-message: |
+            This issue will be labelled 'to be unassigned' in a week because no response has been encountered.
+          include-only-assigned: true
+          remove-stale-when-updated: true
+          only-issue-labels: 'good first issue'
+          stale-issue-label: 'to be unassigned'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,20 +22,19 @@ jobs:
           stale-pr-message: |
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
-jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v8
-        with:
-          days-before-stale: 21
-          stale-issue-message: |
-            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
-          include-only-assigned: true
-          remove-stale-when-updated: true
-          only-issue-labels: 'good first issue'
-jobs:
-  stale:
+  stale1:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/stale@v8
+         with:
+           days-before-stale: 21
+           stale-issue-message: |
+             This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+           include-only-assigned: true
+           remove-stale-when-updated: true
+           only-issue-labels: 'good first issue'  
+
+  stale2:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
@@ -47,3 +46,4 @@ jobs:
           remove-stale-when-updated: true
           only-issue-labels: 'good first issue'
           stale-issue-label: 'to be unassigned'
+    


### PR DESCRIPTION
fix: Created jobs for stale and assigned issues  
 #1709

Changes

* Added a job for assigned issues that have been inactive for 3 weeks
* Added another job to label the issues with 'to be unassigned'  which has been stale for another week deprived of any response beforehand