### PR TITLE
docs: contrib: git (WIP)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,57 +35,7 @@ Please check [Building the Documentation Locally](content/en/contribute/docs/loc
 
 The documentation source is stored on github.com
 and you use the standard github facilities to modify it.
-The following notes are provided for people who need a little help.
-
-### Fork and clone the repository
-
-Perform the following steps to create a copy of this repository on your local machine:
-
-1. Fork the Keptn repository:
-
-     * Log into GitHub (or create a GitHub account and then log into it).
-     * Go to the [Keptn lifecycle-toolkit repository](https://github.com/keptn/lifecycle-toolkit).
-     * Click the **Fork** button at the top of the screen.
-     * Choose the user for the fork from the options you are given,
-       usually your GitHub ID.
-
-   A copy of this repository is now available in your GitHub account.
-
-2. Get the string to use when cloning your fork:
-
-     * Click the green "Code" button on the UI page.
-     * Select the protocol to use for this clone (either HTTPS or SSH).
-     * A box is displayed that gives the URL for the selected protocol.
-       Click the icon at the right end of that box to copy that URL.
-
-3. Run the **git clone** command from the shell of a local directory
-    to clone the forked repository to a directory on your local machine,
-    pasting in the URl you saved in the previous step:
-
-    ```console
-    git clone https://github.com/<UserName>/lifecycle-toolkit
-    ```
-
-    or
-
-    ```console
-    git clone git@github.com:<UserName>/lifecycle-toolkit.git
-    ```
-
-    Where <*UserName*> is your GitHub username.
-    The lifecycle-toolkit directory is now available in the local directory.
-
-4. Associate your clone with `upstream`.
-   To do this, use the same string you used to clone your fork.
-
-   * Be sure that you are in the root folder of the project
-     and run *git status* to confirm that you are on the `main` branch.
-   * Type the following to associate `upstream` with your clone,
-     pasting in the string for the main repo that you copied above.:
-
-     ```console
-     git remote add upstream https://github.com/keptn/lifecycle-toolkit.git 
-     ```
+Please check [Working with Git](content/en/contribute/general/git/_index.md).
 
 ### Create a new branch and make your changes
 

--- a/docs/content/en/contribute/general/git/_index.md
+++ b/docs/content/en/contribute/general/git/_index.md
@@ -1,0 +1,20 @@
+---
+title: Working with Git
+description: Using Git to contribute software and docs
+weight: 200
+---
+
+Keptn source for software and documentation is stored in the
+[Keptn lifecycle-toolkit repository](https://github.com/keptn/lifecycle-toolkit).
+Contributions are made using standard Git practices.
+This section describes the basic steps required to contribute using Git
+and summarizes some standard practices we use with Keptn..
+
+You can submit small changes using the github editor,
+although be sure so include the DCO signoff.
+
+If you are doing significant work,
+you should fork and clone your own copy of the repository,
+make your changes in a local branch,
+then push those changes to github where they can be reviewed
+and ultimately merged into the product.

--- a/docs/content/en/contribute/general/git/branch-create/_index.md
+++ b/docs/content/en/contribute/general/git/branch-create/_index.md
@@ -1,0 +1,9 @@
+---
+title: Create local branch
+description: How to create a local branch and make modifications in it
+weight: 30
+---
+
+After you
+[fork and clone](../fork-clone)
+the Keptn repository,

--- a/docs/content/en/contribute/general/git/fork-clone/_index.md
+++ b/docs/content/en/contribute/general/git/fork-clone/_index.md
@@ -1,0 +1,58 @@
+---
+title: Fork and clone the repository
+description: How to get a local version of the Keptn repository
+weight: 20
+---
+
+Perform the following steps to create a copy
+of the Keptn repository on your local machine:
+
+1. Fork the Keptn repository:
+
+     * Log into GitHub (or create a GitHub account and then log into it).
+     * Go to the [Keptn lifecycle-toolkit repository](https://github.com/keptn/lifecycle-toolkit).
+     * Click the **Fork** button at the top of the screen.
+     * Choose the user for the fork from the options you are given,
+       usually your GitHub ID.
+
+   A copy of this repository is now available in your GitHub account.
+
+
+2. Get the string to use when cloning your fork:
+
+     * Click the green "Code" button on the UI page.
+     * Select the protocol to use for this clone (either HTTPS or SSH).
+     * A box is displayed that gives the URL for the selected protocol.
+       Click the icon at the right end of that box to copy that URL.
+
+3. Run the **git clone** command from the shell of a local directory
+    to clone the forked repository to a directory on your local machine,
+    pasting in the URl you saved in the previous step.
+    For example, if you are using HTTPS:
+
+    ```console
+    git clone https://github.com/<UserName>/lifecycle-toolkit
+    ```
+
+    Or if you are using SSH:
+
+    ```console
+    git clone git@github.com:<UserName>/lifecycle-toolkit.git
+    ```
+
+    Where <*UserName*> is your GitHub username.
+    The lifecycle-toolkit directory is now available in the local directory.
+
+4. Associate your clone with `upstream`.
+
+   - In a shell, go to the root folder of the project
+     and run *git status* to confirm that you are on the `main` branch.
+   - Type the following to associate `upstream` with your clone,
+     pasting in the string for the main repo that you copied above.:
+
+     ```console
+     git remote add upstream https://github.com/keptn/lifecycle-toolkit.git
+     ```
+You are now ready to
+[create a local branch](../branch-create)
+and begin to create the software or documentation modifications.

--- a/docs/content/en/contribute/general/git/pr-create/_index.md
+++ b/docs/content/en/contribute/general/git/pr-create/_index.md
@@ -1,0 +1,6 @@
+---
+title: Create PR
+description: Create and submit a PR with your changes
+weight: 40
+---
+

--- a/docs/content/en/contribute/general/git/review/_index.md
+++ b/docs/content/en/contribute/general/git/review/_index.md
@@ -1,0 +1,6 @@
+---
+title: PR review process
+description: How to navigate the review process
+weight: 50
+---
+


### PR DESCRIPTION
Closes https://github.com/keptn/lifecycle-toolkit/issues/997 

This PR moves info about working with github from the two CONTRIBUTING.md files into contribute/general/git.  Done so far:
* Fork/clone repo