### PR TITLE
docs: begin official word list for Keptn documentation

### DIFF
--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -72,10 +72,10 @@ It is important to use the related terminology correctly:
   For example, "`KeptnMetric resources" or "KeptnApp resources".
 
 * The first occurence of a CRD name in a section should be a link to the
-  [CRD YAML Reference](../../../../../docs/yaml-crd-ref)
+  [CRD YAML Reference](../../../docs/yaml-crd-ref)
   page if there is one.
   Otherwise, it should be a link to the appropriate spot in the
-  [API Reference](../../../../../docs/crd-ref)
+  [API Reference](../../../docs/crd-ref)
   section.
 
 * Occurrences of a resource name that are not links to a reference page

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -60,15 +60,16 @@ It is important to use the related terminology correctly:
   of a resource that is part of the Kubernetes core
 
 * A "Custom Resource Definition (CRD)" is the definition
-  (or syntax) for defining that Custom resource.
+  (or syntax) of a resource that Keptn (or some other product) 
+  adds to Kubernetes
 
 * An instance of a CRD or RD that a user creates is a custom resource
-  or just a resource.
-  Most of the time, we recommend just using the term resource.
+  or just a resource but not a CRD or RD.
+  Most of the time, we recommend just using the term "resource".
 
 * Do not turn resource names into plurals by adding an "s".
   If you need a plural form, use the word "resources".
-  For example, "`KeptnMetric resources".
+  For example, "`KeptnMetric resources" or "KeptnApp resources".
 
 * The first occurence of a CRD name in a section should be a link to the
   [CRD YAML Reference](../../../../../docs/yaml-crd-ref)

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -67,10 +67,6 @@ It is important to use the related terminology correctly:
   or just a resource but not a CRD or RD.
   Most of the time, we recommend just using the term "resource".
 
-* Do not turn resource names into plurals by adding an "s".
-  If you need a plural form, use the word "resources".
-  For example, "`KeptnMetric resources" or "KeptnApp resources".
-
 * The first occurence of a CRD name in a section should be a link to the
   [CRD YAML Reference](../../../docs/yaml-crd-ref)
   page if there is one.

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -44,7 +44,7 @@ The earlier project is called "Keptn v1".
 
 The Keptn project is a "toolkit" with three use cases, named:
 
-* Custom metrics (or Deployment data access)
+* Metrics (or Deployment data access)
 
 * Observability (or Deployment observability)
 

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -38,7 +38,7 @@ The earlier project is called "Keptn v1".
   Use `keptn` if it is part of a command name, pathname,
   an argument to a command or function, etc.
 
-* As a project name that may be trademarked,
+* As a project name that is trademarked,
   you should not use an apostrophe-s to make it a possessive ("Keptn's")
   or hyphentate it (as in "Keptn-specific").
 

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -53,7 +53,7 @@ The Keptn project is a "toolkit" with three use cases, named:
 ## CRD, resource, etc
 
 Keptn makes extensive use of Kubernetes
-[Custom resources](https://developers.google.com/style/word-list).
+[Custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 It is important to use the related terminology correctly:
 
 * A "Resource Definition (RD)" is the definition (or syntax)

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -57,7 +57,7 @@ Keptn makes extensive use of Kubernetes
 It is important to use the related terminology correctly:
 
 * A "Resource Definition (RD)" is the definition (or syntax)
-  of a resource that is part of the Kubernetes core
+  of a resource that is part of the official Kubernetes API
 
 * A "Custom Resource Definition (CRD)" is the definition
   (or syntax) of a resource that Keptn (or some other product)

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -13,15 +13,19 @@ but should adhere to recommendations in:
 * [CNCF Style Guide](https://github.com/cncf/foundation/blob/main/style-guide.md).
 
 * The [Kubernetes documentation](https://kubernetes.io/docs/home/)
-  is a good reference for Kubernetes terms.  In particular:
+  is a good reference for Kubernetes terms.
+   In particular:
 
-  - [Concepts](https://kubernetes.io/docs/concepts/)
-  - [Reference](https://kubernetes.io/docs/reference/)
+  * [Concepts](https://kubernetes.io/docs/concepts/)
+  * [Reference](https://kubernetes.io/docs/reference/)
 
 * The [Google developer documentation style guide](https://developers.google.com/style)
-  is a comprehensive reference for technical writers.  In particular:
+  is a comprehensive reference for technical writers.
+   In particular:
 
-  - [Word list](https://developers.google.com/style/word-list)
+  * [Word list](https://developers.google.com/style/word-list)
+    includes good information about words and phrases
+    that are commonly used in technical documentation.
 
 ## Keptn project
 
@@ -29,12 +33,12 @@ This is the proper name of the project that was developed
 under the code name of "Keptn Lifecycle Toolkit (KLT)".
 The earlier project is called "Keptn v1".
 
-* Keptn is capitalized when used in prose as the name of the product,
+* Keptn is capitalized when used in prose as the name of the project,
   although the logo uses a lowercase "k".
   Use `keptn` if it is part of a command name, pathname,
   an argument to a command or function, etc.
 
-* As a product name that may be trademarked,
+* As a project name that may be trademarked,
   you should not use an apostrophe-s to make it a possessive ("Keptn's")
   or hyphentate it (as in "Keptn-specific").
 

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -1,0 +1,77 @@
+---
+title: Word list
+description: Proper use of terms for the Keptn project documentation
+weight: 800
+---
+
+This document summarizes information
+about the proper use of terminology for the Keptn project.
+
+The Keptn project does not maintain a formal style guide
+but should adhere to recommendations in:
+
+* [CNCF Style Guide](https://github.com/cncf/foundation/blob/main/style-guide.md).
+
+* The [Kubernetes documentation](https://kubernetes.io/docs/home/)
+  is a good reference for Kubernetes terms.  In particular:
+
+  - [Concepts](https://kubernetes.io/docs/concepts/)
+  - [Reference](https://kubernetes.io/docs/reference/)
+
+* The [Google developer documentation style guide](https://developers.google.com/style)
+  is a comprehensive reference for technical writers.  In particular:
+
+  - [Word list](https://developers.google.com/style/word-list)
+
+## Keptn project
+
+This is the proper name of the project that was developed
+under the code name of "Keptn Lifecycle Toolkit (KLT)".
+The earlier project is called "Keptn v1".
+
+* Keptn is capitalized when used in prose as the name of the product,
+  although the logo uses a lowercase "k".
+  Use `keptn` if it is part of a command name, pathname,
+  an argument to a command or function, etc.
+
+* As a product name that may be trademarked,
+  you should not use an apostrophe-s to make it a possessive ("Keptn's")
+  or hyphentate it (as in "Keptn-specific").
+
+The Keptn project is a "toolkit" with three use cases, named:
+
+* Custom metrics (or Deployment data access)
+
+* Observability (or Deployment observability)
+
+* Release lifecycle management (or Orchestrate deployment checks)
+
+## CRD, resource, etc
+
+Keptn makes extensive use of Kubernetes
+[Custom resources](https://developers.google.com/style/word-list).
+It is important to use the related terminology correctly:
+
+* A "Resource Definition (RD)" is the definition (or syntax)
+  of a resource that is part of the Kubernetes core
+
+* A "Custom Resource Definition (CRD)" is the definition
+  (or syntax) for defining that Custom resource.
+
+* An instance of a CRD or RD that a user creates is a custom resource
+  or just a resource.
+  Most of the time, we recommend just using the term resource.
+
+* Do not turn resource names into plurals by adding an "s".
+  If you need a plural form, use the word "resources".
+  For example, "`KeptnMetric resources".
+
+* The first occurence of a CRD name in a section should be a link to the
+  [CRD YAML Reference](../../../../../docs/yaml-crd-ref)
+  page if there is one.
+  Otherwise, it should be a link to the appropriate spot in the
+  [API Reference](../../../../../docs/crd-ref)
+  section.
+
+* Occurrences of a resource name that are not links to a reference page
+  should be enclosed in tics so they render as code-case.

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -25,7 +25,7 @@ but should adhere to recommendations in:
 
   * [Word list](https://developers.google.com/style/word-list)
     includes good information about words and phrases
-    that are commonly used in technical documentation.
+    that are commonly used in technical documentation
 
 ## Keptn project
 

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -60,7 +60,7 @@ It is important to use the related terminology correctly:
   of a resource that is part of the Kubernetes core
 
 * A "Custom Resource Definition (CRD)" is the definition
-  (or syntax) of a resource that Keptn (or some other product) 
+  (or syntax) of a resource that Keptn (or some other product)
   adds to Kubernetes
 
 * An instance of a CRD or RD that a user creates is a custom resource


### PR DESCRIPTION
Closes https://github.com/keptn/lifecycle-toolkit/issues/812

This is the beginning of an "official" list of terminology and how to use it in Keptn docs.  I don't see us ever doing a big effort to come up with such a list but, by starting the list, we can add to it as issues arise.

This first iteration has two entries: Keptn and CRD/resources.  See if you agree with what I wrote here.  Also suggests other terms that should be included now.