### PR TITLE
feat(metrics-operator): expose analysis results as Prometheus Metric

### DIFF
--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -149,11 +149,13 @@ func (a *AnalysisReconciler) evaluateObjectives(ctx context.Context, res map[str
 }
 
 func (a *AnalysisReconciler) reportResultsAsPromMetric(eval evalType.AnalysisResult, analysis *metricsapi.Analysis) {
+	f := analysis.Spec.From.String()
+	t := analysis.Spec.To.String()
 	labelsAnalysis := prometheus.Labels{
 		"name":      analysis.Name,
 		"namespace": analysis.Namespace,
-		"from":      analysis.Spec.From.GoString(),
-		"to":        analysis.Spec.To.GoString(),
+		"from":      f,
+		"to":        t,
 	}
 	if m, err := a.Metrics.AnalysisResult.GetMetricWith(labelsAnalysis); err == nil {
 		m.Set(eval.GetAchievedPercentage())
@@ -171,6 +173,8 @@ func (a *AnalysisReconciler) reportResultsAsPromMetric(eval evalType.AnalysisRes
 			"analysis_namespace": analysis.Namespace,
 			"key_objective":      fmt.Sprintf("%v", o.Objective.KeyObjective),
 			"weight":             fmt.Sprintf("%v", o.Objective.Weight),
+			"from":               f,
+			"to":                 t,
 		}
 		if m, err := a.Metrics.ObjectiveResult.GetMetricWith(labelsObjective); err == nil {
 			m.Set(o.Value)

--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -144,7 +144,7 @@ func (a *AnalysisReconciler) evaluateObjectives(ctx context.Context, res map[str
 		analysis.Status.Warning = true
 	}
 	analysis.Status.Pass = eval.Pass
-	a.reportResultsAsPromMetric(eval, analysis)
+	go a.reportResultsAsPromMetric(eval, analysis)
 	return a.updateStatus(ctx, analysis)
 }
 

--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -156,24 +156,23 @@ func writemetric(eval evalType.AnalysisResult, analysis *metricsapi.Analysis, de
 	prometheus.MustRegister(m)
 	m.Set(eval.GetAchievedPercentage())
 	// expose also the individual objectives
-	for _, o := range def.Spec.Objectives {
-		name := o.AnalysisValueTemplateRef.Name
-		ns := o.AnalysisValueTemplateRef.Namespace
+	for _, o := range eval.ObjectiveResults {
+		name := o.Objective.AnalysisValueTemplateRef.Name
+		ns := o.Objective.AnalysisValueTemplateRef.Namespace
 		labelNames := []string{"name", "namespace", "analysis_name", "analysis_namespace", "key_objective", "weight"}
 		labels := prometheus.Labels{
 			"name":               name,
 			"namespace":          ns,
 			"analysis_name":      analysis.Name,
 			"analysis_namespace": analysis.Namespace,
-			"key_objective":      fmt.Sprintf("%v", o.KeyObjective),
-			"weight":             fmt.Sprintf("%v", o.Weight),
+			"key_objective":      fmt.Sprintf("%v", o.Objective.KeyObjective),
+			"weight":             fmt.Sprintf("%v", o.Objective.Weight),
 		}
 		g := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "keptn.analysis.objective",
 			Help: "Result of the Analysis Objective",
 		}, labelNames)
-		// TODO: link Results to Definitions
-		g.With(labels).Set(0)
+		g.With(labels).Set(o.Value)
 		prometheus.MustRegister(g)
 	}
 

--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -184,6 +184,27 @@ func (a *AnalysisReconciler) reportResultsAsPromMetric(eval evalType.AnalysisRes
 	}
 }
 
+func SetupMetric() (m Metrics, err error) {
+	labelNamesAnalysis := []string{"name", "namespace", "from", "to"}
+	a := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "keptn_analysis_result",
+		Help: "Result of Analysis",
+	}, labelNamesAnalysis)
+	err = prometheus.Register(a)
+
+	labelNames := []string{"name", "namespace", "analysis_name", "analysis_namespace", "key_objective", "weight", "from", "to"}
+	o := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "keptn_objective_result",
+		Help: "Result of the Analysis Objective",
+	}, labelNames)
+	err = prometheus.Register(o)
+
+	return Metrics{
+		AnalysisResult:  a,
+		ObjectiveResult: o,
+	}, err
+}
+
 func (a *AnalysisReconciler) updateStatus(ctx context.Context, analysis *metricsapi.Analysis) error {
 	if err := a.Client.Status().Update(ctx, analysis); err != nil {
 		a.Log.Error(err, "Failed to update the Analysis status")

--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"time"
 
 	"github.com/go-logr/logr"
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1alpha3"
 	common "github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/analysis"
 	evalType "github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/analysis/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -144,7 +144,7 @@ func (a *AnalysisReconciler) evaluateObjectives(ctx context.Context, res map[str
 		analysis.Status.Warning = true
 	}
 	analysis.Status.Pass = eval.Pass
-	go a.reportResultsAsPromMetric(eval, analysis)
+	a.reportResultsAsPromMetric(eval, analysis)
 	return a.updateStatus(ctx, analysis)
 }
 

--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -184,7 +184,9 @@ func (a *AnalysisReconciler) reportResultsAsPromMetric(eval evalType.AnalysisRes
 	}
 }
 
+//nolint:ineffassign,staticcheck
 func SetupMetric() (m Metrics, err error) {
+
 	labelNamesAnalysis := []string{"name", "namespace", "from", "to"}
 	a := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "keptn_analysis_result",

--- a/metrics-operator/controllers/common/analysis/objective_evaluator.go
+++ b/metrics-operator/controllers/common/analysis/objective_evaluator.go
@@ -20,8 +20,9 @@ func NewObjectiveEvaluator(t ITargetEvaluator) ObjectiveEvaluator {
 
 func (oe *ObjectiveEvaluator) Evaluate(values map[string]v1alpha3.ProviderResult, obj *v1alpha3.Objective) types.ObjectiveResult {
 	result := types.ObjectiveResult{
-		Score: 0.0,
-		Value: 0.0,
+		Score:     0.0,
+		Value:     0.0,
+		Objective: obj,
 	}
 
 	// get the value

--- a/metrics-operator/controllers/common/analysis/objective_evaluator_test.go
+++ b/metrics-operator/controllers/common/analysis/objective_evaluator_test.go
@@ -30,6 +30,11 @@ func TestObjectiveEvaluator_Evaluate(t *testing.T) {
 			want: types.ObjectiveResult{
 				Score: 0.0,
 				Error: fmt.Errorf("required value 'name' not available"),
+				Objective: &v1alpha3.Objective{
+					AnalysisValueTemplateRef: v1alpha3.ObjectReference{
+						Name: "name",
+					},
+				},
 			},
 		},
 		{
@@ -56,6 +61,12 @@ func TestObjectiveEvaluator_Evaluate(t *testing.T) {
 				Value: 20.0,
 				Result: types.TargetResult{
 					Pass: true,
+				},
+				Objective: &v1alpha3.Objective{
+					AnalysisValueTemplateRef: v1alpha3.ObjectReference{
+						Name: "name",
+					},
+					Weight: 2,
 				},
 			},
 		},
@@ -86,6 +97,12 @@ func TestObjectiveEvaluator_Evaluate(t *testing.T) {
 					Pass:    false,
 					Warning: true,
 				},
+				Objective: &v1alpha3.Objective{
+					AnalysisValueTemplateRef: v1alpha3.ObjectReference{
+						Name: "name",
+					},
+					Weight: 2,
+				},
 			},
 		},
 		{
@@ -114,6 +131,12 @@ func TestObjectiveEvaluator_Evaluate(t *testing.T) {
 				Result: types.TargetResult{
 					Pass:    false,
 					Warning: false,
+				},
+				Objective: &v1alpha3.Objective{
+					AnalysisValueTemplateRef: v1alpha3.ObjectReference{
+						Name: "name",
+					},
+					Weight: 2,
 				},
 			},
 		},

--- a/metrics-operator/controllers/common/analysis/types/types.go
+++ b/metrics-operator/controllers/common/analysis/types/types.go
@@ -31,10 +31,11 @@ type OperatorResult struct {
 }
 
 type ObjectiveResult struct {
-	Result TargetResult `json:"result,omitempty"`
-	Value  float64      `json:"value,omitempty"`
-	Score  float64      `json:"score,omitempty"`
-	Error  error        `json:"error,omitempty"`
+	Result    TargetResult        `json:"result,omitempty"`
+	Objective *v1alpha3.Objective `json:"objective,omitempty"`
+	Value     float64             `json:"value,omitempty"`
+	Score     float64             `json:"score,omitempty"`
+	Error     error               `json:"error,omitempty"`
 }
 
 func (o *ObjectiveResult) IsFail() bool {

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -194,7 +194,7 @@ func main() {
 			setupLog.Error(err, "unable to create metric keptn_analysis_result")
 		}
 
-		labelNames := []string{"name", "namespace", "analysis_name", "analysis_namespace", "key_objective", "weight"}
+		labelNames := []string{"name", "namespace", "analysis_name", "analysis_namespace", "key_objective", "weight", "from", "to"}
 		o := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "keptn_objective_result",
 			Help: "Result of the Analysis Objective",

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -185,7 +185,8 @@ func main() {
 		// OTel Setup
 		metrics, err := analysiscontroller.SetupMetric()
 		if err != nil {
-			setupLog.Error(err, "unable to create metric keptn_objective_result")
+			setupLog.Error(err, "unable to create metric keptn_analysis_result/keptn_objective_result")
+			os.Exit(1)
 		}
 
 		analysisLogger := ctrl.Log.WithName("KeptnAnalysis Controller")

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -186,17 +186,23 @@ func main() {
 		// OTel Setup
 		labelNamesAnalysis := []string{"name", "namespace", "from", "to"}
 		a := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "keptn.analysis.result",
+			Name: "keptn_analysis_result",
 			Help: "Result of Analysis",
 		}, labelNamesAnalysis)
-		prometheus.MustRegister(a)
+		err = prometheus.Register(a)
+		if err != nil {
+			setupLog.Error(err, "unable to create metric keptn_analysis_result")
+		}
 
 		labelNames := []string{"name", "namespace", "analysis_name", "analysis_namespace", "key_objective", "weight"}
 		o := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "keptn.objective.result",
+			Name: "keptn_objective_result",
 			Help: "Result of the Analysis Objective",
 		}, labelNames)
-		prometheus.MustRegister(o)
+		err = prometheus.Register(o)
+		if err != nil {
+			setupLog.Error(err, "unable to create metric keptn_objective_result")
+		}
 
 		analysisLogger := ctrl.Log.WithName("KeptnAnalysis Controller")
 		targetEval := analysis.NewTargetEvaluator(&analysis.OperatorEvaluator{})

--- a/metrics-operator/pkg/metrics/server.go
+++ b/metrics-operator/pkg/metrics/server.go
@@ -187,7 +187,10 @@ func (m *serverManager) recordMetrics() {
 						Name: normName,
 						Help: metric.Name,
 					})
-					prometheus.MustRegister(m.metrics.gauges[normName])
+					err := prometheus.Register(m.metrics.gauges[normName])
+					if err != nil {
+						fmt.Printf("failed to register metric %s\n", m.metrics.gauges[normName])
+					}
 				}
 				val, _ := strconv.ParseFloat(metric.Status.Value, 64)
 				m.metrics.gauges[normName].Set(val)

--- a/test/integration/analysis-controller/01-assert.yaml
+++ b/test/integration/analysis-controller/01-assert.yaml
@@ -9,4 +9,4 @@ spec:
 status:
   pass: true
   # yamllint disable-line rule:line-length
-  raw: '{"objectiveResults":[{"result":{"failResult":{"operator":{"lessThan":{"fixedValue":"2"}}},"warnResult":{"operator":{"lessThan":{"fixedValue":"3"}}},"pass":true},"value":4,"score":1}],"totalScore":1,"maximumScore":1,"pass":true}'
+  raw: '{"objectiveResults":[{"result":{"failResult":{"operator":{"lessThan":{"fixedValue":"2"}}},"warnResult":{"operator":{"lessThan":{"fixedValue":"3"}}},"pass":true},"objective":{"analysisValueTemplateRef":{"name":"ready","namespace":"keptn-lifecycle-toolkit-system"},"target":{"failure":{"lessThan":{"fixedValue":"2"}},"warning":{"lessThan":{"fixedValue":"3"}}},"weight":1},"value":4,"score":1}],"totalScore":1,"maximumScore":1,"pass":true}'


### PR DESCRIPTION
- no panic for Prometheus errors
- `keptn_analysis_result` and `keptn_objective_result` metrics are exposed
- add Objective struct to the Eval result