### PR TITLE
fix: remove klt-cert-manager from version bumps during KLT release

### DIFF
--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -46,7 +46,7 @@ checks
 | ------------------------------------------------------ | ------------------------------------------------------------------------- | ------------------------------------ |
 | `certificateOperator.manager.containerSecurityContext` | Sets security context for the cert manager                                |                                      |
 | `certificateOperator.manager.image.repository`         | specify repo for manager image                                            | `ghcr.io/keptn/certificate-operator` |
-| `certificateOperator.manager.image.tag`                | select tag for manager container <!---x-release-please-version-->         | `v0.8.1`                             |
+| `certificateOperator.manager.image.tag`                | select tag for manager container                                          | `v0.8.1`                             |
 | `certificateOperator.manager.imagePullPolicy`          | select image pull policy for manager container                            | `Always`                             |
 | `certificateOperator.manager.env.labelSelectorKey`     | specify the label selector to find resources to generate certificates for | `keptn.sh/inject-cert`               |
 | `certificateOperator.manager.env.labelSelectorValue`   | specify the value for the label selector                                  | `true`                               |

--- a/helm/chart/doc.yaml
+++ b/helm/chart/doc.yaml
@@ -66,7 +66,7 @@
 ## @skip     certificateOperator.manager.containerSecurityContext.seccompProfile.type
 
 ## @param     certificateOperator.manager.image.repository specify repo for manager image
-## @param     certificateOperator.manager.image.tag select tag for manager container <!---x-release-please-version-->
+## @param     certificateOperator.manager.image.tag select tag for manager container
 ## @param     certificateOperator.manager.imagePullPolicy select image pull policy for manager container
 
 ## @param     certificateOperator.manager.env.labelSelectorKey specify the label selector to find resources to generate certificates for


### PR DESCRIPTION
### This PR
- fixes #1734 
- removes the cert manager release please annotation comment in the helm readme so that it doesn't get the same version as KLT anymore (since it has its own versioning now in a monorepo fashion)