### PR TITLE
docs: manifests ref section, edits to ref section intros

### DIFF
--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -5,23 +5,43 @@ weight: 100
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
-This section provides comprehensive reference information about the
+This section provides comprehensive reference information about all
 [Custom Resource Definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 that are defined for the Keptn Lifecycle Toolkit.
-
-> **Note**
-This section is under development.
-Information that is published here has been reviewed for technical accuracy
-but the format and content is still evolving.
-We welcome your input!**
+This section is auto-generated from the source code.
 
 Each CRD is an object of an API library.
 Keptn APIs follow the Kubernetes API versioning scheme.
 and are themselves composed of objects and sub-objects.
-By introducing CRDs, Keptn is extending the base Kubernetes API with new objects and functionality.
+The Keptn CRDs extend the base Kubernetes API
+with new objects and functionality.
 Keptn APIs follow API versioning conventions recommended by Kubernetes.
 
-For more information, see the Kubernetes documentation:
+Keptn generates most of the resources it needs
+without requiring manual input.
+[Manifest CRD Reference](../yaml-crd-ref)
+contains reference pages for the few manifests
+that must be populated manually.
+
+Use `kubectl` to inspect the current contents of any Keptn resource:
+
+1. List all resources of the specified type within a certain namespace.
+   For example, to list all the `KeptnApp` resources
+   in the `namespace1` namespace, the command is:
+
+   ```
+   kubectl get keptnapp -n namespace1
+   ```
+
+1. Get the current manifest for the specified resource.
+   For example, to view the manifest for the `my-keptn-app` resource
+   in the `namespace1` namespace, the command is:
+
+   ```
+   kubectl get keptnapp -n <namespace> my-keptn-app -oyaml
+   ```
+For more information about the APIs and Custom Resources,
+see the Kubernetes documentation:
 
 * [API Overview](https://kubernetes.io/docs/reference/using-api/)
 

--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -30,7 +30,7 @@ Use `kubectl` to inspect the current contents of any Keptn resource:
    in the `namespace1` namespace, the command is:
 
    ```shell
-   kubectl get keptnapp -n namespace1
+   kubectl get keptnapps -n namespace1
    ```
 
 1. Get the current manifest for the specified resource.

--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -29,7 +29,7 @@ Use `kubectl` to inspect the current contents of any Keptn resource:
    For example, to list all the `KeptnApp` resources
    in the `namespace1` namespace, the command is:
 
-   ```
+   ```shell
    kubectl get keptnapp -n namespace1
    ```
 
@@ -37,9 +37,10 @@ Use `kubectl` to inspect the current contents of any Keptn resource:
    For example, to view the manifest for the `my-keptn-app` resource
    in the `namespace1` namespace, the command is:
 
-   ```
+   ```shell
    kubectl get keptnapp -n <namespace> my-keptn-app -oyaml
    ```
+
 For more information about the APIs and Custom Resources,
 see the Kubernetes documentation:
 

--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -8,7 +8,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 This section provides comprehensive reference information about all
 [Custom Resource Definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 that are defined for the Keptn Lifecycle Toolkit.
-This section is auto-generated from the source code.
+This section is auto-generated from source code.
 
 Each CRD is an object of an API library.
 Keptn APIs follow the Kubernetes API versioning scheme.

--- a/docs/content/en/docs/crd-ref/_index.md
+++ b/docs/content/en/docs/crd-ref/_index.md
@@ -20,7 +20,7 @@ Keptn APIs follow API versioning conventions recommended by Kubernetes.
 Keptn generates most of the resources it needs
 without requiring manual input.
 [Manifest CRD Reference](../yaml-crd-ref)
-contains reference pages for the few manifests
+contains reference pages for the manifests
 that must be populated manually.
 
 Use `kubectl` to inspect the current contents of any Keptn resource:

--- a/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
+++ b/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
@@ -149,5 +149,6 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `interval` _string_ | Interval specifies the duration of the time interval for the data query |
+| `step` _string_ | Step represents the query resolution step width for the data query |
 
 

--- a/docs/content/en/docs/yaml-crd-ref/_index.md
+++ b/docs/content/en/docs/yaml-crd-ref/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Manifest CRD Reference
-description: Reference pages for the manifest YAML files that must be populated
+title: CRD Reference
+description: Reference pages for the manifest files that must be populated
 weight: 100
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---

--- a/docs/content/en/docs/yaml-crd-ref/_index.md
+++ b/docs/content/en/docs/yaml-crd-ref/_index.md
@@ -1,28 +1,22 @@
 ---
-title: CRD YAML Reference
-description: Reference pages for the YAML files that define the KLT CRDs
+title: Manifest CRD Reference
+description: Reference pages for the manifest YAML files that must be populated
 weight: 100
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
 This section provides comprehensive reference information about the
-YAML files used to define the Keptn Lifecycle Toolkit
-[Custom Resource Definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-that are defined for the Keptn Lifecycle Toolkit.
-
-> **Note**
-This section is under development.
-Information that is published here has been reviewed for technical accuracy
-but the format and content is still evolving.
-We welcome your input!**
+manifest YAML files that must be populated
+for the Keptn Lifecycle Toolkit
+[Custom Resource Definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
 Each CRD is an object of an API library.
-Keptn APIs follow the Kubernetes API versioning scheme.
-and are themselves composed of objects and sub-objects.
-By introducing CRDs, Keptn is extending the base Kubernetes API with new objects and functionality.
-Keptn APIs follow API versioning conventions recommended by Kubernetes.
+In addition to the CRDs documented in this section,
+Keptn populates many resources on its own.
+For a comprehensive list of all Keptn resources, see
+[API Reference](../crd-ref).
 
-For more information, see the Kubernetes documentation:
+For more information about CRDs and APIs, see the Kubernetes documentation:
 
 * [API Overview](https://kubernetes.io/docs/reference/using-api/)
 

--- a/docs/content/en/docs/yaml-crd-ref/_index.md
+++ b/docs/content/en/docs/yaml-crd-ref/_index.md
@@ -6,7 +6,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 ---
 
 This section provides comprehensive reference information about the
-manifest YAML files that must be populated
+manifest files that must be populated
 for the Keptn Lifecycle Toolkit
 [Custom Resource Definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 


### PR DESCRIPTION
This PR does the following:
* Renames the yaml-crd-ref section to be "Manifest CRD Reference"
* Adds xrefs between the two sections to the landing pages of crd-ref and yaml-crd-ref
* Removes some duplicated info from the yaml-crd-ref landing page
* Adds instructions for inspecting an existing resource