### PR TITLE
chore: support external cert-manager

### DIFF
--- a/docs/content/en/docs/concepts/architecture/cert-manager.md
+++ b/docs/content/en/docs/concepts/architecture/cert-manager.md
@@ -39,7 +39,7 @@ It is included to simplify installation for new users
 and because it is much smaller than most standard certificate managers.
 However, KLT is compatible with most certificate managers
 and can be configured to use another certificate manager if you prefer.
-See [Use KLT with cert-manager.io](../../install/cert-manager.md)
+See [Use Keptn with cert-manager.io](../../install/cert-manager.md)
 for instructions.
 
 ## Invalid certificate errors

--- a/docs/content/en/docs/concepts/architecture/cert-manager.md
+++ b/docs/content/en/docs/concepts/architecture/cert-manager.md
@@ -39,7 +39,7 @@ It is included to simplify installation for new users
 and because it is much smaller than most standard certificate managers.
 However, KLT is compatible with most certificate managers
 and can be configured to use another certificate manager if you prefer.
-See [Use your own cert-manager](../../install/cert-manager.md)
+See [Use KLT with cert-manager.io](../../install/cert-manager.md)
 for instructions.
 
 ## Invalid certificate errors

--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -1,5 +1,5 @@
 ---
-title: Use KLT with cert-manager.io (optional)
+title: Use Keptn with cert-manager.io (optional)
 description: Replace the default KLT cert-manager
 weight: 30
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
@@ -27,10 +27,10 @@ The steps are:
 
 * Install the cert-manager of your choice
   if it is not already installed.
-* Add the `Certificate` and `Issuer` CRs for the cert-manager you are using.
-* Install KLT without the built-in `klt-cert-manager` via helm
+* Add the `Certificate` and `Issuer` CRs for `cert-manager.io`.
+* (optional) Install Keptn without the built-in `klt-cert-manager` via Helm
 
-## Add the CR(s) for your cert-manager
+## Add the CR(s) for cert-manager.io
 
 These are the CRs for `cert-manager.io` to be applied to your cluster:
 
@@ -39,13 +39,13 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: klt-certs
-  namespace: <your-klt-namespace>
+  namespace: <your-namespace>
 spec:
   dnsNames:
-  - lifecycle-webhook-service.<your-klt-namespace>.svc
-  - lifecycle-webhook-service.<your-klt-namespace>.svc.cluster.local
-  - metrics-webhook-service.<your-klt-namespace>.svc
-  - metrics-webhook-service.<your-klt-namespace>.svc.cluster.local
+  - lifecycle-webhook-service.<your-namespace>.svc
+  - lifecycle-webhook-service.<your-namespace>.svc.cluster.local
+  - metrics-webhook-service.<your-namespace>.svc
+  - metrics-webhook-service.<your-namespace>.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: klt-selfsigned-issuer
@@ -55,7 +55,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: klt-selfsigned-issuer
-  namespace: <your-klt-namespace>
+  namespace: <your-namespace>
 spec:
   selfSigned: {}
 ```
@@ -65,7 +65,7 @@ Note the following about these fields:
 * The `apiVersion` field refers to the API for the cert-manager.
 * The value of the `.spec.secretName` field as well as the `.metadata.name` of the `Certificate` CR
   must be `klt-certs`.
-* Substitute the namespace placeholders with your namespace, where KLT is installed.
+* Substitute the namespace placeholders with your namespace, where Keptn is installed.
 
 See the [CA Injector](https://cert-manager.io/docs/concepts/ca-injector/)
 documentation for more details.

--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -14,8 +14,8 @@ without the overhead of other cert-managers.
 For a description of the architecture, see
 [Keptn Certificate Manager](../concepts/architecture/cert-manager.md).
 
-KLT also works well with the `cert-manager.io`.
-If you are already `cert-manager.io`,
+KLT also works well with `cert-manager.io`.
+If you are already using `cert-manager.io`,
 you can continue to use it for other components
 and use the KLT cert-manager just for KLT activities
 or you can disable the KLT cert-manager
@@ -25,7 +25,7 @@ If you want KLT to use `cert-manager.io`,
 you must configure it *before* you install KLT.
 The steps are:
 
-* Install the `cert-manager.io` if it is not already installed.
+* Install `cert-manager.io` if it is not already installed.
 * Add the `Certificate` and `Issuer` CRs for `cert-manager.io`.
 * (optional) Install Keptn without the built-in `klt-cert-manager` via Helm
 

--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -1,5 +1,5 @@
 ---
-title: Use your own cert-manager (optional)
+title: Use KLT with cert-manager.io (optional)
 description: Replace the default KLT cert-manager
 weight: 30
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
@@ -64,7 +64,7 @@ Note the following about these fields:
 
 * The `apiVersion` field refers to the API for the cert-manager.
 * The value of the `.spec.secretName` field as well as the `.metadata.name` of the `Certificate` CR
-  must needs to be `klt-certs`.
+  must be `klt-certs`.
 * Substitue the namespace placeholders with your namespace, where KLT is installed.
 
 See the [CA Injector](https://cert-manager.io/docs/concepts/ca-injector/)

--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -28,9 +28,9 @@ The steps are:
 * Install the cert-manager of your choice
   if it is not already installed.
 * Add the `Certificate` and `Issuer` CRs for the cert-manager you are using.
-* Install KLT without `cert-manager` via helm
+* Install KLT without the built-in `klt-cert-manager` via helm
 
-## Add the CRD for your cert-manager
+## Add the CR(s) for your cert-manager
 
 These are the CRs for `cert-manager.io` to be applied to your cluster:
 
@@ -65,7 +65,7 @@ Note the following about these fields:
 * The `apiVersion` field refers to the API for the cert-manager.
 * The value of the `.spec.secretName` field as well as the `.metadata.name` of the `Certificate` CR
   must be `klt-certs`.
-* Substitue the namespace placeholders with your namespace, where KLT is installed.
+* Substitute the namespace placeholders with your namespace, where KLT is installed.
 
 See the [CA Injector](https://cert-manager.io/docs/concepts/ca-injector/)
 documentation for more details.

--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -14,19 +14,18 @@ without the overhead of other cert-managers.
 For a description of the architecture, see
 [Keptn Certificate Manager](../concepts/architecture/cert-manager.md).
 
-KLT, however, works well with standard cert-managers.
-The KLT cert-manager can also coexist with another cert-manager.
-If you are already using a different cert-manager,
-you can continue to use that cert-manager for other components
+KLT also works well with the `cert-manager.io`.
+If you are already `cert-manager.io`,
+you can continue to use it for other components
 and use the KLT cert-manager just for KLT activities
-or you can configure KLT to use that cert-manager.
+or you can disable the KLT cert-manager
+and configure KLT to use `cert-manager.io`.
 
-If you want KLT to use your cert-manager,
+If you want KLT to use `cert-manager.io`,
 you must configure it *before* you install KLT.
 The steps are:
 
-* Install the cert-manager of your choice
-  if it is not already installed.
+* Install the `cert-manager.io` if it is not already installed.
 * Add the `Certificate` and `Issuer` CRs for `cert-manager.io`.
 * (optional) Install Keptn without the built-in `klt-cert-manager` via Helm
 

--- a/docs/content/en/docs/install/cert-manager.md
+++ b/docs/content/en/docs/install/cert-manager.md
@@ -28,6 +28,7 @@ The steps are:
 * Install the cert-manager of your choice
   if it is not already installed.
 * Add the `Certificate` and `Issuer` CRs for the cert-manager you are using.
+* Install KLT without `cert-manager` via helm
 
 ## Add the CRD for your cert-manager
 

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -97,5 +97,5 @@ a light-weight cert-manager that, by default, is installed
 as part of the KLT software.
 If you are using another cert-manager in the cluster,
 you can configure KLT to instead use your cert-manager.
-See [Use your own cert-manager](cert-manager.md)
+See [Use KLT with cert-manager.io](cert-manager.md)
 for detailed instructions.

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -97,5 +97,5 @@ a light-weight cert-manager that, by default, is installed
 as part of the KLT software.
 If you are using another cert-manager in the cluster,
 you can configure KLT to instead use your cert-manager.
-See [Use KLT with cert-manager.io](cert-manager.md)
+See [Use Keptn with cert-manager.io](cert-manager.md)
 for detailed instructions.

--- a/helm/chart/templates/analysis-crd.yaml
+++ b/helm/chart/templates/analysis-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: metrics.keptn.sh

--- a/helm/chart/templates/analysisdefinition-crd.yaml
+++ b/helm/chart/templates/analysisdefinition-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: metrics.keptn.sh

--- a/helm/chart/templates/analysisvaluetemplate-crd.yaml
+++ b/helm/chart/templates/analysisvaluetemplate-crd.yaml
@@ -5,6 +5,7 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: metrics.keptn.sh

--- a/helm/chart/templates/keptnapp-crd.yaml
+++ b/helm/chart/templates/keptnapp-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnapps.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnappcreationrequest-crd.yaml
+++ b/helm/chart/templates/keptnappcreationrequest-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnappcreationrequests.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnappversion-crd.yaml
+++ b/helm/chart/templates/keptnappversion-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnappversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnconfig-crd.yaml
+++ b/helm/chart/templates/keptnconfig-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnconfigs.options.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnevaluation-crd.yaml
+++ b/helm/chart/templates/keptnevaluation-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnevaluations.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnevaluationdefinition-crd.yaml
+++ b/helm/chart/templates/keptnevaluationdefinition-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnevaluationdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnevaluationprovider-crd.yaml
+++ b/helm/chart/templates/keptnevaluationprovider-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnevaluationproviders.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnmetric-crd.yaml
+++ b/helm/chart/templates/keptnmetric-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: metrics.keptn.sh

--- a/helm/chart/templates/keptnmetricsprovider-crd.yaml
+++ b/helm/chart/templates/keptnmetricsprovider-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: metrics.keptn.sh

--- a/helm/chart/templates/keptntask-crd.yaml
+++ b/helm/chart/templates/keptntask-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptntasks.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptntaskdefinition-crd.yaml
+++ b/helm/chart/templates/keptntaskdefinition-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptntaskdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnworkload-crd.yaml
+++ b/helm/chart/templates/keptnworkload-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnworkloads.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnworkloadinstance-crd.yaml
+++ b/helm/chart/templates/keptnworkloadinstance-crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keptnworkloadinstances.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/klt-certs
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/keptnworkloadinstance-crd.yaml
+++ b/helm/chart/templates/keptnworkloadinstance-crd.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keptnworkloadinstances.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.1
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/klt-certs
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     app.kubernetes.io/part-of: keptn-lifecycle-toolkit
     crdGroup: lifecycle.keptn.sh

--- a/helm/chart/templates/lifecycle-mutating-webhook-configuration.yaml
+++ b/helm/chart/templates/lifecycle-mutating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: lifecycle-mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/part-of: "keptn-lifecycle-toolkit"

--- a/helm/chart/templates/lifecycle-validating-webhook-configuration.yaml
+++ b/helm/chart/templates/lifecycle-validating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: lifecycle-validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     keptn.sh/inject-cert: "true"
   {{- include "chart.labels" . | nindent 4 }}

--- a/helm/chart/templates/metrics-validating-webhook-configuration.yaml
+++ b/helm/chart/templates/metrics-validating-webhook-configuration.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: metrics-validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/klt-certs'
   labels:
     keptn.sh/inject-cert: "true"
   {{- include "chart.labels" . | nindent 4 }}


### PR DESCRIPTION
## Changes
 - added `ca-injection` annotations to webhooks and CRDs
 - update documentation how to use external cert-manager

Fixes: https://github.com/keptn/lifecycle-toolkit/issues/1809