### PR TITLE
ci: create jobs to unassign stale good first issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,4 +47,4 @@ jobs:
           include-only-assigned: true
           only-issue-labels: 'good first issue'
           stale-issue-label: 'to be unassigned'
-    
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -36,6 +36,7 @@ jobs:
           include-only-assigned: true
           remove-stale-when-updated: true
           only-issue-labels: 'good first issue'
+
       - uses: actions/stale@v8
         with:
           days-before-stale: 28

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,16 +23,16 @@ jobs:
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
   stale1:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/stale@v8
-         with:
-           days-before-stale: 21
-           stale-issue-message: |
-             This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
-           include-only-assigned: true
-           remove-stale-when-updated: true
-           only-issue-labels: 'good first issue'  
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 21
+          stale-issue-message: |
+            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+          include-only-assigned: true
+          remove-stale-when-updated: true
+          only-issue-labels: 'good first issue'  
 
   stale2:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           days-before-stale: 21
           stale-issue-message: |
-            This issue will be unassigned in a week if no further activity is seen. 
-            If you are active please provide an update on the status of the issue and if you would like to continue 
+            This issue will be unassigned in a week if no further activity is seen.
+            If you are active please provide an update on the status of the issue and if you would like to continue
             working on it.
           include-only-assigned: true
           remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -34,7 +34,7 @@ jobs:
             working on it.
           include-only-assigned: true
           remove-stale-when-updated: true
-          only-issue-labels: 'good first issue'  
+          only-issue-labels: 'good first issue'
 
   to-be-unassigned-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,10 +35,6 @@ jobs:
           include-only-assigned: true
           remove-stale-when-updated: true
           only-issue-labels: 'good first issue'
-
-  to-be-unassigned-label:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/stale@v8
         with:
           days-before-stale: 28

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,28 @@ jobs:
           stale-pr-message: |
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 21
+          stale-issue-message: |
+            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+          include-only-assigned: true
+          remove-stale-when-updated: true
+          only-issue-labels: 'good first issue'
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 28
+          stale-issue-message: |
+            This issue will be labelled 'to be unassigned' in a week because no response has been encountered.
+          include-only-assigned: true
+          remove-stale-when-updated: true
+          only-issue-labels: 'good first issue'
+          stale-issue-label: 'to be unassigned'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,28 +22,27 @@ jobs:
           stale-pr-message: |
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
-  stale1:
+  stale-good-first-issues:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
         with:
           days-before-stale: 21
           stale-issue-message: |
-            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+            This issue will be unassigned in a week if no further activity is seen. If you are active please provide an update on the status of the issue and if you would like to continue working on it..
           include-only-assigned: true
           remove-stale-when-updated: true
           only-issue-labels: 'good first issue'  
 
-  stale2:
+  to-be-unassigned-label:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
         with:
           days-before-stale: 28
           stale-issue-message: |
-            This issue will be labelled 'to be unassigned' in a week because no response has been encountered.
+            This issue will be labelled 'to be unassigned' because no response has been encountered.
           include-only-assigned: true
-          remove-stale-when-updated: true
           only-issue-labels: 'good first issue'
           stale-issue-label: 'to be unassigned'
     

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,4 +47,3 @@ jobs:
           include-only-assigned: true
           only-issue-labels: 'good first issue'
           stale-issue-label: 'to be unassigned'
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,8 +30,10 @@ jobs:
           days-before-stale: 21
           stale-issue-message: |
             This issue will be unassigned in a week if no further activity is seen. 
-            If you are active please provide an update on the status of the issue and if you would like to continue working on it.
+            If you are active please provide an update on the status of the issue and if you would like to continue 
+            working on it.
           include-only-assigned: true
+          remove-stale-when-updated: true
           only-issue-labels: 'good first issue'  
 
   to-be-unassigned-label:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           days-before-stale: 21
           stale-issue-message: |
-            This issue will be unassigned in a week if no further activity is seen. If you are active please provide an update on the status of the issue and if you would like to continue working on it..
+            This issue will be unassigned in a week if no further activity is seen. 
+            If you are active please provide an update on the status of the issue and if you would like to continue working on it.
           include-only-assigned: true
-          remove-stale-when-updated: true
           only-issue-labels: 'good first issue'  
 
   to-be-unassigned-label:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           days-before-stale: 21
           stale-issue-message: |
-            This issue will be unassigned in a week if no further activity is seen.
+            This issue will be unassigned in 1 week if no further activity is seen.
             If you are active please provide an update on the status of the issue and if you would like to continue
             working on it.
           include-only-assigned: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,7 @@ jobs:
           stale-pr-message: |
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
+
   stale-good-first-issues:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,20 +22,19 @@ jobs:
           stale-pr-message: |
             This issue has been automatically marked as stale because it has not had recent activity. It will be
             closed if no further activity occurs. Thank you for your contributions.
-jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v8
-        with:
-          days-before-stale: 21
-          stale-issue-message: |
-            This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
-          include-only-assigned: true
-          remove-stale-when-updated: true
-          only-issue-labels: 'good first issue'
-jobs:
-  stale:
+  stale1:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/stale@v8
+         with:
+           days-before-stale: 21
+           stale-issue-message: |
+             This issue will be unassigned soon if no further activity is seen. If the asignees are active please provide any update.
+           include-only-assigned: true
+           remove-stale-when-updated: true
+           only-issue-labels: 'good first issue'  
+
+  stale2:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
@@ -47,3 +46,4 @@ jobs:
           remove-stale-when-updated: true
           only-issue-labels: 'good first issue'
           stale-issue-label: 'to be unassigned'
+    


### PR DESCRIPTION
fix: This will create a reminder after 3 weeks of assigned issues and thereafter will put a label "to be unassigned" in a week

fixes #1709 