### PR TITLE
docs: rewrite README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,38 @@
 ![version](https://img.shields.io/github/v/release/keptn/lifecycle-toolkit)
 [![GitHub Discussions](https://img.shields.io/github/discussions/keptn/lifecycle-toolkit)](https://github.com/keptn/lifecycle-toolkit/discussions)
 
-The Keptn Lifecycle Toolkit (KLT) provides a “cloud-native” approach
+This is the primary repository for the Keptn software and documentation.
+Keptn provides a “cloud-native” approach
 for managing the application release lifecycle
+metrics, observability, health checks,
 with pre- and post-deployment evaluations and tasks.
-It also supports application health checks,
-metrics, and observability.
 It is an incubating project, under the umbrella of the
 [Keptn Application Lifecycle working group](https://github.com/keptn/wg-app-lifecycle).
+
+> **Note**
+  The primary repository for V1 (formerly known as "Keptn") is
+  [https://github.com/keptn/keptn](https://github.com/keptn/keptn)
+
+## Goals
+
+The Keptn Lifecycle Toolkit provides Cloud Native teams with
+the following capabilities:
+
+- Pre-requisite evaluation before deploying workloads and applications
+- Finding out when an application (not just a workload) is ready and working
+- Checking the Application Health in a declarative (cloud-native) way
+- Standardized way to run pre- and post-deployment tasks
+- Provide out-of-the-box Observability of the deployment cycle
+
+![Operator Maturity Model with third level circled in](./assets/operator-maturity.jpg)
+
+The Keptn Lifecycle Toolkit can be seen as a general purpose and declarative
+[Level 3 operator](https://operatorframework.io/operator-capabilities/)
+for your Application.
+For this reason, the Keptn Lifecycle Toolkit is agnostic to deployment tools
+that are used and works with any GitOps solution.
+
+## Status
 
 Status of the different features:
 
@@ -37,79 +62,32 @@ stable ![status](https://img.shields.io/badge/status-stable-brightgreen) )
 The status follows the
 [Kubernetes API versioning schema](https://kubernetes.io/docs/reference/using-api/#api-versioning).
 
-For more info about the features, please refer to our
-[documentation](https://lifecycle.keptn.sh/docs/).
-The documentation also includes information about
-installing the Keptn Lifecycle Toolkit
-and migrating to it from
-[Keptn v1](https://keptn.sh/docs/).
+## More information
 
-## Watch the KubeCon 2022 Detroit Demo
+For more info about Keptn, please see our
+[documentation](https://lifecycle.keptn.sh/docs/), specifically:
 
-Click to watch it on YouTube:
+- [Introduction to Keptn](https://lifecycle.keptn.sh/docs/intro-klt/)
+  gives an overview of the Keptn facilities.
+- [Getting started](https://lifecycle.keptn.sh/docs/getting-started/)
+  includes some short exercises to introduce you to Keptn.
+- [Installation and upgrade](https://lifecycle.keptn.sh/docs/install/)
+  provides information about preparing your Kubernetes cluster
+  then installing and enabling Keptn.
+- [Implementing Keptn applications](https://lifecycle.keptn.sh/docs/implementing/)
+  documents how to integrate Keptn to work with your existing deployment engine
+  and implement its variouos features.
+- *Architecture* provides detailed technical information
+  about how Keptn works.
+- [CRD Reference](https://lifecycle.keptn.sh/docs/yaml-crd-ref/) and
+  [API Reference](https://lifecycle.keptn.sh/docs/crd-ref/)
+  provide detailed reference material for the custom resources
+  used to configure Keptn.
+- [Contributing to Keptn](https://lifecycle.keptn.sh/contribute/)
+  provides information about how to contribute to the Keptn project.
 
-[![Keptn Lifecycle Toolkit in a Nutshell](https://img.youtube.com/vi/K-cvnZ8EtGc/0.jpg)](https://www.youtube.com/watch?v=K-cvnZ8EtGc)
-
-## Deploy the latest release
-
-### Known Limitations
-
-- Kubernetes >=1.24 is needed to deploy the Lifecycle Toolkit
-- The Lifecycle Toolkit is currently not compatible with [vcluster](https://github.com/loft-sh/vcluster)
-
-### Installation
-
-Use the following command sequence to install the latest release of the Keptn Lifecycle Toolkit:
-
-```shell
-helm repo add klt https://charts.lifecycle.keptn.sh
-helm repo update
-helm upgrade --install keptn klt/klt -n keptn-lifecycle-toolkit-system --create-namespace --wait
-```
-
-For installing the Lifecycle Toolkit via manifests use:
-
-<!---x-release-please-start-version-->
-
-```shell
-kubectl apply -f https://github.com/keptn/lifecycle-toolkit/releases/download/v0.8.1/manifest.yaml
-```
-
-<!---x-release-please-end-->
-
-The Lifecycle Toolkit uses the OpenTelemetry collector to provide a vendor-agnostic implementation of how to receive,
-process and export telemetry data.
-To install it, follow
-their [installation instructions](https://opentelemetry.io/docs/collector/getting-started/).
-We provide some information about this in our [observability example](./examples/support/observability/).
-
-The Lifecycle Toolkit includes a Mutating Webhook which requires TLS certificates to be mounted as a volume in its pod.
-The certificate creation
-is handled automatically
-by [klt-cert-manager](https://github.com/keptn/lifecycle-toolkit/blob/main/klt-cert-manager/README.md).
-Versions 0.6.0
-and earlier have a hard dependency on the [cert-manager](https://cert-manager.io).
-See [installation guideline](https://github.com/keptn/lifecycle-toolkit/blob/main/docs/content/en/docs/snippets/tasks/install.md)
-for more info.
-
-## Goals
-
-The Keptn Lifecycle Toolkit provides Cloud Native teams with
-the following capabilities:
-
-- Pre-requisite evaluation before deploying workloads and applications
-- Finding out when an application (not just a workload) is ready and working
-- Checking the Application Health in a declarative (cloud-native) way
-- Standardized way to run pre- and post-deployment tasks
-- Provide out-of-the-box Observability of the deployment cycle
-
-![Operator Maturity Model with third level circled in](./assets/operator-maturity.jpg)
-
-The Keptn Lifecycle Toolkit can be seen as a general purpose and declarative
-[Level 3 operator](https://operatorframework.io/operator-capabilities/)
-for your Application.
-For this reason, the Keptn Lifecycle Toolkit is agnostic to deployment tools
-that are used and works with any GitOps solution.
+You can also find a number of video presentations and demos about Keptn on the
+[YouTube Keptn channel](https://www.youtube.com/@keptn).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 ![version](https://img.shields.io/github/v/release/keptn/lifecycle-toolkit)
 [![GitHub Discussions](https://img.shields.io/github/discussions/keptn/lifecycle-toolkit)](https://github.com/keptn/lifecycle-toolkit/discussions)
 
-This is the primary repository for the Keptn software and documentation.
-Keptn provides a “cloud-native” approach
+This is the primary repository for
+the Keptn Lifecycle Toolkit (KLT) software and documentation.
+KLT provides a “cloud-native” approach
 for managing the application release lifecycle
 metrics, observability, health checks,
 with pre- and post-deployment evaluations and tasks.
@@ -15,7 +16,7 @@ It is an incubating project, under the umbrella of the
 [Keptn Application Lifecycle working group](https://github.com/keptn/wg-app-lifecycle).
 
 > **Note**
-  The primary repository for V1 (formerly known as "Keptn") is
+  The primary repository for Keptn v1 is
   [https://github.com/keptn/keptn](https://github.com/keptn/keptn)
 
 ## Goals
@@ -67,26 +68,27 @@ The status follows the
 For more info about Keptn, please see our
 [documentation](https://lifecycle.keptn.sh/docs/), specifically:
 
-- [Introduction to Keptn](https://lifecycle.keptn.sh/docs/intro-klt/)
-  gives an overview of the Keptn facilities.
+- [Introduction to Keptn Lifecycle Toolkit](https://lifecycle.keptn.sh/docs/intro-klt/)
+  gives an overview of the KLT facilities.
 - [Getting started](https://lifecycle.keptn.sh/docs/getting-started/)
-  includes some short exercises to introduce you to Keptn.
+  includes some short exercises to introduce you to KLT.
 - [Installation and upgrade](https://lifecycle.keptn.sh/docs/install/)
   provides information about preparing your Kubernetes cluster
-  then installing and enabling Keptn.
-- [Implementing Keptn applications](https://lifecycle.keptn.sh/docs/implementing/)
-  documents how to integrate Keptn to work with your existing deployment engine
+  then installing and enabling KLT.
+- [Implementing KLT applications](https://lifecycle.keptn.sh/docs/implementing/)
+  documents how to integrate KLT to work with your existing deployment engine
   and implement its variouos features.
 - *Architecture* provides detailed technical information
-  about how Keptn works.
+  about how KLT works.
 - [CRD Reference](https://lifecycle.keptn.sh/docs/yaml-crd-ref/) and
   [API Reference](https://lifecycle.keptn.sh/docs/crd-ref/)
   provide detailed reference material for the custom resources
-  used to configure Keptn.
+  used to configure KLT.
 - [Contributing to Keptn](https://lifecycle.keptn.sh/contribute/)
   provides information about how to contribute to the Keptn project.
 
-You can also find a number of video presentations and demos about Keptn on the
+You can also find a number of video presentations and demos
+about the Keptn Lifecycle Toolkit on the
 [YouTube Keptn channel](https://www.youtube.com/@keptn).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For more info about Keptn, please see our
 - [Implementing KLT applications](https://lifecycle.keptn.sh/docs/implementing/)
   documents how to integrate KLT to work with your existing deployment engine
   and implement its variouos features.
-- *Architecture* provides detailed technical information
+- [Architecture](https://lifecycle.keptn.sh/docs/concepts/architecture/) provides detailed technical information
   about how KLT works.
 - [CRD Reference](https://lifecycle.keptn.sh/docs/yaml-crd-ref/) and
   [API Reference](https://lifecycle.keptn.sh/docs/crd-ref/)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ with pre- and post-deployment evaluations and tasks.
 It is an incubating project, under the umbrella of the
 [Keptn Application Lifecycle working group](https://github.com/keptn/wg-app-lifecycle).
 
-> **Note**
-  The primary repository for Keptn v1 is
-  [https://github.com/keptn/keptn](https://github.com/keptn/keptn)
-
 ## Goals
 
 The Keptn Lifecycle Toolkit provides Cloud Native teams with
@@ -62,6 +58,22 @@ stable ![status](https://img.shields.io/badge/status-stable-brightgreen) )
 -->
 The status follows the
 [Kubernetes API versioning schema](https://kubernetes.io/docs/reference/using-api/#api-versioning).
+
+## Installation
+
+The Keptn Lifecycle Toolkit can be installed on any Kubernetes cluster
+running Kubernetes >=1.24.
+Note that the Lifecycle Toolkit is not currently compatible with
+[vcluster](https://github.com/loft-sh/vcluster).
+
+Use the following command sequence
+to install the latest release of the Keptn Lifecycle Toolkit:
+
+```shell
+helm repo add klt https://charts.lifecycle.keptn.sh
+helm repo update
+helm upgrade --install keptn klt/klt -n keptn-lifecycle-toolkit-system --create-namespace --wait
+```
 
 ## More information
 


### PR DESCRIPTION
This is a proposed rewrite of the main KLT README file.  It strips out information that is now included in the main doc set, adds some headers, etc.  I also implemented the new product naming conventions -- please verify that they are done correctly.

Please consider whether this is the appropriate information to have in the README file, remembering that we want to minimize the duplication of information that must be maintained as the product evolves.

I did not strip out the Architecture section.  That should be removed when the relevant information has been merged into the Architecture section of the documentation.