### PR TITLE
chore: promote Release Lifecycle to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Status of the different features:
   Observability: expose [OTel](https://opentelemetry.io/) metrics and traces of your deployment.
 - ![status](https://img.shields.io/badge/status-alpha-orange)
   K8s Custom Metrics: expose your Observability platform via the [Custom Metric API](https://github.com/kubernetes/design-proposals-archive/blob/main/instrumentation/custom-metrics-api.md).
-- ![status](https://img.shields.io/badge/status-alpha-orange)
+- ![status](https://img.shields.io/badge/status-beta-yellow)
   Release lifecycle: handle pre- and post-checks of your Application deployment.
 - ![status](https://img.shields.io/badge/status-stable-brightgreen)
   Certificate Manager: automatically configure TLS certificates for


### PR DESCRIPTION
After the python, deno, and container runtime release, we can mark it as beta. 
This feature can be marked as stable after we have the readiness gate put in place with #1448