### PR TITLE
docs: add better instructions for OTel example

### DIFF
--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -117,7 +117,8 @@ using the default configuration included with Keptn,
 use the following commands.
 Use similar commands if you define a different configuration::
 
-⚠️ Make sure you have cloned the `lifecycle-toolkit` repository and have `cd` into the correct directory before running the below commands.
+> **Note**
+Make sure you have cloned the `lifecycle-toolkit` repository and have `cd`ed into the correct directory (`examples/support/observability`) before running the below commands.
 
 ```shell
 kubectl create namespace monitoring

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -117,9 +117,11 @@ using the default configuration included with Keptn,
 use the following commands.
 Use similar commands if you define a different configuration::
 
+⚠️ Make sure you have cloned the `lifecycle-toolkit` repository and have `cd` into the correct directory before running the below commands.
+
 ```shell
 kubectl create namespace monitoring
-kubectl apply -f config/prometheus/setup
+kubectl apply --server-side -f config/prometheus/setup
 kubectl apply -f config/prometheus/
 ```
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -118,7 +118,8 @@ use the following commands.
 Use similar commands if you define a different configuration::
 
 > **Note**
-Make sure you have cloned the `lifecycle-toolkit` repository and have `cd`ed into the correct directory (`examples/support/observability`) before running the below commands.
+You must clone  the `lifecycle-toolkit` repository and `cd` into the correct directory
+(`examples/support/observability`) before running the following commands.
 
 ```shell
 kubectl create namespace monitoring

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -119,7 +119,7 @@ Use similar commands if you define a different configuration::
 
 ```shell
 kubectl create namespace monitoring
-kubectl apply --server-side -f config/prometheus/setup
+kubectl apply -f config/prometheus/setup
 kubectl apply -f config/prometheus/
 ```
 


### PR DESCRIPTION
This PR fixes: #1748 

Adding an instruction above the commands to clone the repo and `cd` into the current directory.