### PR TITLE
feat: metrics-operator monorepo setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,15 +264,8 @@ jobs:
           ---
           EOF
           cat namespace.yaml \
-<<<<<<< HEAD
             lifecycle-operator/config/rendered/release.yaml \
-            scheduler/config/rendered/release.yaml \
-            klt-cert-manager/config/rendered/release.yaml \
-            metrics-operator/config/rendered/release.yaml > klt-manifest.yaml
-=======
-            operator/config/rendered/release.yaml \
             scheduler/config/rendered/release.yaml > klt-manifest.yaml
->>>>>>> feat: metrics-operator monorepo setup
 
       - name: Create Cert-Manager manifest
         if: needs.release-please.outputs.cert-manager-release-created == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,9 +252,14 @@ jobs:
           make release-manifests
           cd ../lifecycle-operator
           make controller-gen release-manifests
+          cd ../klt-cert-manager
+          make controller-gen release-manifests
+          cd ../metrics-operator
+          make controller-gen release-manifests
           cd ..
           echo "---" >> lifecycle-operator/config/rendered/release.yaml
           echo "---" >> scheduler/config/rendered/release.yaml
+          echo "---" >> klt-cert-manager/config/rendered/release.yaml
           cat >> namespace.yaml << EOF
           ---
           apiVersion: v1
@@ -265,7 +270,9 @@ jobs:
           EOF
           cat namespace.yaml \
             lifecycle-operator/config/rendered/release.yaml \
-            scheduler/config/rendered/release.yaml > klt-manifest.yaml
+            scheduler/config/rendered/release.yaml \
+            klt-cert-manager/config/rendered/release.yaml \
+            metrics-operator/config/rendered/release.yaml > klt-manifest.yaml
 
       - name: Create Cert-Manager manifest
         if: needs.release-please.outputs.cert-manager-release-created == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
       klt-tag-name: ${{ steps.release.outputs.tag_name }}
       cert-manager-release-created: ${{ steps.release.outputs.klt-cert-manager--release_created }}
       cert-manager-tag-name: ${{ steps.release.outputs.klt-cert-manager--tag_name }}
+      metrics-operator-release-created: ${{ steps.release.outputs.metrics-operator--release_created }}
+      metrics-operator-tag-name: ${{ steps.release.outputs.metrics-operator--tag_name }}
       releases-created: ${{ steps.release.outputs.releases_created }}
       build-matrix: ${{ steps.build-matrix.outputs.result }}
     steps:
@@ -42,10 +44,11 @@ jobs:
 
       - name: Release Info
         run: |
-          echo "Release KLT:              ${{ steps.release.outputs.release_created }}"
-          echo "Release KLT Cert Manager: ${{ steps.release.outputs.klt-cert-manager--release_created }}"
-          echo "Anything to release:      ${{ steps.release.outputs.releases_created }}"
-          echo "Paths to be released:     ${{ steps.release.outputs.paths_released }}"
+          echo "Release KLT:                  ${{ steps.release.outputs.release_created }}"
+          echo "Release KLT Cert Manager:     ${{ steps.release.outputs.klt-cert-manager--release_created }}"
+          echo "Release KLT Metrics Operator: ${{ steps.release.outputs.metrics-operator--release_created }}"
+          echo "Anything to release:          ${{ steps.release.outputs.releases_created }}"
+          echo "Paths to be released:         ${{ steps.release.outputs.paths_released }}"
 
       - name: Create build matrix
         id: build-matrix
@@ -53,56 +56,57 @@ jobs:
         env:
           RELEASE_KLT: ${{ steps.release.outputs.release_created }}
           RELEASE_CERT_MANAGER: ${{ steps.release.outputs.klt-cert-manager--release_created }}
+          RELEASE_METRICS_OPERATOR: ${{ steps.release.outputs.metrics-operator--release_created }}
           KLT_TAG: ${{ steps.release.outputs.tag_name }}
           CERT_MANAGER_TAG: ${{ steps.release.outputs.klt-cert-manager--tag_name }}
+          METRICS_OPERATOR_TAG: ${{ steps.release.outputs.metrics-operator--tag_name }}
         with:
           script: |
-            const { RELEASE_KLT, RELEASE_CERT_MANAGER, KLT_TAG, CERT_MANAGER_TAG } = process.env
-            const kltMatrix = [
-              {
-                  name: "lifecycle-operator",
-                  folder: "lifecycle-operator/",
-                  tagName: KLT_TAG
-              },
-              {
-                  name: "metrics-operator",
-                  folder: "metrics-operator/",
-                  tagName: KLT_TAG
-              },
-              {
-                  name: "scheduler",
-                  folder: "scheduler/",
-                  tagName: KLT_TAG
-              },
-              {
-                  name: "functions-runtime",
-                  folder: "functions-runtime/",
-                  tagName: KLT_TAG
-              },
-              {
-                  name: "python-runtime",
-                  folder: "python-runtime/",
-                  tagName: KLT_TAG
-              }
-            ]
+            const { RELEASE_KLT, RELEASE_CERT_MANAGER, RELEASE_METRICS_OPERATOR, KLT_TAG, CERT_MANAGER_TAG, METRICS_OPERATOR_TAG } = process.env
 
-            const certManagerMatrix = [
-              {
+            var result = []
+            if (RELEASE_KLT === "true") {
+              result.push(...[
+                {
+                    name: "lifecycle-operator",
+                    folder: "lifecycle-operator/",
+                    tagName: KLT_TAG
+                },
+                {
+                    name: "scheduler",
+                    folder: "scheduler/",
+                    tagName: KLT_TAG
+                },
+                {
+                    name: "functions-runtime",
+                    folder: "functions-runtime/",
+                    tagName: KLT_TAG
+                },
+                {
+                    name: "python-runtime",
+                    folder: "python-runtime/",
+                    tagName: KLT_TAG
+                }
+              ])
+            }
+
+            if (RELEASE_CERT_MANAGER === "true") {
+              result.push({
                   name: "certificate-operator",
                   folder: "klt-cert-manager/",
                   tagName: CERT_MANAGER_TAG
-              }
-            ]
-
-            let result = {}
-            if (RELEASE_KLT === "true" && RELEASE_CERT_MANAGER === "true") {
-                result = { config: [...kltMatrix, ...certManagerMatrix]}
-            } else if (RELEASE_KLT === "true") {
-                result = { config: kltMatrix }
-            } else if (RELEASE_CERT_MANAGER === "true") {
-                result = { config: certManagerMatrix }
+              })
             }
-            return result
+
+            if (RELEASE_METRICS_OPERATOR === "true") {
+              result.push({
+                  name: "metrics-operator",
+                  folder: "metrics-operator/",
+                  tagName: METRICS_OPERATOR_TAG
+              })
+            }
+
+            return { config: result }
 
   build-release:
     if: needs.release-please.outputs.releases-created == 'true'
@@ -144,7 +148,8 @@ jobs:
         run: |
           # Remove artifact prefix from tag so that we get clean image tags
           temp="${IMAGE_TAG##klt-}"
-          echo "IMAGE_TAG=${temp##cert-manager-}" >> "$GITHUB_OUTPUT"
+          temp="${temp##cert-manager-}"
+          echo "IMAGE_TAG=${temp##metrics-operator-}" >> "$GITHUB_OUTPUT"
 
       - name: Build Docker Image
         id: docker_build_image
@@ -208,7 +213,7 @@ jobs:
           key: build-tools-${{ github.ref_name }}
 
       - name: Cache build tools metrics-operator
-        if: needs.release-please.outputs.klt-release-created == 'true'
+        if: needs.release-please.outputs.metrics-operator-release-created == 'true'
         id: cache-build-tools-metrics-operator
         uses: actions/cache@v3
         with:
@@ -247,14 +252,9 @@ jobs:
           make release-manifests
           cd ../lifecycle-operator
           make controller-gen release-manifests
-          cd ../klt-cert-manager
-          make controller-gen release-manifests
-          cd ../metrics-operator
-          make controller-gen release-manifests
           cd ..
           echo "---" >> lifecycle-operator/config/rendered/release.yaml
           echo "---" >> scheduler/config/rendered/release.yaml
-          echo "---" >> klt-cert-manager/config/rendered/release.yaml
           cat >> namespace.yaml << EOF
           ---
           apiVersion: v1
@@ -264,10 +264,15 @@ jobs:
           ---
           EOF
           cat namespace.yaml \
+<<<<<<< HEAD
             lifecycle-operator/config/rendered/release.yaml \
             scheduler/config/rendered/release.yaml \
             klt-cert-manager/config/rendered/release.yaml \
             metrics-operator/config/rendered/release.yaml > klt-manifest.yaml
+=======
+            operator/config/rendered/release.yaml \
+            scheduler/config/rendered/release.yaml > klt-manifest.yaml
+>>>>>>> feat: metrics-operator monorepo setup
 
       - name: Create Cert-Manager manifest
         if: needs.release-please.outputs.cert-manager-release-created == 'true'
@@ -279,7 +284,37 @@ jobs:
           make controller-gen release-manifests
           cd ..
           echo "---" >> klt-cert-manager/config/rendered/release.yaml
-          cat klt-cert-manager/config/rendered/release.yaml > cert-manager-manifest.yaml
+          cat >> namespace.yaml << EOF
+          ---
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: keptn-lifecycle-toolkit-system
+          ---
+          EOF
+          cat namespace.yaml \
+            klt-cert-manager/config/rendered/release.yaml > cert-manager-manifest.yaml
+
+      - name: Create Metrics Operator manifest
+        if: needs.release-please.outputs.metrics-operator-release-created == 'true'
+        env:
+          RELEASE_REGISTRY: ghcr.io/keptn
+          CHART_APPVERSION: ${{ needs.release-please.outputs.metrics-operator-tag-name }}
+        run: |
+          cd metrics-operator
+          make controller-gen release-manifests
+          cd ..
+          echo "---" >> metrics-operator/config/rendered/release.yaml
+          cat >> namespace.yaml << EOF
+          ---
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: keptn-lifecycle-toolkit-system
+          ---
+          EOF
+          cat namespace.yaml \
+            metrics-operator/config/rendered/release.yaml > metrics-operator-manifest.yaml
 
       - name: Attach KLT release assets
         if: needs.release-please.outputs.klt-release-created == 'true'
@@ -294,6 +329,13 @@ jobs:
         with:
           tag_name: ${{ needs.release-please.outputs.cert-manager-tag-name }}
           files: cert-manager-manifest.yaml
+
+      - name: Attach Metrics Operator release assets
+        if: needs.release-please.outputs.metrics-operator-release-created == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.release-please.outputs.metrics-operator-tag-name }}
+          files: metrics-operator-manifest.yaml
 
   update-docs:
     name: Update Documentation

--- a/helm/chart/README.md
+++ b/helm/chart/README.md
@@ -136,23 +136,23 @@ checks
 
 ### Keptn Metrics Operator controller
 
-| Name                                                                        | Description                                                   | Value                            |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------- |
-| `metricsOperator.manager.containerSecurityContext`                          | Sets security context privileges                              |                                  |
-| `metricsOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                               | `false`                          |
-| `metricsOperator.manager.containerSecurityContext.capabilities.drop`        |                                                               | `["ALL"]`                        |
-| `metricsOperator.manager.containerSecurityContext.privileged`               |                                                               | `false`                          |
-| `metricsOperator.manager.containerSecurityContext.runAsGroup`               |                                                               | `65532`                          |
-| `metricsOperator.manager.containerSecurityContext.runAsNonRoot`             |                                                               | `true`                           |
-| `metricsOperator.manager.containerSecurityContext.runAsUser`                |                                                               | `65532`                          |
-| `metricsOperator.manager.containerSecurityContext.seccompProfile.type`      |                                                               | `RuntimeDefault`                 |
-| `metricsOperator.manager.image.repository`                                  | specify registry for manager image                            | `ghcr.io/keptn/metrics-operator` |
-| `metricsOperator.manager.image.tag`                                         | select tag for manager image <!---x-release-please-version--> | `v0.8.1`                         |
-| `metricsOperator.manager.env.exposeKeptnMetrics`                            | enable metrics exporter                                       | `true`                           |
-| `metricsOperator.manager.env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller                      | `0`                              |
-| `metricsOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container                    |                                  |
-| `metricsOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container                   |                                  |
-| `metricsOperator.manager.resources`                                         | specify limits and requests for manager container             |                                  |
+| Name                                                                        | Description                                       | Value                            |
+| --------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------- |
+| `metricsOperator.manager.containerSecurityContext`                          | Sets security context privileges                  |                                  |
+| `metricsOperator.manager.containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                          |
+| `metricsOperator.manager.containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                        |
+| `metricsOperator.manager.containerSecurityContext.privileged`               |                                                   | `false`                          |
+| `metricsOperator.manager.containerSecurityContext.runAsGroup`               |                                                   | `65532`                          |
+| `metricsOperator.manager.containerSecurityContext.runAsNonRoot`             |                                                   | `true`                           |
+| `metricsOperator.manager.containerSecurityContext.runAsUser`                |                                                   | `65532`                          |
+| `metricsOperator.manager.containerSecurityContext.seccompProfile.type`      |                                                   | `RuntimeDefault`                 |
+| `metricsOperator.manager.image.repository`                                  | specify registry for manager image                | `ghcr.io/keptn/metrics-operator` |
+| `metricsOperator.manager.image.tag`                                         | select tag for manager image                      | `v0.8.1`                         |
+| `metricsOperator.manager.env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                           |
+| `metricsOperator.manager.env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                              |
+| `metricsOperator.manager.livenessProbe`                                     | custom livenessprobe for manager container        |                                  |
+| `metricsOperator.manager.readinessProbe`                                    | custom readinessprobe for manager container       |                                  |
+| `metricsOperator.manager.resources`                                         | specify limits and requests for manager container |                                  |
 
 ### Global
 

--- a/helm/chart/doc.yaml
+++ b/helm/chart/doc.yaml
@@ -206,7 +206,7 @@
 
 
 ## @param   metricsOperator.manager.image.repository specify registry for manager image
-## @param   metricsOperator.manager.image.tag  select tag for manager image <!---x-release-please-version-->
+## @param   metricsOperator.manager.image.tag select tag for manager image
 
 ## @param   metricsOperator.manager.env.exposeKeptnMetrics enable metrics exporter
 ## @param   metricsOperator.manager.env.metricsControllerLogLevel sets the log level of Metrics Controller

--- a/metrics-operator/Dockerfile
+++ b/metrics-operator/Dockerfile
@@ -45,9 +45,9 @@ ENTRYPOINT ["/manager"]
 
 FROM gcr.io/distroless/static-debian11:nonroot AS production
 
-LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
+LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit/metrics-operator" \
     org.opencontainers.image.url="https://keptn.sh" \
-    org.opencontainers.image.title="Keptn Lifecycle Operator" \
+    org.opencontainers.image.title="Keptn Metrics Operator" \
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.licenses="Apache-2.0"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "separate-pull-requests": true,
-  "last-release-sha": "b37aed920eb766c33ae765ed740bc5e508ac430a",
+  "last-release-sha": "9bb78bb1c74aeb3524fb258d8c77d8493c42cd4f",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "pull-request-title-pattern": "chore: release${component} ${version}",
@@ -12,7 +12,7 @@
       "prerelease": false,
       "monorepo-tags": "klt",
       "draft": false,
-      "exclude-paths": ["klt-cert-manager"],
+      "exclude-paths": ["klt-cert-manager", "metrics-operator"],
       "extra-files": [
         "README.md",
         "operator/config/manager/manager.yaml",
@@ -20,7 +20,6 @@
         "Makefile",
         "operator/Makefile",
         "scheduler/Makefile",
-        "metrics-operator/Makefile",
         "docs/content/en/docs/snippets/tasks/install.md",
         "helm/chart/values.yaml",
         "helm/chart/README.md"
@@ -31,6 +30,17 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "go",
       "monorepo-tags": "cert-manager",
+      "prerelease": false,
+      "draft": false,
+      "extra-files": [
+        "Makefile"
+      ]
+    },
+    "metrics-operator": {
+      "package-name": "metrics-operator",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "go",
+      "monorepo-tags": "metrics-operator",
       "prerelease": false,
       "draft": false,
       "extra-files": [


### PR DESCRIPTION
### This PR
- sets up release please to work with the KLT repo as a monorepo with separate releases for KLT lifecycle-operator, KLT cert-manager and KLT metrics-operator
- Separate release PRs will be created for the 3 artifacts that can be merged separately. Release Please will create separate git tags and github releases for 3 artifacts as well
- renamed general klt release to lifecycle-operator, as from now it's a monorepo itself
- remove release-please tag for metrics-operator on helm docs auto updates
- re-generate CRD documentation

Fixes: #1597 

### Test

This could be test only on fork:

PRs creted: https://github.com/odubajDT/lifecycle-controller/pulls
release please run: https://github.com/odubajDT/lifecycle-controller/actions/runs/5691308796/job/15426250933