### PR TITLE
docs: fix link to deno web page

### DIFF
--- a/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
@@ -122,7 +122,7 @@ When using the `deno-runtime` runner to define a task,
 the task is coded in Deno-script
 (which is mostly the same as JavaScript and TypeScript)
 and executed in the
-[Deno](https://deno.land/manual@v1.36.2/runtime) runner,
+[Deno](https://deno.land/manual) runner,
 which is a lightweight runtime environment
 that executes in your namespace.
 Note that Deno has tighter restrictions

--- a/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
@@ -122,7 +122,7 @@ When using the `deno-runtime` runner to define a task,
 the task is coded in Deno-script
 (which is mostly the same as JavaScript and TypeScript)
 and executed in the
-[Deno](https://deno.com/) runner,
+[Deno](https://deno.land/manual@v1.36.2/runtime) runner,
 which is a lightweight runtime environment
 that executes in your namespace.
 Note that Deno has tighter restrictions


### PR DESCRIPTION
Deno seems to have renamed their web page and it is causing failures in other PRs.  This PR replaces the deno.com link with what appears to be the correct link.