### PR TITLE
ci: fix release matrix again again again again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
                 }
             });
             console.log("release matrix: " + JSON.stringify({ config: releaseMatrix }));
-            return { config: releaseMatrix };
+            return releaseMatrix.length > 0 ? { config: releaseMatrix } : {};
 
   build-release:
     if: needs.release-please.outputs.releases-created == 'true'


### PR DESCRIPTION
as a fix for https://github.com/keptn/lifecycle-toolkit/actions/runs/6085201088

This fixes scenarios where no artifacts need to be built but the release matrix still has `{config: []}` inside which means that the build steps start, but then the matrix has no content so we get an error.