### PR TITLE
docs: fix typos and grammar issues

### DIFF
--- a/docs/content/en/contribute/docs/contribution-guidelines/_index.md
+++ b/docs/content/en/contribute/docs/contribution-guidelines/_index.md
@@ -5,7 +5,7 @@ weight: 300
 ---
 
 Before using the **Keptn Lifecycle Toolkit**
-as a contributor to the Kepth Lifecycle Toolkit repository,
+as a contributor to the Keptn Lifecycle Toolkit repository,
 it is expected that you comply with the guidelines while
 making contributions towards the repository.
 

--- a/docs/content/en/contribute/docs/source-file-structure/_index.md
+++ b/docs/content/en/contribute/docs/source-file-structure/_index.md
@@ -18,7 +18,6 @@ As an example, the metadata section for the *Concepts* section of the documentat
 ```yaml
 title: Concepts
 description: Learn about underlying concepts of the keptn lifecycle toolkit.
-icon: concepts
 layout: quickstart
 weight: 50
 ```

--- a/docs/content/en/contribute/general/technologies/_index.md
+++ b/docs/content/en/contribute/general/technologies/_index.md
@@ -22,7 +22,7 @@ please submit an issue.
   * [ ] [Philosophy](https://youtu.be/ZuIQurh_kDk)
   * [ ] [Kubernetes Deconstructed: Understanding Kubernetes by Breaking It Down](https://www.youtube.com/watch?v=90kZRyPcRZw)
 * **CRD**
-  * [ ] [Custom Resouce Definition (CRD)](https://www.youtube.com/watch?v=xGafiZEX0YA)
+  * [ ] [Custom Resource Definition (CRD)](https://www.youtube.com/watch?v=xGafiZEX0YA)
   * [ ] [Kubernetes Operator simply explained in 10 mins](https://www.youtube.com/watch?v=ha3LjlD6g7g)
   * [ ] [Writing Kubernetes Controllers for CRDs](https://www.youtube.com/watch?v=7wdUa4Ulwxg)
 * **Kube-builder Tutorial**

--- a/docs/content/en/docs/concepts/architecture/cert-manager.md
+++ b/docs/content/en/docs/concepts/architecture/cert-manager.md
@@ -1,7 +1,6 @@
 ---
 title: Keptn Certificate Manager
 description: Learn how the cert-manager works
-icon: concepts
 layout: quickstart
 weight: 100
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html

--- a/docs/content/en/docs/concepts/architecture/components/metrics-operator/_index.md
+++ b/docs/content/en/docs/concepts/architecture/components/metrics-operator/_index.md
@@ -52,7 +52,7 @@ where external monitoring and alerting tools can scrape them.
 It is an important component of the metrics operator
 as it allows for the collection and exposure of custom metrics,
 which can be used to gain insight into the behavior and performance
-of applications running on a Kubenetes cluster.
+of applications running on a Kubernetes cluster.
 
 The **Metrics controller** fetches metrics from an SLI provider.
 The controller reconciles a [`KeptnMetric`](../../../../yaml-crd-ref/metric.md)

--- a/docs/content/en/docs/concepts/architecture/components/metrics-operator/_index.md
+++ b/docs/content/en/docs/concepts/architecture/components/metrics-operator/_index.md
@@ -22,7 +22,7 @@ all your metrics data, regardless of its source,
 so you can use multiple instances of multiple observability platforms.
 
 Keptn metrics are integrated with the Kubernetes
-[Custom Metrics API](https://github.com/kubernetes/metrics#custom-metrics-api)
+[Custom Metrics API](https://github.com/kubernetes/metrics#custom-metrics-api),
 so they are compatible with the Kubernetes
 [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
 (HPA), which enables the horizontal scaling of workloads

--- a/docs/content/en/docs/concepts/architecture/keptn-apps/_index.md
+++ b/docs/content/en/docs/concepts/architecture/keptn-apps/_index.md
@@ -112,11 +112,11 @@ KLT automatically generates appropriate
 [KeptnApp](../../../yaml-crd-ref/app.md)
 resources that are used for observability,
 based on whether the `keptn.sh/app` or `app.kubernetes.io/part-of`
-annotation/label is poulated:
+annotation/label is populated:
 resource for each defined group.
 that together constitute a single deployable Keptn Application.
 
-* If either of these labels/allotations are populated,
+* If either of these labels/annotations are populated,
   KLT automatically generates a `KeptnApp` resource
   that includes all workloads that have the same annotation/label,
   thus creating a `KeptnApp` resource for each defined grouping

--- a/docs/content/en/docs/crd-ref/lifecycle/v1alpha2/_index.md
+++ b/docs/content/en/docs/crd-ref/lifecycle/v1alpha2/_index.md
@@ -153,7 +153,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefiniton |
+| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition |
 | `status` _KeptnState_ |  |
 | `name` _string_ | Name is the name of the Evaluation/Task |
 | `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ |  |

--- a/docs/content/en/docs/crd-ref/lifecycle/v1alpha3/_index.md
+++ b/docs/content/en/docs/crd-ref/lifecycle/v1alpha3/_index.md
@@ -169,7 +169,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefiniton |
+| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition |
 | `status` _KeptnState_ |  |
 | `name` _string_ | Name is the name of the Evaluation/Task |
 | `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#time-v1-meta)_ | StartTime represents the time at which the Item (Evaluation/Task) started. |

--- a/docs/content/en/docs/crd-ref/lifecycle/v1alpha3/_index.md
+++ b/docs/content/en/docs/crd-ref/lifecycle/v1alpha3/_index.md
@@ -112,7 +112,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is the name of the referenced KeptnTaksDefinition. |
+| `name` _string_ | Name is the name of the referenced KeptnTaskDefinition. |
 
 
 #### FunctionStatus

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -263,7 +263,7 @@ These metrics can then be visualised in Grafana.
 For example:
 
 - `keptn_app_active` tracks the number of applications that Keptn manages
-- `keptn_deployment_active` tracks the currently live number of deployments occuring.
+- `keptn_deployment_active` tracks the currently live number of deployments occurring.
   Expect this metric to be `0` when everything is currently deployed.
   It will occasionally rise to `n` during deployments and then fall back to `0` when deployments are completed.
 

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -271,7 +271,7 @@ There are many other Keptn metrics.
 
 ## Step 7: Make DORA metrics more user friendly
 
-It is much more user friendly to provide dashboards for metrics, logs and traces.
+It is much more user-friendly to provide dashboards for metrics, logs and traces.
 So let's install new Observability components to help us:
 
 - [Cert manager](https://cert-manager.io): Jaeger requires cert-manager

--- a/docs/content/en/docs/implementing/_index.md
+++ b/docs/content/en/docs/implementing/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Implementing Keptn applications
 description: Learn how to implement your KLT application
-icon: concepts
 layout: quickstart
 weight: 40
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html

--- a/docs/content/en/docs/implementing/add-app-awareness/index.md
+++ b/docs/content/en/docs/implementing/add-app-awareness/index.md
@@ -17,7 +17,7 @@ To get this working, we need to modify our application manifest with two things:
 
 ### TL;DR
 
-You can also used the prepared manifest and apply it directly using: `kubectl apply -k sample-app/version-2/` and
+You can also use the prepared manifest and apply it directly using: `kubectl apply -k sample-app/version-2/` and
 proceed [here](#watch-application-behavior).
 
 ---

--- a/docs/content/en/docs/implementing/integrate/_index.md
+++ b/docs/content/en/docs/implementing/integrate/_index.md
@@ -7,7 +7,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 ---
 
 The Keptn Lifecycle Toolkit works
-on top of the default scheduler for the cluster
+on top of the default scheduler for the cluster,
 so it can trace all activities of all deployment workloads on the cluster,
 no matter what tool is used for the deployment.
 This same mechanism allows KLT to inject pre- and post-deployment checks
@@ -165,7 +165,7 @@ In general, annotations are more appropriate than labels
 for integrating KLT with your applications
 because they store references, names, and version information
 so the 63 char limitation is quite restrictive.
-However labels can be used if you specifically need them
+However, labels can be used if you specifically need them
 and can accommodate the size restriction.
 
 ## Pre- and post-deployment checks
@@ -200,7 +200,7 @@ do the following:
   [Working with Keptn tasks](../tasks)
   for more information.
 * Annotate your [Workloads](https://kubernetes.io/docs/concepts/workloads/)
-  ([Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
+  [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
   [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
   and
   [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
@@ -241,7 +241,7 @@ The deployment is kept in a pending state
 until the infrastructure is capable of accepting deployments again.
 
 If everything is fine, the deployment continues and afterward,
-a slack notification is sent with the result of the deployment
+a Slack notification is sent with the result of the deployment
 
 ## Use Keptn automatic app discovery
 

--- a/docs/content/en/docs/implementing/integrate/_index.md
+++ b/docs/content/en/docs/implementing/integrate/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Integrate KLT with your applications
 description: How to integrate the Keptn Lifecycle Toolkit into your Kubernetes cluster
-icon: concepts
 layout: quickstart
 weight: 45
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html

--- a/docs/content/en/docs/implementing/integrate/_index.md
+++ b/docs/content/en/docs/implementing/integrate/_index.md
@@ -78,7 +78,7 @@ keptn.sh/version: myAwesomeWorkloadVersion
 keptn.sh/app: myAwesomeAppName
 ```
 
-Alternatively, you can use Kubernete keys for annotations or labels.
+Alternatively, you can use Kubernetes keys for annotations or labels.
 These are part of the Kubernetes
 [Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/):
 
@@ -167,7 +167,7 @@ for integrating KLT with your applications
 because they store references, names, and version information
 so the 63 char limitation is quite restrictive.
 However labels can be used if you specifically need them
-and can accomodate the size restriction.
+and can accommodate the size restriction.
 
 ## Pre- and post-deployment checks
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -125,7 +125,7 @@ kubectl apply -f config/prometheus/
 
 ### Integrate OpenTelemetry into the Keptn Lifecycle Toolkit
 
-To integrate OpenTelementry into the Keptn Lifecycle Toolkit:
+To integrate OpenTelemetry into the Keptn Lifecycle Toolkit:
 
 - Apply
   [basic annotations](../implementing/integrate/#basic-annotations)
@@ -138,7 +138,7 @@ To integrate OpenTelementry into the Keptn Lifecycle Toolkit:
 
 The
 [otel-collector.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/support/observability/config/otel-collector.yaml)
-is the OpenTelementry manifest file for the PodtatoHead example,
+is the OpenTelemetry manifest file for the PodtatoHead example,
 located in the `config` directory.
 To deploy and configure the OpenTelemetry collector
 using this manifest, the command is:

--- a/docs/content/en/docs/implementing/restart-application-deployment/_index.md
+++ b/docs/content/en/docs/implementing/restart-application-deployment/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Restart an Application Deployment
 description: Learn how to restart an unsuccessful Keptn Application Deployment.
-icon: concepts
 layout: quickstart
 weight: 100
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html

--- a/docs/content/en/docs/implementing/tasks/_index.md
+++ b/docs/content/en/docs/implementing/tasks/_index.md
@@ -212,8 +212,7 @@ spec:
 
 ### Pass secrets to a function
 
-Kubernetes
-[secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+[Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
 can be passed to the function
 using the `secureParameters` field.
 

--- a/docs/content/en/docs/implementing/tasks/_index.md
+++ b/docs/content/en/docs/implementing/tasks/_index.md
@@ -58,7 +58,7 @@ defines the runner to use for the container:
   that you define to includes a runtime, an application
   and its runtime dependencies.
   This gives you the greatest flexibility
-  to define tasks using the lanugage and facilities of your choice
+  to define tasks using the language and facilities of your choice
 
 KLT also includes two "pre-defined" runners:
 

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -1,7 +1,6 @@
 ---
 title: Kubernetes cluster
 description: Bring or install a Kubernetes cluster 
-icon: concepts
 layout: quickstart
 weight: 25
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html

--- a/docs/content/en/docs/install/upgrade.md
+++ b/docs/content/en/docs/install/upgrade.md
@@ -19,7 +19,7 @@ helm upgrade --install keptn klt/klt \
 ```
 
 Use the `--set` flag or download and edit the `values.yaml` file
-to modify the configuration as discused on the
+to modify the configuration as discussed on the
 [Install the Lifecycle Toolkit](../install/) page.
 
 > **Warning**

--- a/docs/content/en/docs/install/upgrade.md
+++ b/docs/content/en/docs/install/upgrade.md
@@ -1,7 +1,6 @@
 ---
 title: Upgrade
 description: How to upgrade to the latest version of the Lifecycle Toolkit
-icon: concepts
 layout: quickstart
 weight: 45
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html

--- a/docs/content/en/docs/intro-klt/_index.md
+++ b/docs/content/en/docs/intro-klt/_index.md
@@ -5,7 +5,7 @@ weight: 20
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
-This section contains tutorials on how to use the Keptn Lifecyle Toolkit.
+This section contains tutorials on how to use the Keptn Lifecycle Toolkit.
 
 When you understand the toolkit, begin with the [getting started guide](../getting-started/).
 
@@ -148,7 +148,7 @@ the Keptn Lifecycle Toolkit:
   and the concepts that drive the Keptn Lifecycle Toolkit,
   then gives a simple demonstration of a Keptn Lifecycle Controller implementation.
 
-* [Introducing Keptn Lifecyle Toolkit](https://youtu.be/449HAFYkUlY)
+* [Introducing Keptn Lifecycle Toolkit](https://youtu.be/449HAFYkUlY)
   gives an overview of what KLT does and how to implement it.
 
 * [Keptn Lifecycle Toolkit Demo Tutorial on k3s, with ArgoCD for GitOps, OTel, Prometheus and Grafana](https://www.youtube.com/watch?v=6J_RzpmXoCc)

--- a/docs/content/en/docs/intro-klt/usecase-orchestrate.md
+++ b/docs/content/en/docs/intro-klt/usecase-orchestrate.md
@@ -127,7 +127,7 @@ In our example, the tasks are defined in the
 [keptn-tasks.yaml](https://github.com/keptn-sandbox/klt-on-k3s-with-argocd/blob/main/simplenode-dev/keptn-tasks.yaml)
 file.
 As an example,
-we have a `notify` task that composes some markdown text
+we have a `notify` task that composes some Markdown text
 to be sent as Slack notifications
 The `KeptnTaskDefinition` looks like this:
 

--- a/docs/content/en/docs/intro-klt/usecase-orchestrate.md
+++ b/docs/content/en/docs/intro-klt/usecase-orchestrate.md
@@ -4,7 +4,7 @@ description: How KLT orchestrates pre- and post-deployment evaluations and tasks
 weight: 20
 ---
 
-In this exercise, we will configure the Keptn Lifecyle Toolkit
+In this exercise, we will configure the Keptn Lifecycle Toolkit
 to run deployment checks as part of your deployment.
 Whether you are deploying your software with
 Argo, Flux, another deployment engine, or even `kubectl apply`,
@@ -13,7 +13,7 @@ the Lifecycle Toolkit can do the following:
 * Pre-deploy: Validate external dependencies,
   confirm that images are scanned, and so forth
 
-* Post-deply: Execute tests, notify stakeholders,
+* Post-deploy: Execute tests, notify stakeholders,
   promote to the next stage
 
 * Automatically validate against your SLO (Service Level Objectives)
@@ -89,7 +89,7 @@ you need to do the following:
 
 An `evaluation` is a KeptnMetric that has a defined target value.
 Evaluations are resources that are defined in a
-[KeptinEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
+[KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
 yaml file.
 In our example, evaluations are defined in the
 [keptn-evaluations.yaml](https://github.com/keptn-sandbox/klt-on-k3s-with-argocd/blob/main/simplenode-dev/keptn-evaluations.yaml)

--- a/docs/content/en/docs/intro-klt/usecase_metrics.md
+++ b/docs/content/en/docs/intro-klt/usecase_metrics.md
@@ -131,7 +131,7 @@ metadata:
 spec:
   type: dynatrace
   targetServer: "https://hci34192.live.dynatrace.com"
-  secretKeyRef
+  secretKeyRef:
     name: dynatrace
     key: DT_TOKEN
 ...

--- a/docs/content/en/docs/migrate/strategy/_index.md
+++ b/docs/content/en/docs/migrate/strategy/_index.md
@@ -86,7 +86,7 @@ Some key points:
   using Kubernetes capabilities.
 
 * KLT provides extensive observability data
-  using OpenTelementry and Prometheus
+  using OpenTelemetry and Prometheus
   rather than storing the data in a special Keptn database.
   This data can be displayed using Grafana and Jaeger
   or the dashboard of your choice.
@@ -151,7 +151,7 @@ For example:
   a `KeptnTask` using the `container-runner`.
 * A Keptn v1 service that runs a database
   can probably be translated
-  into a Kubenetes `StateFulSet` workload; see
+  into a Kubernetes `StateFulSet` workload; see
   [Workload Resources](https://kubernetes.io/docs/concepts/workloads/controllers/)
   for more information.
 * A Keptn v1 service that runs a webserver
@@ -273,7 +273,7 @@ When migrating to KLT, you need to define a
 [KeptnMetricsProvider](../../yaml-crd-ref/metricsprovider.md)
 resource for the data provider(s) you are using.
 Note that KLT allows you to support multiple data providers
-and multiple instances of each data provider for your SLI's
+and multiple instances of each data provider for your SLIs
 whereas Keptn v1 only allows you to use one SLI per project.
 
 The queries defined for the Keptn v1 SLIs
@@ -286,7 +286,7 @@ resources.
 KLT at this time does not support the full range
 of Quality Gates evaluations that are represented by
 [SLOs](https://keptn.sh/docs/1.0.x/reference/files/slo/).
-Facilities such as weighting of SLI's and scoring of the evaluation
+Facilities such as weighting of SLIs and scoring of the evaluation
 do not currently exist.
 This functionality is under development; see
 [Epic 1646](https://github.com/keptn/lifecycle-toolkit/issues/1646).
@@ -309,7 +309,7 @@ but it does provide limited "Day 2" facilities:
 * `KeptnMetricsDefinition` resources can be retrieved and used
   to implement the Kubernetes HorizontalPodAutoscaler (HPA),
   which can detect the need for additional resources
-  (more pods, memory, disk space, etc)
+  (more pods, memory, disk space, etc.)
   and automatically add those resources to your configuration
   based on the `ReplicaSet` resources you have defined.
   See

--- a/docs/content/en/docs/migrate/strategy/_index.md
+++ b/docs/content/en/docs/migrate/strategy/_index.md
@@ -299,7 +299,7 @@ resources.
 
 KLT does not currently support the same level of
 [remediations](https://keptn.sh/docs/1.0.x/reference/files/remediation/)
-as Keptn v1 does
+as Keptn v1 does,
 but it does provide limited "Day 2" facilities:
 
 * Any query that is possible for your data provider post-deployment

--- a/docs/content/en/docs/troubleshooting.md
+++ b/docs/content/en/docs/troubleshooting.md
@@ -61,7 +61,7 @@ to get further information refer to this [issue](https://github.com/keptn/lifecy
 
 ## I cannot see DORA metrics or OpenTelemetry traces
 
-KLT will automatically generate DORA metrics and Otel traces for every deployment, but
+KLT will automatically generate DORA metrics and OTel traces for every deployment, but
 by default it does not know where to send them.
 
 You need an OpenTelemetry collector

--- a/docs/content/en/docs/tutorials/_index.md
+++ b/docs/content/en/docs/tutorials/_index.md
@@ -5,6 +5,6 @@ weight: 40
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
-This section contains tutorials on how to use the Keptn Lifecyle Toolkit.
+This section contains tutorials on how to use the Keptn Lifecycle Toolkit.
 
 Begin with the [getting started guide](../getting-started/) first, then come back here to complete these tutorials.

--- a/docs/content/en/docs/yaml-crd-ref/app.md
+++ b/docs/content/en/docs/yaml-crd-ref/app.md
@@ -117,7 +117,7 @@ The Keptn Lifecycle Toolkit adds the concept of applications
 defined as a set of workloads that can be executed.
 A `KeptnApp` resource is added
 into the repository of the deployment engine
-(ArgoCD, Flux, etc)
+(ArgoCD, Flux, etc.)
 and is then deployed by that deployment engine.
 
 A `KeptnApp` resource is created automatically, using the

--- a/docs/content/en/docs/yaml-crd-ref/metric.md
+++ b/docs/content/en/docs/yaml-crd-ref/metric.md
@@ -130,7 +130,7 @@ Beginning with the `v1alpha3` API version,
 Keptn allows you to define multiple instances of the same data source.
 In earlier versions, you could use multiple data sources
 but only one instance of each.
-Consequently the `v1alpha1` and `v1alpha2` API versions
+Consequently, the `v1alpha1` and `v1alpha2` API versions
 define the `provider` field with the type of the data provider
 (`prometheus`, `dynatrace`, or `dql`)
 rather than the particular name assigned

--- a/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
@@ -27,7 +27,7 @@ differentiated by the `spec` section:
   You define the runner, an application,
   and its runtime dependencies.
   This gives you the flexibility
-  to define tasks using the lanugage and facilities of your choice,
+  to define tasks using the language and facilities of your choice,
   although it is more complicated that using one of the pre-defined runtimes.
   See
   [Yaml synopsis for container-runtime](#yaml-synopsis-for-container-runtime)

--- a/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
@@ -23,7 +23,7 @@ differentiated by the `spec` section:
 
 * The `custom-runtime` runner provides
   a standard Kubernetes application container
-  that is run as part of a Kubernetes job..
+  that is run as part of a Kubernetes job.
   You define the runner, an application,
   and its runtime dependencies.
   This gives you the flexibility
@@ -407,7 +407,7 @@ the size of the volume is 50% of the memory allocated for the node.
 
 A task can be executed either pre-deployment or post-deployment
 as specified in the pod template specs of your Workloads
-([Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
+[Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
 [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
 [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/),
 and
@@ -565,7 +565,7 @@ This task is then referenced in
 
 [app.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-3/app.yaml).
 
-This is a a trivial example that just runs `busybox`,
+This is a trivial example that just runs `busybox`,
 then spawns a shell and runs the `sleep 30` command.
 
 ## Examples for a python-runtime runner

--- a/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
@@ -96,7 +96,7 @@ but timeouts seem to be measured in seconds.
     and code the functionality in Deno script,
     which is similar to JavaScript and Typescript.
     See
-    [Yaml synopsis for deno-runtime contailer](#yaml-synopsis-for-deno-runtime-container).
+    [Yaml synopsis for deno-runtime container](#yaml-synopsis-for-deno-runtime-container).
     * **python** -- Use a `python-runtime` function
     and code the functionality in Python 3.
     See
@@ -107,7 +107,7 @@ but timeouts seem to be measured in seconds.
       for which you define the image, runner, runtime parameters, etc.
       and code the functionality to match the container you define.
       See
-      [Yaml synopsis for container-runtime contaier](#yaml-synopsis-for-container-runtime).
+      [Yaml synopsis for container-runtime container](#yaml-synopsis-for-container-runtime).
   * **retries** (optional) - specifies the number of times,
     a job executing the `KeptnTaskDefinition`
     should be restarted if an attempt is unsuccessful.

--- a/lifecycle-operator/apis/lifecycle/v1alpha2/keptnworkloadinstance_types.go
+++ b/lifecycle-operator/apis/lifecycle/v1alpha2/keptnworkloadinstance_types.go
@@ -64,7 +64,7 @@ type KeptnWorkloadInstanceStatus struct {
 }
 
 type ItemStatus struct {
-	// DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+	// DefinitionName is the name of the EvaluationDefinition/TaskDefinition
 	DefinitionName string `json:"definitionName,omitempty"`
 	// +kubebuilder:default:=Pending
 	Status common.KeptnState `json:"status,omitempty"`

--- a/lifecycle-operator/apis/lifecycle/v1alpha3/keptntaskdefinition_types.go
+++ b/lifecycle-operator/apis/lifecycle/v1alpha3/keptntaskdefinition_types.go
@@ -86,7 +86,7 @@ type ConfigMapReference struct {
 }
 
 type FunctionReference struct {
-	// Name is the name of the referenced KeptnTaksDefinition.
+	// Name is the name of the referenced KeptnTaskDefinition.
 	Name string `json:"name,omitempty"`
 }
 
@@ -115,9 +115,9 @@ type FunctionStatus struct {
 	ConfigMap string `json:"configMap,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:storageversion
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:storageversion
+// +kubebuilder:subresource:status
 
 // KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 type KeptnTaskDefinition struct {
@@ -130,7 +130,7 @@ type KeptnTaskDefinition struct {
 	Status KeptnTaskDefinitionStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 type KeptnTaskDefinitionList struct {

--- a/lifecycle-operator/apis/lifecycle/v1alpha3/keptnworkloadinstance_types.go
+++ b/lifecycle-operator/apis/lifecycle/v1alpha3/keptnworkloadinstance_types.go
@@ -86,7 +86,7 @@ type KeptnWorkloadInstanceStatus struct {
 }
 
 type ItemStatus struct {
-	// DefinitionName is the name of the EvaluationDefinition/TaskDefiniton
+	// DefinitionName is the name of the EvaluationDefinition/TaskDefinition
 	DefinitionName string `json:"definitionName,omitempty"`
 	// +kubebuilder:default:=Pending
 	Status common.KeptnState `json:"status,omitempty"`


### PR DESCRIPTION
### This PR
- fixes tons of typos and grammar errors
- fixes the left sidebar items not being aligned by removing the `icon: concepts` from all page headers