### PR TITLE
docs: remove evaluationdefnition.md for codebase clarity

### DIFF
--- a/docs/content/en/docs-v0.8.0/yaml-crd-ref/evaluationdefnition.md
+++ b/docs/content/en/docs-v0.8.0/yaml-crd-ref/evaluationdefnition.md
@@ -1,5 +1,0 @@
----
-title: KeptnEvaluationDefinition
-description: Define all workloads and checks associated with an application
-weight: 20
----

--- a/docs/content/en/docs/yaml-crd-ref/evaluationdefnition.md
+++ b/docs/content/en/docs/yaml-crd-ref/evaluationdefnition.md
@@ -1,5 +1,0 @@
----
-title: KeptnEvaluationDefinition
-description: Define all workloads and checks associated with an application
-weight: 20
----


### PR DESCRIPTION
Fix #1727

Removing [evaluationdefnition.md](https://lifecycle.keptn.sh/docs/yaml-crd-ref/evaluationdefnition/) file - eliminating duplication and enhancing clarity

cc @StackScribe 