### PR TITLE
docs: add text about name change

### DIFF
--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -56,6 +56,10 @@ and **replace** the following `volumes` definition
        secretName: webhook-server-cert
    ```
 
+Note the name change from `certs-dir` to `cert`.
+This is intentional.
+Kubernetes does not allow replacing an `emptyDir` with a `secret` so the name change resolves this issue.
+
 Each manifest must have the following special annotation:
 
 ```yaml


### PR DESCRIPTION
This PR:

- Adds text explaining the name change from `certs-dir` to `cert`


@StackScribe as discussed, could I get a quick approval on this and we can see if this makes it's way to live quickly.