### PR TITLE
feat(metrics-operator): introduce SLO -> AnalysisDefinition converter

### DIFF
--- a/metrics-operator/api/v1alpha3/analysisdefinition_types.go
+++ b/metrics-operator/api/v1alpha3/analysisdefinition_types.go
@@ -24,9 +24,9 @@ import (
 // AnalysisDefinitionSpec defines the desired state of AnalysisDefinition
 type AnalysisDefinitionSpec struct {
 	// Objectives defines a list of objectives to evaluate for an analysis
-	Objectives []Objective `json:"objectives,omitempty"`
+	Objectives []Objective `json:"objectives,omitempty" yaml:"objectives,omitempty"`
 	// TotalScore defines the required score for an analysis to be successful
-	TotalScore TotalScore `json:"totalScore"`
+	TotalScore TotalScore `json:"totalScore" yaml:"totalScore"`
 }
 
 // TotalScore defines the required score for an analysis to be successful
@@ -34,53 +34,53 @@ type TotalScore struct {
 	// PassPercentage defines the threshold to reach for an analysis to pass
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:validation:Maximum:=100
-	PassPercentage int `json:"passPercentage"`
+	PassPercentage int `json:"passPercentage" yaml:"passPercentage"`
 	// WarningPercentage defines the threshold to reach for an analysis to pass with a 'warning' status
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:validation:Maximum:=100
-	WarningPercentage int `json:"warningPercentage"`
+	WarningPercentage int `json:"warningPercentage" yaml:"warningPercentage"`
 }
 
 // Objective defines an objective for analysis
 type Objective struct {
 	// AnalysisValueTemplateRef refers to the appropriate AnalysisValueTemplate
-	AnalysisValueTemplateRef ObjectReference `json:"analysisValueTemplateRef"`
+	AnalysisValueTemplateRef ObjectReference `json:"analysisValueTemplateRef" yaml:"analysisValueTemplateRef"`
 	// Target defines failure or warning criteria
-	Target Target `json:"target,omitempty"`
+	Target Target `json:"target,omitempty" yaml:"target,omitempty"`
 	// Weight can be used to emphasize the importance of one Objective over the others
 	// +kubebuilder:default:=1
-	Weight int `json:"weight,omitempty"`
+	Weight int `json:"weight,omitempty" yaml:"weight,omitempty"`
 	// KeyObjective defines whether the whole analysis fails when this objective's target is not met
 	// +kubebuilder:default:=false
-	KeyObjective bool `json:"keyObjective,omitempty"`
+	KeyObjective bool `json:"keyObjective,omitempty" yaml:"keyObjective,omitempty"`
 }
 
 // Target defines the failure and warning criteria
 type Target struct {
 	// Failure defines limits up to which an analysis fails
-	Failure *Operator `json:"failure,omitempty"`
+	Failure *Operator `json:"failure,omitempty" yaml:"failure,omitempty"`
 	// Warning defines limits where the result does not pass or fail
-	Warning *Operator `json:"warning,omitempty"`
+	Warning *Operator `json:"warning,omitempty" yaml:"warning,omitempty"`
 }
 
 // OperatorValue represents the value to which the result is compared
 type OperatorValue struct {
 	// FixedValue defines the value for comparison
-	FixedValue resource.Quantity `json:"fixedValue"`
+	FixedValue resource.Quantity `json:"fixedValue" yaml:"fixedValue"`
 }
 
 // Operator specifies the supported operators for value comparisons
 type Operator struct {
 	// LessThanOrEqual represents '<=' operator
-	LessThanOrEqual *OperatorValue `json:"lessThanOrEqual,omitempty"`
+	LessThanOrEqual *OperatorValue `json:"lessThanOrEqual,omitempty" yaml:"lessThanOrEqual,omitempty"`
 	// LessThan represents '<' operator
-	LessThan *OperatorValue `json:"lessThan,omitempty"`
+	LessThan *OperatorValue `json:"lessThan,omitempty" yaml:"lessThan,omitempty"`
 	// GreaterThan represents '>' operator
-	GreaterThan *OperatorValue `json:"greaterThan,omitempty"`
+	GreaterThan *OperatorValue `json:"greaterThan,omitempty" yaml:"greaterThan,omitempty"`
 	// GreaterThanOrEqual represents '>=' operator
-	GreaterThanOrEqual *OperatorValue `json:"greaterThanOrEqual,omitempty"`
+	GreaterThanOrEqual *OperatorValue `json:"greaterThanOrEqual,omitempty" yaml:"greaterThanOrEqual,omitempty"`
 	// EqualTo represents '==' operator
-	EqualTo *OperatorValue `json:"equalTo,omitempty"`
+	EqualTo *OperatorValue `json:"equalTo,omitempty" yaml:"equalTo,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -88,10 +88,10 @@ type Operator struct {
 
 // AnalysisDefinition is the Schema for the analysisdefinitions APIs
 type AnalysisDefinition struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Spec AnalysisDefinitionSpec `json:"spec,omitempty"`
+	Spec AnalysisDefinitionSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
 	// unused field
 	Status string `json:"status,omitempty"`
 }

--- a/metrics-operator/converter/sli_converter_test.go
+++ b/metrics-operator/converter/sli_converter_test.go
@@ -117,7 +117,7 @@ func TestConvertSLI(t *testing.T) {
 	require.Contains(t, res, expectedOutput2)
 }
 
-func TestConvertQuary(t *testing.T) {
+func TestConvertQuery(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -137,7 +137,7 @@ func setupTarget(o Objective) (metricsapi.Target, error) {
 	if len(o.Warning) == 0 {
 		if len(o.Pass) > 0 {
 			if len(o.Pass[0].Operators) > 0 {
-				// TODO cover use cases with multiple criterias (create new objectives)
+				// TODO cover use cases with multiple operators (create new objectives)
 				op, err := setupOperator(o.Pass[0].Operators[0])
 				if err != nil {
 					return target, err
@@ -153,6 +153,7 @@ func setupTarget(o Objective) (metricsapi.Target, error) {
 	var err error
 	if len(o.Pass) > 0 {
 		if len(o.Pass[0].Operators) > 0 {
+			// TODO cover use cases with multiple operators (create new objectives)
 			op, err := setupOperator(o.Pass[0].Operators[0])
 			if err != nil {
 				return target, err
@@ -160,6 +161,7 @@ func setupTarget(o Objective) (metricsapi.Target, error) {
 			target.Warning = op
 		}
 		if len(o.Warning[0].Operators) > 0 {
+			// TODO cover use cases with multiple operators (create new objectives)
 			op, err := setupOperator(o.Warning[0].Operators[0])
 			if err != nil {
 				return target, err

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -49,7 +49,7 @@ func (o *Objective) hasSupportedCriteria() bool {
 func (c *SLOConverter) Convert(fileContent []byte, analysisDef string, namespace string) (string, error) {
 	//check that provider and namespace is set
 	if analysisDef == "" || namespace == "" {
-		return "", fmt.Errorf("missing arguments: '--definition' and '--namespace' needs to be set for conversion")
+		return "", fmt.Errorf("missing arguments: 'definition' and 'namespace' needs to be set for conversion")
 	}
 
 	// unmarshall content
@@ -125,7 +125,7 @@ func (c *SLOConverter) convertSLO(sloContent *SLO, name string, namespace string
 	return definition, nil
 }
 
-// removes % symbol from the scoring values and converts to numberic value
+// removes % symbol from the scoring values and converts to numeric value
 func removePercentage(str string) (int, error) {
 	t := strings.ReplaceAll(str, "%", "")
 	f, err := strconv.ParseFloat(t, 64)
@@ -148,7 +148,7 @@ func setupTarget(o *Objective) (*metricsapi.Target, error) {
 		return target, nil
 	}
 
-	// if warning criteria are not defined, negotiate the pass criteria to create fail criteria
+	// if warning criteria are not defined, negate the pass criteria to create fail criteria
 	if len(o.Warning) == 0 {
 		if len(o.Pass) > 0 {
 			if len(o.Pass[0].Operators) > 0 {
@@ -231,7 +231,7 @@ func newOperator(op string) (*metricsapi.Operator, error) {
 	return &metricsapi.Operator{}, fmt.Errorf("invalid operator: '%s'", op)
 }
 
-// checks and negotiates the existing operator
+// checks and negates the existing operator
 func createOperator(op string, value string) (*metricsapi.Operator, error) {
 	dec := inf.NewDec(1, 0)
 	_, ok := dec.SetString(value)

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -1,0 +1,216 @@
+package converter
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha3"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type SLOConverter struct {
+}
+
+func NewSLOConverter() *SLOConverter {
+	return &SLOConverter{}
+}
+
+type SLO struct {
+	Objectives []Objective `yaml:"objectives" json:"objectives"`
+	TotalScore Score       `yaml:"total_score" json:"total_score"`
+}
+
+type Score struct {
+	Pass    string `yaml:"pass" json:"pass"`
+	Warning string `yaml:"warning" json:"warning"`
+}
+
+type Objective struct {
+	Name    string     `yaml:"sli" json:"sli"`
+	KeySLI  bool       `yaml:"key_sli,omitempty" json:"key_sli,omitempty"`
+	Weight  int        `yaml:"weight,omitempty" json:"weight,omitempty"`
+	Warning []Criteria `yaml:"warning,omitempty" json:"warning,omitempty"`
+	Pass    []Criteria `yaml:"pass,omitempty" json:"pass,omitempty"`
+}
+
+type Criteria struct {
+	Operators []string `yaml:"criteria,omitempty" json:"criteria,omitempty"`
+}
+
+func (c *SLOConverter) Convert(fileContent []byte, analysisDef string, namespace string) (string, error) {
+	//check that provider and namespace is set
+	if analysisDef == "" || namespace == "" {
+		return "", fmt.Errorf("--definition and --slo-namespace needs to be set for conversion")
+	}
+
+	// unmarshall content
+	content := &SLO{}
+	err := yaml.Unmarshal(fileContent, content)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling file content: %s", err.Error())
+	}
+
+	// convert
+	analysisDefinition, err := c.convertSLO(content, analysisDef, namespace)
+	if err != nil {
+		return "", err
+	}
+
+	// marshal AnalysisDefinition to Yaml
+	yamlData, err := yaml.Marshal(analysisDefinition)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling data: %s", err.Error())
+	}
+
+	return string(yamlData), nil
+}
+
+func (c *SLOConverter) convertSLO(sloContent *SLO, name string, namespace string) (*metricsapi.AnalysisDefinition, error) {
+	definition := &metricsapi.AnalysisDefinition{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "AnalysisDefinition",
+			APIVersion: "metrics.keptn.sh/v1alpha3",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: metricsapi.AnalysisDefinitionSpec{
+			TotalScore: metricsapi.TotalScore{
+				PassPercentage:    removePercentage(sloContent.TotalScore.Pass),
+				WarningPercentage: removePercentage(sloContent.TotalScore.Warning),
+			},
+			Objectives: make([]metricsapi.Objective, len(sloContent.Objectives), len(sloContent.Objectives)*2),
+		},
+	}
+
+	for i, o := range sloContent.Objectives {
+		objective := metricsapi.Objective{
+			AnalysisValueTemplateRef: metricsapi.ObjectReference{
+				Name:      o.Name,
+				Namespace: namespace,
+			},
+			KeyObjective: o.KeySLI,
+			Weight:       o.Weight,
+			Target:       setupTarget(o),
+		}
+		definition.Spec.Objectives[i] = objective
+	}
+	return definition, nil
+}
+
+func removePercentage(str string) int {
+	t := strings.ReplaceAll(str, "%", "")
+	y, _ := strconv.Atoi(t)
+	return y
+}
+
+func setupTarget(o Objective) metricsapi.Target {
+	target := metricsapi.Target{}
+	o = cleanupObjective(o)
+	if shouldIgnoreObjective(o) {
+		return target
+	}
+
+	if len(o.Warning) == 0 {
+		if len(o.Pass) > 0 {
+			if len(o.Pass[0].Operators) > 0 {
+				op, _ := setupOperator(o.Pass[0].Operators[0])
+				target.Failure = op
+				return target
+			}
+		}
+	}
+
+	if len(o.Pass) > 0 {
+		if len(o.Pass[0].Operators) > 0 {
+			op, _ := setupOperator(o.Pass[0].Operators[0])
+			target.Warning = op
+		}
+		if len(o.Warning[0].Operators) > 0 {
+			op, _ := setupOperator(o.Warning[0].Operators[0])
+			target.Failure = op
+		}
+	}
+
+	return target
+}
+
+func cleanupObjective(o Objective) Objective {
+	o.Pass = cleanupCriteria(o.Pass)
+	o.Warning = cleanupCriteria(o.Warning)
+	return o
+}
+
+func cleanupCriteria(criteria []Criteria) []Criteria {
+	newCriteria := make([]Criteria, 0, len(criteria))
+	for _, c := range criteria {
+		operators := make([]string, 0, len(c.Operators))
+		for _, op := range c.Operators {
+			// keep only criteria with real values, not percentage
+			if !strings.Contains(op, "%") {
+				operators = append(operators, op)
+			}
+		}
+		// if criterium does have operator, store it
+		if len(operators) > 0 {
+			newCriteria = append(newCriteria, Criteria{Operators: operators})
+		}
+	}
+
+	return newCriteria
+}
+
+func shouldIgnoreObjective(o Objective) bool {
+	return len(o.Pass) > 1 || len(o.Warning) > 1
+}
+
+func setupOperator(op string) (*metricsapi.Operator, error) {
+	// remove whitespaces
+	op = strings.Replace(op, " ", "", -1)
+
+	operators := []string{"<=", "<", ">=", ">"}
+	for _, operator := range operators {
+		if strings.HasPrefix(op, operator) {
+			return createOperator(operator, strings.TrimPrefix(op, operator))
+		}
+	}
+
+	return &metricsapi.Operator{}, nil
+}
+
+func createOperator(o string, value string) (*metricsapi.Operator, error) {
+	v, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	if o == "<=" {
+		return &metricsapi.Operator{
+			GreaterThan: &metricsapi.OperatorValue{
+				FixedValue: *resource.NewQuantity(v, resource.DecimalSI),
+			},
+		}, nil
+	} else if o == "<" {
+		return &metricsapi.Operator{
+			GreaterThanOrEqual: &metricsapi.OperatorValue{
+				FixedValue: *resource.NewQuantity(v, resource.DecimalSI),
+			},
+		}, nil
+	} else if o == ">=" {
+		return &metricsapi.Operator{
+			LessThan: &metricsapi.OperatorValue{
+				FixedValue: *resource.NewQuantity(v, resource.DecimalSI),
+			},
+		}, nil
+	} else if o == ">" {
+		return &metricsapi.Operator{
+			LessThanOrEqual: &metricsapi.OperatorValue{
+				FixedValue: *resource.NewQuantity(v, resource.DecimalSI),
+			},
+		}, nil
+	}
+
+	return &metricsapi.Operator{}, fmt.Errorf("invalid operator")
+}

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -124,7 +124,8 @@ func removePercentage(str string) (int, error) {
 }
 
 // creates and sets up the target struct from objective
-// nolint:gocognit
+// TODO refactor this function in a follow-up
+// nolint:gocognit,gocyclo
 func setupTarget(o *Objective) (*metricsapi.Target, error) {
 	target := &metricsapi.Target{}
 	// clean up % criteria
@@ -218,7 +219,7 @@ func setupOperator(op string) (*metricsapi.Operator, error) {
 		}
 	}
 
-	return &metricsapi.Operator{}, nil
+	return &metricsapi.Operator{}, fmt.Errorf("invalid operator: '%s'", op)
 }
 
 // checks and negotiates the existing operator
@@ -253,5 +254,5 @@ func createOperator(op string, value string) (*metricsapi.Operator, error) {
 		}, nil
 	}
 
-	return &metricsapi.Operator{}, fmt.Errorf("invalid operator")
+	return &metricsapi.Operator{}, fmt.Errorf("invalid operator: '%s'", op)
 }

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -196,7 +196,7 @@ func cleanupObjective(o *Objective) *Objective {
 }
 
 // remove % operators from criterium structure
-// if criterium did have only % operators, remove it from strucutre
+// if criteria did have only % operators, remove it from strucutre
 func cleanupCriteria(criteria []Criteria) []Criteria {
 	newCriteria := make([]Criteria, 0, len(criteria))
 	for _, c := range criteria {

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -124,7 +124,7 @@ func removePercentage(str string) (int, error) {
 }
 
 // creates and sets up the target struct from objective
-// TODO refactor this function in a follow-up
+// TODO refactor this function in a follow-up + weight distribution
 // nolint:gocognit,gocyclo
 func setupTarget(o *Objective) (*metricsapi.Target, error) {
 	target := &metricsapi.Target{}
@@ -136,7 +136,7 @@ func setupTarget(o *Objective) (*metricsapi.Target, error) {
 		return target, nil
 	}
 
-	// if warning criteria are not defined, negotiate the existing and create fail criteria
+	// if warning criteria are not defined, negotiate the pass criteria to create fail criteria
 	if len(o.Warning) == 0 {
 		if len(o.Pass) > 0 {
 			if len(o.Pass[0].Operators) > 0 {
@@ -151,8 +151,9 @@ func setupTarget(o *Objective) (*metricsapi.Target, error) {
 		}
 	}
 
-	// warn criteria -> fail criteria
-	// pass criteria -> warn criteria
+	// if warning criteria are defined, create new criteria with the following logic:
+	// !(warn criteria) -> fail criteria
+	// !(pass criteria) -> warn criteria
 	var err error
 	if len(o.Pass) > 0 {
 		if len(o.Pass[0].Operators) > 0 {

--- a/metrics-operator/converter/slo_converter.go
+++ b/metrics-operator/converter/slo_converter.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -127,7 +128,11 @@ func (c *SLOConverter) convertSLO(sloContent *SLO, name string, namespace string
 // removes % symbol from the scoring values and converts to numberic value
 func removePercentage(str string) (int, error) {
 	t := strings.ReplaceAll(str, "%", "")
-	return strconv.Atoi(t)
+	f, err := strconv.ParseFloat(t, 64)
+	if err != nil {
+		return 0, err
+	}
+	return int(math.Round(f)), nil
 }
 
 // creates and sets up the target struct from objective

--- a/metrics-operator/converter/slo_converter_test.go
+++ b/metrics-operator/converter/slo_converter_test.go
@@ -1,0 +1,37 @@
+package converter
+
+import "testing"
+
+const SLOContent = `---
+spec_version: "0.1.1"
+comparison:
+  aggregate_function: "avg"
+  compare_with: "single_result"
+  include_result_with_score: "pass"
+  number_of_comparison_results: 1
+filter:
+objectives:
+  - sli: "response_time_p95"
+    key_sli: false
+    pass:             # pass if (relative change <= 75% AND absolute value is < 75ms)
+      - criteria:
+          - "<=+75%"  # relative values require a prefixed sign (plus or minus)
+          - "<800"     # absolute values only require a logical operator
+    warning:          # if the response time is below 200ms, the result should be a warning
+      - criteria:
+          - "<=1000"
+          - "<=+100%"
+    weight: 1
+  - sli: "throughput"
+    pass:
+      - criteria:
+          - "<=+100%"
+          - ">=-80%"
+  - sli: "error_rate"
+total_score:
+  pass: "100%"
+  warning: "65%"`
+
+func TestConvert(t *testing.T) {
+
+}

--- a/metrics-operator/converter/slo_converter_test.go
+++ b/metrics-operator/converter/slo_converter_test.go
@@ -1,6 +1,12 @@
 package converter
 
-import "testing"
+import (
+	"testing"
+
+	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha3"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 const SLOContent = `---
 spec_version: "0.1.1"
@@ -13,15 +19,23 @@ filter:
 objectives:
   - sli: "response_time_p95"
     key_sli: false
-    pass:             # pass if (relative change <= 75% AND absolute value is < 75ms)
+    pass:
       - criteria:
-          - "<=+75%"  # relative values require a prefixed sign (plus or minus)
-          - "<800"     # absolute values only require a logical operator
-    warning:          # if the response time is below 200ms, the result should be a warning
+          - "<=+75%"
+          - "<800"
+    warning:
       - criteria:
           - "<=1000"
           - "<=+100%"
     weight: 1
+  - sli: "cpu"
+    pass:
+      - criteria:
+          - "<=+100%"
+          - ">=80"
+      - criteria:
+          - "<=+100%"
+          - ">=80"
   - sli: "throughput"
     pass:
       - criteria:
@@ -32,6 +46,459 @@ total_score:
   pass: "100%"
   warning: "65%"`
 
-func TestConvert(t *testing.T) {
+const expectedOutput = `apiVersion: metrics.keptn.sh/v1alpha3
+kind: AnalysisDefinition
+metadata:
+  creationTimestamp: null
+  name: defname
+spec:
+  objectives:
+  - analysisValueTemplateRef:
+      name: response_time_p95
+      namespace: default
+    target:
+      failure:
+        greaterThan:
+          fixedValue: 1k
+      warning:
+        greaterThanOrEqual:
+          fixedValue: "800"
+    weight: 1
+  - analysisValueTemplateRef:
+      name: cpu
+      namespace: default
+    target: {}
+  - analysisValueTemplateRef:
+      name: throughput
+      namespace: default
+    target: {}
+  - analysisValueTemplateRef:
+      name: error_rate
+      namespace: default
+    target: {}
+  totalScore:
+    passPercentage: 100
+    warningPercentage: 65
+`
 
+func TestConvertSLO(t *testing.T) {
+	c := NewSLOConverter()
+	// no provider nor namespace
+	res, err := c.Convert([]byte(SLOContent), "", "")
+	require.NotNil(t, err)
+	require.Equal(t, "", res)
+
+	// invalid file content
+	res, err = c.Convert([]byte("invalid"), "dynatrace", "keptn")
+	require.NotNil(t, err)
+	require.Equal(t, "", res)
+
+	// happy path
+	res, err = c.Convert([]byte(SLOContent), "defname", "default")
+	require.Nil(t, err)
+	require.Equal(t, expectedOutput, res)
+}
+
+func TestCreateOperator(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      string
+		value   string
+		out     *metricsapi.Operator
+		wantErr bool
+	}{
+		{
+			name:    "invalid int value",
+			op:      "",
+			value:   "val",
+			out:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "unsupported operator",
+			op:      "",
+			value:   "1",
+			out:     nil,
+			wantErr: true,
+		},
+		{
+			name:  "lessEqual operator",
+			op:    "<=",
+			value: "1",
+			out: &metricsapi.Operator{
+				GreaterThan: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "less operator",
+			op:    "<",
+			value: "1",
+			out: &metricsapi.Operator{
+				GreaterThanOrEqual: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "greaterEqual operator",
+			op:    ">=",
+			value: "1",
+			out: &metricsapi.Operator{
+				LessThan: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "greater operator",
+			op:    ">",
+			value: "1",
+			out: &metricsapi.Operator{
+				LessThanOrEqual: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := createOperator(tt.op, tt.value)
+			if tt.wantErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.out, res)
+			}
+		})
+
+	}
+}
+
+func TestSetupOperator(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      string
+		out     *metricsapi.Operator
+		wantErr bool
+	}{
+		{
+			name:    "unsupported operator",
+			op:      "",
+			out:     nil,
+			wantErr: true,
+		},
+		{
+			name: "lessEqual operator",
+			op:   "<=1",
+			out: &metricsapi.Operator{
+				GreaterThan: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "less operator",
+			op:   "<1",
+			out: &metricsapi.Operator{
+				GreaterThanOrEqual: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "greaterEqual operator",
+			op:   ">=1",
+			out: &metricsapi.Operator{
+				LessThan: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "greater operator",
+			op:   ">1",
+			out: &metricsapi.Operator{
+				LessThanOrEqual: &metricsapi.OperatorValue{
+					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := setupOperator(tt.op)
+			if tt.wantErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.out, res)
+			}
+		})
+
+	}
+}
+
+func TestShouldIgnoreObjective(t *testing.T) {
+	tests := []struct {
+		name string
+		o    *Objective
+		want bool
+	}{
+		{
+			name: "empty criteria",
+			o: &Objective{
+				Pass:    []Criteria{},
+				Warning: []Criteria{},
+			},
+			want: false,
+		},
+		{
+			name: "valid criteria",
+			o: &Objective{
+				Pass: []Criteria{
+					{
+						Operators: []string{},
+					},
+				},
+				Warning: []Criteria{
+					{
+						Operators: []string{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "OR criteria",
+			o: &Objective{
+				Pass: []Criteria{
+					{
+						Operators: []string{},
+					},
+					{
+						Operators: []string{},
+					},
+				},
+				Warning: []Criteria{
+					{
+						Operators: []string{},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldIgnoreObjective(tt.o))
+		})
+
+	}
+}
+
+func TestRemovePercentage(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "no percentage",
+			val:     "1",
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "percentage",
+			val:     "1%",
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "only percentage",
+			val:     "%",
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := removePercentage(tt.val)
+			if tt.wantErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.want, res)
+			}
+		})
+	}
+}
+
+func TestCleanupCriteria(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []Criteria
+		out  []Criteria
+	}{
+		{
+			name: "empty criteria",
+			in:   []Criteria{},
+			out:  []Criteria{},
+		},
+		{
+			name: "no criteria to clean up",
+			in: []Criteria{
+				{
+					Operators: []string{"<100"},
+				},
+			},
+			out: []Criteria{
+				{
+					Operators: []string{"<100"},
+				},
+			},
+		},
+		{
+			name: "criteria to clean up",
+			in: []Criteria{
+				{
+					Operators: []string{"<100", "<10%"},
+				},
+			},
+			out: []Criteria{
+				{
+					Operators: []string{"<100"},
+				},
+			},
+		},
+		{
+			name: "multiple criteria to clean up",
+			in: []Criteria{
+				{
+					Operators: []string{"<100", "<10%"},
+				},
+				{
+					Operators: []string{"<10%"},
+				},
+			},
+			out: []Criteria{
+				{
+					Operators: []string{"<100"},
+				},
+			},
+		},
+		{
+			name: "all criteria to clean up",
+			in: []Criteria{
+				{
+					Operators: []string{"<10%"},
+				},
+				{
+					Operators: []string{"<10%"},
+				},
+			},
+			out: []Criteria{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.out, cleanupCriteria(tt.in))
+		})
+	}
+}
+
+func TestCleanupObjective(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *Objective
+		out  *Objective
+	}{
+		{
+			name: "pass criteria to clean up",
+			in: &Objective{
+				Pass: []Criteria{
+					{
+						Operators: []string{"<100", "<10%"},
+					},
+					{
+						Operators: []string{"<10%"},
+					},
+				},
+			},
+			out: &Objective{
+				Pass: []Criteria{
+					{
+						Operators: []string{"<100"},
+					},
+				},
+				Warning: []Criteria{},
+			},
+		},
+		{
+			name: "warning criteria to clean up",
+			in: &Objective{
+				Warning: []Criteria{
+					{
+						Operators: []string{"<100", "<10%"},
+					},
+					{
+						Operators: []string{"<10%"},
+					},
+				},
+			},
+			out: &Objective{
+				Warning: []Criteria{
+					{
+						Operators: []string{"<100"},
+					},
+				},
+				Pass: []Criteria{},
+			},
+		},
+		{
+			name: "no criteria to clean up",
+			in: &Objective{
+				Warning: []Criteria{
+					{
+						Operators: []string{"<100"},
+					},
+				},
+			},
+			out: &Objective{
+				Warning: []Criteria{
+					{
+						Operators: []string{"<100"},
+					},
+				},
+				Pass: []Criteria{},
+			},
+		},
+		{
+			name: "no criteria",
+			in:   &Objective{},
+			out: &Objective{
+				Warning: []Criteria{},
+				Pass:    []Criteria{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.out, cleanupObjective(tt.in))
+		})
+	}
 }

--- a/metrics-operator/converter/slo_converter_test.go
+++ b/metrics-operator/converter/slo_converter_test.go
@@ -5,6 +5,7 @@ import (
 
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha3"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/inf.v0"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -101,6 +102,10 @@ func TestConvert(t *testing.T) {
 }
 
 func TestCreateOperator(t *testing.T) {
+	dec := inf.NewDec(1, 0)
+	_, ok := dec.SetString("1")
+	require.True(t, ok)
+
 	tests := []struct {
 		name    string
 		op      string
@@ -128,7 +133,7 @@ func TestCreateOperator(t *testing.T) {
 			value: "1",
 			out: &metricsapi.Operator{
 				GreaterThan: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -139,7 +144,7 @@ func TestCreateOperator(t *testing.T) {
 			value: "1",
 			out: &metricsapi.Operator{
 				GreaterThanOrEqual: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -150,7 +155,7 @@ func TestCreateOperator(t *testing.T) {
 			value: "1",
 			out: &metricsapi.Operator{
 				LessThan: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -161,7 +166,7 @@ func TestCreateOperator(t *testing.T) {
 			value: "1",
 			out: &metricsapi.Operator{
 				LessThanOrEqual: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -182,6 +187,10 @@ func TestCreateOperator(t *testing.T) {
 }
 
 func TestSetupOperator(t *testing.T) {
+	dec := inf.NewDec(1, 0)
+	_, ok := dec.SetString("1")
+	require.True(t, ok)
+
 	tests := []struct {
 		name    string
 		op      string
@@ -199,7 +208,7 @@ func TestSetupOperator(t *testing.T) {
 			op:   "<=1",
 			out: &metricsapi.Operator{
 				GreaterThan: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -209,7 +218,7 @@ func TestSetupOperator(t *testing.T) {
 			op:   "<1",
 			out: &metricsapi.Operator{
 				GreaterThanOrEqual: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -219,7 +228,7 @@ func TestSetupOperator(t *testing.T) {
 			op:   ">=1",
 			out: &metricsapi.Operator{
 				LessThan: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -229,7 +238,7 @@ func TestSetupOperator(t *testing.T) {
 			op:   ">1",
 			out: &metricsapi.Operator{
 				LessThanOrEqual: &metricsapi.OperatorValue{
-					FixedValue: *resource.NewQuantity(1, resource.DecimalSI),
+					FixedValue: *resource.NewDecimalQuantity(*dec, resource.DecimalSI),
 				},
 			},
 			wantErr: false,
@@ -238,7 +247,7 @@ func TestSetupOperator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := setupOperator(tt.op)
+			res, err := newOperator(tt.op)
 			if tt.wantErr {
 				require.NotNil(t, err)
 			} else {
@@ -302,7 +311,7 @@ func TestShouldIgnoreObjective(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, shouldIgnoreObjective(tt.o))
+			require.Equal(t, tt.want, tt.o.hasSupportedCriteria())
 		})
 
 	}
@@ -505,6 +514,14 @@ func TestCleanupObjective(t *testing.T) {
 }
 
 func TestSetupTarget(t *testing.T) {
+	dec10 := inf.NewDec(1, 0)
+	_, ok := dec10.SetString("10")
+	require.True(t, ok)
+
+	dec15 := inf.NewDec(1, 0)
+	_, ok = dec15.SetString("15")
+	require.True(t, ok)
+
 	tests := []struct {
 		name    string
 		o       *Objective
@@ -561,7 +578,7 @@ func TestSetupTarget(t *testing.T) {
 			want: &metricsapi.Target{
 				Failure: &metricsapi.Operator{
 					GreaterThanOrEqual: &metricsapi.OperatorValue{
-						FixedValue: *resource.NewQuantity(10, resource.DecimalSI),
+						FixedValue: *resource.NewDecimalQuantity(*dec10, resource.DecimalSI),
 					},
 				},
 			},
@@ -598,12 +615,12 @@ func TestSetupTarget(t *testing.T) {
 			want: &metricsapi.Target{
 				Failure: &metricsapi.Operator{
 					GreaterThan: &metricsapi.OperatorValue{
-						FixedValue: *resource.NewQuantity(15, resource.DecimalSI),
+						FixedValue: *resource.NewDecimalQuantity(*dec15, resource.DecimalSI),
 					},
 				},
 				Warning: &metricsapi.Operator{
 					GreaterThanOrEqual: &metricsapi.OperatorValue{
-						FixedValue: *resource.NewQuantity(10, resource.DecimalSI),
+						FixedValue: *resource.NewDecimalQuantity(*dec10, resource.DecimalSI),
 					},
 				},
 			},
@@ -660,6 +677,14 @@ func TestSetupTarget(t *testing.T) {
 }
 
 func TestConvertSLO(t *testing.T) {
+	dec10 := inf.NewDec(1, 0)
+	_, ok := dec10.SetString("10")
+	require.True(t, ok)
+
+	dec15 := inf.NewDec(1, 0)
+	_, ok = dec15.SetString("15")
+	require.True(t, ok)
+
 	c := NewSLOConverter()
 
 	tests := []struct {
@@ -777,12 +802,12 @@ func TestConvertSLO(t *testing.T) {
 							Target: metricsapi.Target{
 								Failure: &metricsapi.Operator{
 									GreaterThan: &metricsapi.OperatorValue{
-										FixedValue: *resource.NewQuantity(15, resource.DecimalSI),
+										FixedValue: *resource.NewDecimalQuantity(*dec15, resource.DecimalSI),
 									},
 								},
 								Warning: &metricsapi.Operator{
 									GreaterThanOrEqual: &metricsapi.OperatorValue{
-										FixedValue: *resource.NewQuantity(10, resource.DecimalSI),
+										FixedValue: *resource.NewDecimalQuantity(*dec10, resource.DecimalSI),
 									},
 								},
 							},
@@ -797,7 +822,7 @@ func TestConvertSLO(t *testing.T) {
 							Target: metricsapi.Target{
 								Failure: &metricsapi.Operator{
 									GreaterThanOrEqual: &metricsapi.OperatorValue{
-										FixedValue: *resource.NewQuantity(10, resource.DecimalSI),
+										FixedValue: *resource.NewDecimalQuantity(*dec10, resource.DecimalSI),
 									},
 								},
 							},

--- a/metrics-operator/converter/slo_converter_test.go
+++ b/metrics-operator/converter/slo_converter_test.go
@@ -337,6 +337,18 @@ func TestRemovePercentage(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "percentage with float - round down",
+			val:     "1.333333%",
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:    "percentage with float - round up",
+			val:     "1.833333%",
+			want:    2,
+			wantErr: false,
+		},
+		{
 			name:    "only percentage",
 			val:     "%",
 			want:    0,

--- a/metrics-operator/go.mod
+++ b/metrics-operator/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/common v0.44.0
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.26.7
 	k8s.io/apiextensions-apiserver v0.26.7
 	k8s.io/apimachinery v0.26.7
@@ -108,7 +109,6 @@ require (
 	google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd // indirect
 	google.golang.org/grpc v1.52.3 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -89,7 +89,7 @@ func main() {
 	flag.StringVar(&SLIFilePath, "convert-sli", "", "The path the the SLI file to be converted")
 	flag.StringVar(&provider, "sli-provider", "", "The name of KeptnMetricsProvider referenced in KeptnValueTemplates")
 	flag.StringVar(&namespace, "sli-namespace", "", "The namespace of the referenced KeptnMetricsProvider")
-	flag.StringVar(&SLOFilePath, "convert-slo", "", "The path the the SLI file to be converted")
+	flag.StringVar(&SLOFilePath, "convert-slo", "", "The path the the SLO file to be converted")
 	flag.StringVar(&analysisDefinition, "definition", "", "The name of AnalysisDefinition to be created")
 	flag.StringVar(&namespace, "slo-namespace", "", "The namespace of the referenced AnalysisValueTemplate")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
## Changes
 - introduced convertor for SLO files
 - unit tests
 - converter is part of metrics-operator binary under --convert-slo flag

## Usage
`./metrics-operator --convert-slo=slo.yaml --slo-namespace=default --definition=defname`

## Missing pieces
-  There is need to cover the cases when multiple criteria have logical AND operator in between them, see TODOs in `setupTarget` function and [here](https://github.com/keptn/spec/blob/master/service_level_objective.md#comparison) for more information

Part-of: #1760 