### PR TITLE
fix(metrics-operator): flaky test in SLI converter

### DIFF
--- a/metrics-operator/converter/sli_converter_test.go
+++ b/metrics-operator/converter/sli_converter_test.go
@@ -14,7 +14,7 @@ indicators:
   throughput: "builtin:service.requestCount.total:merge(0):count?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)"
   response_time_p95: "builtin:service.response.time:merge(0):percentile(95)?scope=tag(keptn_project:$PROJECT),tag(keptn_stage:$STAGE),tag(keptn_service:$SERVICE),tag(keptn_deployment:$DEPLOYMENT)"`
 
-const expectedOutput = `---
+const expectedOutput1 = `---
 apiVersion: metrics.keptn.sh/v1alpha3
 kind: AnalysisValueTemplate
 metadata:
@@ -25,7 +25,9 @@ spec:
     name: dynatrace
     namespace: keptn
   query: builtin:service.response.time:merge(0):percentile(95)?scope=tag(keptn_project:{{.project}}),tag(keptn_stage:{{.stage}}),tag(keptn_service:{{.service}}),tag(keptn_deployment:{{.deployment}})
----
+`
+
+const expectedOutput2 = `---
 apiVersion: metrics.keptn.sh/v1alpha3
 kind: AnalysisValueTemplate
 metadata:
@@ -108,7 +110,10 @@ func TestConvertSLI(t *testing.T) {
 	// happy path
 	res, err = c.Convert([]byte(sliContent), "dynatrace", "keptn")
 	require.Nil(t, err)
-	require.Equal(t, expectedOutput, res)
+	// need to check the result with contains, as there is no guarantee
+	// of order of the AnalysisValueTemplates in resulting manifest
+	require.Contains(t, res, expectedOutput1)
+	require.Contains(t, res, expectedOutput2)
 }
 
 func TestConvertQuary(t *testing.T) {


### PR DESCRIPTION
## Changes

Order of the results in manifests is not guaranteed, as we unmarshal the data to a map, which does not guarantee the order of the elements by default