### PR TITLE
feat: add monitor action to all KLT workflows

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -264,7 +264,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          path: ./helm-charts-repository
+          path: ./helm-charts-repository 
           commit-message: "feat: update KLT chart"
           signoff: true
           branch: klt-chart-update-${{ needs.prepare_ci_run.outputs.BRANCH_SLUG }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,6 +37,9 @@ jobs:
       NON_FORKED_AND_NON_ROBOT_RUN: ${{ steps.get_run_type.outputs.NON_FORKED_AND_NON_ROBOT_RUN }}
 
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -85,6 +88,9 @@ jobs:
           - name: "certificate-operator"
             folder: "klt-cert-manager/"
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -131,6 +137,9 @@ jobs:
           - name: "certificate-operator"
             folder: "klt-cert-manager/"
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -235,6 +244,9 @@ jobs:
     needs: [prepare_ci_run, build_image]
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out klt repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -11,6 +11,9 @@ jobs:
     name: Component Tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,6 +24,9 @@ jobs:
           - name: "scheduler"
             folder: "scheduler/"
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,6 +36,9 @@ jobs:
           - name: "certificate-operator"
             folder: "klt-cert-manager/"
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -22,6 +22,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,6 +23,9 @@ jobs:
     name: Run Integration Tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -19,6 +19,9 @@ jobs:
     name: Run load Tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -29,6 +29,9 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
@@ -41,6 +44,9 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -68,6 +74,9 @@ jobs:
     name: Check CRD auto-generated docs
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -17,6 +17,9 @@ jobs:
     name: Performance Tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/release-examples.yml
+++ b/.github/workflows/release-examples.yml
@@ -22,6 +22,9 @@ jobs:
   release-examples:
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       releases-created: ${{ steps.release.outputs.releases_created }}
       build-matrix: ${{ steps.build-matrix.outputs.result }}
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -122,6 +125,9 @@ jobs:
     env:
       IMAGE_NAME: ghcr.io/keptn/${{ matrix.config.name }}
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -201,6 +207,9 @@ jobs:
       - build-release
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -20,6 +20,9 @@ jobs:
     name: "Prepare Security Scans"
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Determine Target Branch
         id: determine_branch
         run: |
@@ -102,6 +105,9 @@ jobs:
           - tool: "kubescape"
             kubescape-framework: "ARMOBest"
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Set up Go
         if: matrix.tool == 'kubeconform'
         uses: actions/setup-go@v4
@@ -200,6 +206,9 @@ jobs:
           - "scheduler"
           - "certificate-operator"
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Download images
         id: download_images
         uses: actions/download-artifact@v3
@@ -227,6 +236,9 @@ jobs:
           - "klt-cert-manager"
 
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
@@ -250,6 +262,9 @@ jobs:
     needs: [security-scans, govulncheck, trivy]
     if: failure() && github.event_name == 'schedule'
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Formulate bug issue
         id: formulate_bug_issue
         run: |

--- a/.github/workflows/set-date.yml
+++ b/.github/workflows/set-date.yml
@@ -7,6 +7,9 @@ jobs:
   set_date:
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Get project data
         env:
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_PROJECT_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - uses: actions/stale@v8
         with:
           days-before-stale: 60
@@ -26,6 +29,9 @@ jobs:
   stale-good-first-issues:
     runs-on: ubuntu-latest
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - uses: actions/stale@v8
         with:
           days-before-stale: 21

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -9,6 +9,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Update Labels
         uses: actions/labeler@v4
         with:

--- a/.github/workflows/validate-helm-chart.yml
+++ b/.github/workflows/validate-helm-chart.yml
@@ -16,6 +16,9 @@ jobs:
     name: Check helm documentation values
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -54,6 +57,9 @@ jobs:
     name: Run helm tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Check out code
         uses: actions/checkout@v3
 

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -12,6 +12,9 @@ jobs:
   validate:
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - name: Validate Pull Request
         uses: amannn/action-semantic-pull-request@v5.2.0
         env:

--- a/.github/workflows/yaml-checks.yaml
+++ b/.github/workflows/yaml-checks.yaml
@@ -23,6 +23,9 @@ jobs:
   yamllint:
     runs-on: ubuntu-22.04
     steps:
+      - name: Installing local proxy
+        uses: GitHubSecurityLab/actions-permissions/monitor@v1
+
       - uses: actions/checkout@v3
 
       - name: Lint YAML files


### PR DESCRIPTION
This PR closes: #1642 

This PR adds [monitor action](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor) to all the KLT workflow jobs as the first step.