### PR TITLE
docs: improve getting started guide

### DIFF
--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -77,10 +77,6 @@ Apply the file and restart Keptn to pick up the new config:
 
 ```shell
 kubectl apply -f collectorconfig.yaml
-kubectl rollout restart deployment -n keptn-lifecycle-toolkit-system -l control-plane=lifecycle-operator
-kubectl rollout status deployment -n keptn-lifecycle-toolkit-system -l control-plane=lifecycle-operator --watch
-kubectl rollout restart deployment -n keptn-lifecycle-toolkit-system -l component=scheduler
-kubectl rollout status deployment -n keptn-lifecycle-toolkit-system -l component=scheduler --watch
 ```
 
 ## Step 2: Create Namespace for Demo Application
@@ -331,10 +327,10 @@ Create some Keptn Grafana dashboards that will be available when Grafana is inst
 <!---x-release-please-start-version-->
 ```shell
 kubectl create ns monitoring
-kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.1/examples/support/observability/config/prometheus/grafana-config.yaml
-kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.1/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
-kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.1/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
-kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.1/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
+kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.2/examples/support/observability/config/prometheus/grafana-config.yaml
+kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.2/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
+kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.2/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
+kubectl apply -f https://raw.githubusercontent.com/keptn/lifecycle-toolkit/klt-v0.8.2/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
 ```
 <!---x-release-please-end-->
 
@@ -412,7 +408,7 @@ prometheus:
       - job_name: "scrape_klt"
         scrape_interval: 5s
         static_configs:
-          - targets: ['keptn-klt-lifecycle-operator-metrics-service.keptn-lifecycle-toolkit-system.svc.cluster.local:2222']
+          - targets: ['lifecycle-operator-metrics-service.keptn-lifecycle-toolkit-system.svc.cluster.local:2222']
 ```
 
 ```shell

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,7 +26,8 @@
         "helm/chart/Chart.yaml",
         "Makefile",
         "helm/chart/values.yaml",
-        "helm/chart/README.md"
+        "helm/chart/README.md",
+        "docs/content/en/docs/getting-started/_index.md"
       ]
     },
     "klt-cert-manager": {


### PR DESCRIPTION
### This PR
- removes the `rollout restart` commands since they are not needed
- fixes the klt tag version for the examples files
- fixes the service name in the prometheus helm values
- fixes release-please not updating the tag in the examples urls