### PR TITLE
docs: contrib: DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ couple of days, but feel free to let us know about your PR
 * `style`: changes that do not affect the meaning of the code
 * `test`: adding missing tests or correcting existing tests
 
-## DCO
+## Developer Certification of Origin (DCO)
 
 All commits must be accompanied by a DCO sign-off.
 See

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,46 +154,9 @@ couple of days, but feel free to let us know about your PR
 * `style`: changes that do not affect the meaning of the code
 * `test`: adding missing tests or correcting existing tests
 
-## Auto signoff commit messages
+## DCO
 
-We have a DCO check that runs on every PR to verify that the commit has been signed off.
-
-To sign off the commits use `-s` flag, you can can use
-
-```bash
-git commit -s -m "my awesome contribution"
-```
-
-To sign off the last commit you made, you can use
-
-```bash
-git commit --amend --signoff
-```
-
-or the command below to sign off the last 2 commits you made
-
-```bash
-git rebase HEAD~2 --signoff
-```
-
-This process is sometimes inconvenient but you can automate it
-by creating a pre-commit git hook as follows:
-
-1. Create the hook:
-
-    ``` bash
-    touch .git/hooks/prepare-commit-msg
-    ```
-
-2. Add the following to the `prepare-commit-msg` file:
-
-    ```bash
-    SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
-    grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"
-    ```
-
-3. Give it execution permissions by calling:
-
-    ```bash
-    chmod +x ./.git/hooks/prepare-commit-msg
-    ```
+All commits must be accompanied by a DCO sign-off.
+See
+[DCO](docs/content/en/contribute/general/dco)
+for more information.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -229,85 +229,12 @@ Add "WIP" (Work in Progress) or "Draft" to the title if the PR is not yet ready 
    git branch -d <branch-name>
    ```
 
-### Developer Certification of Origin (DCO)
+## DCO
 
-Licensing is very important to open source projects.
-It helps ensure the software continues to be available under the
-terms that the author desired.
-
-Keptn uses [Apache License 2.0](https://github.com/keptn/lifecycle-toolkit/blob/main/LICENSE) to strike a balance
-between open contributions and allowing you to use the software however you would like to.
-
-The license tells you what rights you have that are provided by the copyright holder.
-It is important that the contributor fully understands what rights they are licensing and agrees to them.
-Sometimes the copyright holder isn't the contributor, such as when the contributor is doing work on behalf of a company.
-
-To make a good faith effort to ensure these criteria are met,
-Keptn requires the Developer Certificate of Origin (DCO) process to be followed.
-
-The DCO is an attestation attached to every contribution made by every developer.
-In the commit message of the contribution, the developer simply adds a Signed-off-by statement and
-thereby agrees to the DCO, which you can find below or at <http://developercertificate.org/>.
-
-```text
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-#### DCO Sign-Off Methods
-
-The DCO requires a sign-off message in the following format to appear on each commit in the pull request:
-
-```text
-Signed-off-by: Humpty Dumpty <humpty.dumpty@example.com>
-```
-
-The DCO text can either be manually added to your commit body,
-or you can add either **-s** or **--signoff** to your usual git commit commands.
-If you are using the GitHub UI to make a change you can add the sign-off message directly to the commit message
-when creating the pull request.
-If you forget to add the sign-off you can also amend a previous commit
-with the sign-off by running **git commit --amend -s**.
-If you've pushed your changes to GitHub already you'll need to force push your branch after this with **git push -f**.
-
-**ATTRIBUTION**:
-
-* <https://probot.github.io/apps/dco/>
-* <https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md>
-* <https://code.asam.net/simulation/wiki/-/wikis/docs/project_guidelines/ASAM-DCO?version_id=c510bffb1195dc04deb9db9451112669073f0ba5>
-* <https://thesofproject.github.io/latest/contribute/contribute_guidelines.html>
+All commits must be accompanied by a DCO sign-off.
+ See
+[DCO](content/en/contribute/general/dco)
+for more information.
 
 ## Source File Structure
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -229,7 +229,7 @@ Add "WIP" (Work in Progress) or "Draft" to the title if the PR is not yet ready 
    git branch -d <branch-name>
    ```
 
-## DCO
+## Developer Certification of Origin (DCO)
 
 All commits must be accompanied by a DCO sign-off.
  See

--- a/docs/content/en/contribute/general/dco/_index.md
+++ b/docs/content/en/contribute/general/dco/_index.md
@@ -87,9 +87,9 @@ Use the **-s** or **--signoff** flag to the `git commit` command
 to sign off on a commit.
 For example:
 
-```bash 
+```bash
 git commit -s -m "my awesome contribution"
-``` 
+```
 
 If you forget to add the sign-off,
 run the following command to amend the previous commit

--- a/docs/content/en/contribute/general/dco/_index.md
+++ b/docs/content/en/contribute/general/dco/_index.md
@@ -10,7 +10,7 @@ Keptn requires the Developer Certificate of Origin (DCO) process
 to be followed for each commit.
 With the DCO, you attest that the contribution adheres
 to the terms of the Apache License that covers Keptn
-and that you are granting ownership of you work to the Keptn project.
+and that you are granting ownership of your work to the Keptn project.
 
 Licensing is very important to open source projects.
 It helps ensure that the software continues to be available under the

--- a/docs/content/en/contribute/general/dco/_index.md
+++ b/docs/content/en/contribute/general/dco/_index.md
@@ -73,10 +73,11 @@ The DCO check runs on each PR to verify
 that the commit has been signed off properly.
 Your builds will fail and can not be merged if the DCO check fails.
 
-This can be implemented by doing any of the following:
+Do any of the following
+to implement the DCO signoff on each commit:
 
 * [Add **-s** or **--signoff**](#sign-off-with-git-commit--s)
-  to your usual git `commit` commands
+  to your usual `git commit` commands
 * [Manually add text](#manually-add-text-to-commit-description)
   to your commit body
 * [Automate DCO](#automate-dco)

--- a/docs/content/en/contribute/general/dco/_index.md
+++ b/docs/content/en/contribute/general/dco/_index.md
@@ -1,0 +1,150 @@
+---
+title: DCO
+description: Working with DCO
+weight: 200
+---
+
+### Developer Certification of Origin (DCO)
+
+Keptn requires the Developer Certificate of Origin (DCO) process
+to be followed for each commit.
+With the DCO, you attest that the contribution adheres
+to the terms of the Apache License that covers Keptn
+and that you are granting ownership of you work to the Keptn project.
+
+Licensing is very important to open source projects.
+It helps ensure that the software continues to be available under the
+terms that the author desired.
+Keptn uses [Apache License 2.0](https://github.com/keptn/lifecycle-toolkit/blob/main/LICENSE),
+which strikes a balance between open contributions
+and allowing you to use the software however you would like to.
+
+The license tells you what rights the copyright holder gives you.
+It is important that the contributor fully understands
+what rights they are licensing and agrees to them.
+Sometimes the copyright holder is not the contributor,
+such as when the contributor is doing work on behalf of a company.
+
+You must add a Signed-off-by statement for each commit you contribute,
+thereby agreeing to the DCO.
+The text of the DCO is given here
+and available at <http://developercertificate.org/>:
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## DCO Sign-Off Methods
+
+The DCO check runs on each PR to verify
+that the commit has been signed off properly.
+Your builds will fail and can not be merged if the DCO check fails.
+
+This can be implemented by doing any of the following:
+
+* [Add **-s** or **--signoff**](#sign-off-with-git-commit--s)
+  to your usual git `commit` commands
+* [Manually add text](#manually-add-text-to-commit-description)
+  to your commit body
+* [Automate DCO](#automate-dco)
+
+## Sign off with git commit -s
+
+Use the **-s** or **--signoff** flag to the `git commit` command
+to sign off on a commit.
+For example:
+
+```bash 
+git commit -s -m "my awesome contribution"
+``` 
+
+If you forget to add the sign-off,
+run the following command to amend the previous commit
+with the sign-off:
+
+```bash
+git commit --amend --signoff
+```
+
+Use the following command
+to sign off the last 2 commits you made:
+
+```bash
+git rebase HEAD~2 --signoff
+```
+
+## Manually add text to commit description
+
+To sign off on a commit not made with the command line
+(such as those made directly with the github editor
+or as suggestions made to a PR during review),
+you can add text like the following to the commit description block.
+You must specify your real name and the email address to use:
+
+  ```text
+  Signed-off-by: Humpty Dumpty <humpty.dumpty@example.com>
+  ```
+
+## Automate DCO
+
+The DCO  process is sometimes inconvenient but you can automate it
+by creating a pre-commit git hook as follows:
+
+1. Create the hook:
+
+    ``` bash
+    touch .git/hooks/prepare-commit-msg
+    ```
+
+2. Add the following to the `prepare-commit-msg` file:
+
+    ```bash
+    SOB=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+    grep -qs "^$SOB" "$1" || echo "$SOB" >> "$1"
+    ```
+
+3. Give it execution permissions by calling:
+
+    ```bash
+    chmod +x ./.git/hooks/prepare-commit-msg
+    ```
+
+## ATTRIBUTION
+
+* <https://probot.github.io/apps/dco/>
+* <https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md>
+* <https://code.asam.net/simulation/wiki/-/wikis/docs/project_guidelines/ASAM-DCO?version_id=c510bffb1195dc04deb9db9451112669073f0ba5>
+* <https://thesofproject.github.io/latest/contribute/contribute_guidelines.html>


### PR DESCRIPTION
Closes https://github.com/keptn/lifecycle-toolkit/issues/1884 

This PR:
* Combines/rewrites info about working with DCO from the main CONTRIBUTING.md and docs CONTRIBUTING.md files
* Replaces the DCO content in the main CONTRIBUTING.md file with a link to this page
* Replaces the DCO content in the main CONTRIBUTING.md file with a link to this page