### PR TITLE
fix: fix Go badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![build](https://img.shields.io/github/actions/workflow/status/keptn/lifecycle-toolkit/CI.yaml?branch=main)
 ![Codecov](https://img.shields.io/codecov/c/github/keptn/lifecycle-toolkit?token=KPGfrBb2sA)
-![goversion](https://img.shields.io/github/go-mod/go-version/keptn/lifecycle-toolkit?filename=operator%2Fgo.mod)
+![goversion](https://img.shields.io/github/go-mod/go-version/keptn/lifecycle-toolkit?filename=lifecycle-operator/go.mod)
 ![version](https://img.shields.io/github/v/release/keptn/lifecycle-toolkit)
 [![GitHub Discussions](https://img.shields.io/github/discussions/keptn/lifecycle-toolkit)](https://github.com/keptn/lifecycle-toolkit/discussions)
 


### PR DESCRIPTION
This PR

- Fixes the broken Go version badge on the readme

<img width="598" alt="image" src="https://github.com/keptn/lifecycle-toolkit/assets/26523841/f11ab5bc-300b-452b-8df5-3a3454669a2a">

<img width="472" alt="image" src="https://github.com/keptn/lifecycle-toolkit/assets/26523841/977d7422-b8d2-47da-8f43-930904bbf445">

