### PR TITLE
docs: fix xref to cert-manager page

### DIFF
--- a/docs/content/en/docs/concepts/architecture/cert-manager.md
+++ b/docs/content/en/docs/concepts/architecture/cert-manager.md
@@ -11,7 +11,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 The Keptn Cert Manager automatically configures TLS certificates to
 [secure communication with the Kubernetes API](https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security).
 You can instead
-[configure your own certificate manager](https://lifecycle.keptn.sh/docs/install/cert-manager/)
+[configure Keptn to use cert-manager.io](../../operate/cert-manager/)
 for this purpose.
 
 Keptn includes a Mutating Webhook

--- a/docs/content/en/docs/concepts/architecture/cert-manager.md
+++ b/docs/content/en/docs/concepts/architecture/cert-manager.md
@@ -11,7 +11,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 The Keptn Cert Manager automatically configures TLS certificates to
 [secure communication with the Kubernetes API](https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security).
 You can instead
-[configure Keptn to use cert-manager.io](../../../operate/cert-manager/)
+[configure Keptn to use cert-manager.io](../../operate/cert-manager.md)
 for this purpose.
 
 Keptn includes a Mutating Webhook

--- a/docs/content/en/docs/concepts/architecture/cert-manager.md
+++ b/docs/content/en/docs/concepts/architecture/cert-manager.md
@@ -11,7 +11,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 The Keptn Cert Manager automatically configures TLS certificates to
 [secure communication with the Kubernetes API](https://kubernetes.io/docs/concepts/security/controlling-access/#transport-security).
 You can instead
-[configure Keptn to use cert-manager.io](../../operate/cert-manager/)
+[configure Keptn to use cert-manager.io](../../../operate/cert-manager/)
 for this purpose.
 
 Keptn includes a Mutating Webhook


### PR DESCRIPTION
The Architecture page for cert-manager was pointing to the old location for information about replacing the Keptn cert-manager with cert-manager.io.  This fixes that.