### PR TITLE
docs: adapt DORA metrics kubectl command

### DIFF
--- a/docs/content/en/docs/implementing/dora/_index.md
+++ b/docs/content/en/docs/implementing/dora/_index.md
@@ -44,6 +44,7 @@ kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle
 ```
 
 - Then port-forward to the name of your service:
+
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```

--- a/docs/content/en/docs/implementing/dora/_index.md
+++ b/docs/content/en/docs/implementing/dora/_index.md
@@ -37,13 +37,13 @@ Metrics are collected only for the resources that are annotated.
 
 To view DORA metrics, run the following two commands:
 
-1. Retrieve the service name with:
+- Retrieve the service name with:
 
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
 ```
 
-2. Then port-forward to the name of your service:
+- Then port-forward to the name of your service:
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```

--- a/docs/content/en/docs/implementing/dora/_index.md
+++ b/docs/content/en/docs/implementing/dora/_index.md
@@ -35,11 +35,17 @@ or
 
 Metrics are collected only for the resources that are annotated.
 
-To view DORA metrics, run the following command:
+To view DORA metrics, run the following two commands:
+
+1. Retrieve the service name with:
 
 ```shell
-kubectl port-forward -n keptn-lifecycle-toolkit-system \
-   svc/lifecycle-operator-metrics-service 2222
+kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
+```
+
+2. Then port-forward to the name of your service:``
+```shell
+kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```
 
 Then view the metrics at:

--- a/docs/content/en/docs/implementing/dora/_index.md
+++ b/docs/content/en/docs/implementing/dora/_index.md
@@ -43,7 +43,7 @@ To view DORA metrics, run the following two commands:
 kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
 ```
 
-2. Then port-forward to the name of your service:``
+2. Then port-forward to the name of your service:
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -68,6 +68,7 @@ kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle
 ```
 
 - Then port-forward to the name of your service:
+
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -61,13 +61,13 @@ that are annotated.
 
 To view DORA metrics, run the following two commands:
 
-1. Retrieve the service name with:
+- Retrieve the service name with:
 
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
 ```
 
-2. Then port-forward to the name of your service:
+- Then port-forward to the name of your service:
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -67,7 +67,7 @@ To view DORA metrics, run the following two commands:
 kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
 ```
 
-2. Then port-forward to the name of your service:``
+2. Then port-forward to the name of your service:
 ```shell
 kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -59,11 +59,17 @@ to the Workload resource.
 Metrics are collected only for the resources
 that are annotated.
 
-To view DORA metrics, run the following command:
+To view DORA metrics, run the following two commands:
+
+1. Retrieve the service name with:
 
 ```shell
-kubectl port-forward -n keptn-lifecycle-toolkit-system \
-   svc/lifecycle-operator-metrics-service 2222
+kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
+```
+
+2. Then port-forward to the name of your service:``
+```shell
+kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
 ```
 
 Then view the metrics at:


### PR DESCRIPTION
This PR fixes: #1747 

[The kubectl command](https://github.com/keptn/lifecycle-toolkit/blob/main/docs/content/en/docs/implementing/dora/_index.md?plain=1#L40-#L43) on the DORA page doesn't work when users install using helm because helm prepends the chart name to the svc name.

Changes suggested by @agardnerIT are applied here.

Before:
![Screenshot from 2023-08-09 20-04-12](https://github.com/keptn/lifecycle-toolkit/assets/101946115/2f5ca6c8-e107-44a3-9318-8c81e7a81ea0)

After:
![Screenshot from 2023-08-09 20-53-39](https://github.com/keptn/lifecycle-toolkit/assets/101946115/74e9e0df-4cc6-43bb-b551-ee377c289a37)


