### PR TITLE
fix(metrics-operator): introduce `.status.state` in Analysis

### DIFF
--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -241,6 +241,10 @@ spec:
               raw:
                 description: Raw contains the raw result of the SLO computation
                 type: string
+              state:
+                default: Pending
+                description: State describes the current state of the Analysis
+                type: string
               storedValues:
                 additionalProperties:
                   description: ProviderResult stores reference of already collected
@@ -273,6 +277,8 @@ spec:
               warning:
                 description: Warning returns whether the analysis returned a warning
                 type: boolean
+            required:
+            - state
             type: object
         type: object
     served: true

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -162,6 +162,9 @@ spec:
     - jsonPath: .spec.analysisDefinition.name
       name: AnalysisDefinition
       type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .status.warning
       name: Warning
       type: string

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -245,7 +245,7 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
-                description: State describes the current state of the Analysis
+                description: State describes the current state of the Analysis (Pending/Progressing/Completed)
                 type: string
               storedValues:
                 additionalProperties:

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -245,7 +245,6 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
-                default: Pending
                 description: State describes the current state of the Analysis
                 type: string
               storedValues:

--- a/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
+++ b/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
@@ -129,7 +129,7 @@ _Appears in:_
 
 _Underlying type:_ `string`
 
-
+AnalysisState represents the state of the analysis
 
 _Appears in:_
 - [AnalysisStatus](#analysisstatus)

--- a/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
+++ b/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
@@ -150,7 +150,7 @@ _Appears in:_
 | `raw` _string_ | Raw contains the raw result of the SLO computation |
 | `pass` _boolean_ | Pass returns whether the SLO is satisfied |
 | `warning` _boolean_ | Warning returns whether the analysis returned a warning |
-| `state` _[AnalysisState](#analysisstate)_ | State describes the current state of the Analysis |
+| `state` _[AnalysisState](#analysisstate)_ | State describes the current state of the Analysis (Pending/Progressing/Completed) |
 | `storedValues` _object (keys:string, values:[ProviderResult](#providerresult))_ | StoredValues contains all analysis values that have already been retrieved successfully |
 
 

--- a/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
+++ b/docs/content/en/docs/crd-ref/metrics/v1alpha3/_index.md
@@ -125,6 +125,17 @@ _Appears in:_
 | `analysisDefinition` _[ObjectReference](#objectreference)_ | AnalysisDefinition refers to the AnalysisDefinition, a CRD that stores the AnalysisValuesTemplates |
 
 
+#### AnalysisState
+
+_Underlying type:_ `string`
+
+
+
+_Appears in:_
+- [AnalysisStatus](#analysisstatus)
+
+
+
 #### AnalysisStatus
 
 
@@ -139,6 +150,7 @@ _Appears in:_
 | `raw` _string_ | Raw contains the raw result of the SLO computation |
 | `pass` _boolean_ | Pass returns whether the SLO is satisfied |
 | `warning` _boolean_ | Warning returns whether the analysis returned a warning |
+| `state` _[AnalysisState](#analysisstate)_ | State describes the current state of the Analysis |
 | `storedValues` _object (keys:string, values:[ProviderResult](#providerresult))_ | StoredValues contains all analysis values that have already been retrieved successfully |
 
 

--- a/helm/chart/templates/analysis-crd.yaml
+++ b/helm/chart/templates/analysis-crd.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .spec.analysisDefinition.name
       name: AnalysisDefinition
       type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .status.warning
       name: Warning
       type: string

--- a/helm/chart/templates/analysis-crd.yaml
+++ b/helm/chart/templates/analysis-crd.yaml
@@ -106,7 +106,6 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
-                default: Pending
                 description: State describes the current state of the Analysis
                 type: string
               storedValues:

--- a/helm/chart/templates/analysis-crd.yaml
+++ b/helm/chart/templates/analysis-crd.yaml
@@ -102,6 +102,10 @@ spec:
               raw:
                 description: Raw contains the raw result of the SLO computation
                 type: string
+              state:
+                default: Pending
+                description: State describes the current state of the Analysis
+                type: string
               storedValues:
                 additionalProperties:
                   description: ProviderResult stores reference of already collected
@@ -134,6 +138,8 @@ spec:
               warning:
                 description: Warning returns whether the analysis returned a warning
                 type: boolean
+            required:
+            - state
             type: object
         type: object
     served: true

--- a/helm/chart/templates/analysis-crd.yaml
+++ b/helm/chart/templates/analysis-crd.yaml
@@ -106,7 +106,7 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
-                description: State describes the current state of the Analysis
+                description: State describes the current state of the Analysis (Pending/Progressing/Completed)
                 type: string
               storedValues:
                 additionalProperties:

--- a/metrics-operator/api/v1alpha3/analysis_types.go
+++ b/metrics-operator/api/v1alpha3/analysis_types.go
@@ -45,9 +45,9 @@ type AnalysisStatus struct {
 	// Raw contains the raw result of the SLO computation
 	Raw string `json:"raw,omitempty"`
 	// Pass returns whether the SLO is satisfied
-	Pass bool `json:"pass"`
+	Pass bool `json:"pass,omitempty"`
 	// Warning returns whether the analysis returned a warning
-	Warning bool `json:"warning"`
+	Warning bool `json:"warning,omitempty"`
 	// State describes the current state of the Analysis
 	// +kubebuilder:default:=Pending
 	State AnalysisState `json:"state"`

--- a/metrics-operator/api/v1alpha3/analysis_types.go
+++ b/metrics-operator/api/v1alpha3/analysis_types.go
@@ -58,6 +58,7 @@ type AnalysisStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="AnalysisDefinition",type=string,JSONPath=.spec.analysisDefinition.name
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 //+kubebuilder:printcolumn:name="Warning",type=string,JSONPath=`.status.warning`
 //+kubebuilder:printcolumn:name="Pass",type=string,JSONPath=`.status.pass`
 

--- a/metrics-operator/api/v1alpha3/analysis_types.go
+++ b/metrics-operator/api/v1alpha3/analysis_types.go
@@ -48,7 +48,7 @@ type AnalysisStatus struct {
 	Pass bool `json:"pass,omitempty"`
 	// Warning returns whether the analysis returned a warning
 	Warning bool `json:"warning,omitempty"`
-	// State describes the current state of the Analysis
+	// State describes the current state of the Analysis (Pending/Progressing/Completed)
 	State AnalysisState `json:"state"`
 	// StoredValues contains all analysis values that have already been retrieved successfully
 	StoredValues map[string]ProviderResult `json:"storedValues,omitempty"`

--- a/metrics-operator/api/v1alpha3/analysis_types.go
+++ b/metrics-operator/api/v1alpha3/analysis_types.go
@@ -45,9 +45,12 @@ type AnalysisStatus struct {
 	// Raw contains the raw result of the SLO computation
 	Raw string `json:"raw,omitempty"`
 	// Pass returns whether the SLO is satisfied
-	Pass bool `json:"pass,omitempty"`
+	Pass bool `json:"pass"`
 	// Warning returns whether the analysis returned a warning
-	Warning bool `json:"warning,omitempty"`
+	Warning bool `json:"warning"`
+	// State describes the current state of the Analysis
+	// +kubebuilder:default:=Pending
+	State AnalysisState `json:"state"`
 	// StoredValues contains all analysis values that have already been retrieved successfully
 	StoredValues map[string]ProviderResult `json:"storedValues,omitempty"`
 }

--- a/metrics-operator/api/v1alpha3/analysis_types.go
+++ b/metrics-operator/api/v1alpha3/analysis_types.go
@@ -49,7 +49,6 @@ type AnalysisStatus struct {
 	// Warning returns whether the analysis returned a warning
 	Warning bool `json:"warning,omitempty"`
 	// State describes the current state of the Analysis
-	// +kubebuilder:default:=Pending
 	State AnalysisState `json:"state"`
 	// StoredValues contains all analysis values that have already been retrieved successfully
 	StoredValues map[string]ProviderResult `json:"storedValues,omitempty"`

--- a/metrics-operator/api/v1alpha3/common.go
+++ b/metrics-operator/api/v1alpha3/common.go
@@ -29,7 +29,7 @@ const (
 )
 
 func (s AnalysisState) IsPending() bool {
-	return s == StatePending
+	return s == StatePending || s == ""
 }
 
 func (s AnalysisState) IsCompleted() bool {

--- a/metrics-operator/api/v1alpha3/common.go
+++ b/metrics-operator/api/v1alpha3/common.go
@@ -31,3 +31,7 @@ const (
 func (s AnalysisState) IsPending() bool {
 	return s == StatePending
 }
+
+func (s AnalysisState) IsCompleted() bool {
+	return s == StateCompleted
+}

--- a/metrics-operator/api/v1alpha3/common.go
+++ b/metrics-operator/api/v1alpha3/common.go
@@ -18,3 +18,15 @@ func (o *ObjectReference) GetNamespace(defaultNamespace string) string {
 
 	return defaultNamespace
 }
+
+type AnalysisState string
+
+const (
+	StatePending     AnalysisState = "Pending"
+	StateProgressing AnalysisState = "Progressing"
+	StateCompleted   AnalysisState = "Completed"
+)
+
+func (s AnalysisState) IsPending() bool {
+	return s == StatePending
+}

--- a/metrics-operator/api/v1alpha3/common.go
+++ b/metrics-operator/api/v1alpha3/common.go
@@ -19,6 +19,7 @@ func (o *ObjectReference) GetNamespace(defaultNamespace string) string {
 	return defaultNamespace
 }
 
+// AnalysisState represents the state of the analysis
 type AnalysisState string
 
 const (

--- a/metrics-operator/api/v1alpha3/common_test.go
+++ b/metrics-operator/api/v1alpha3/common_test.go
@@ -25,3 +25,11 @@ func TestObjectReference_GetNamespace(t *testing.T) {
 
 	require.Equal(t, "ns", o.GetNamespace("default"))
 }
+
+func TestAnalysisState_IsPending(t *testing.T) {
+	a := StatePending
+	require.True(t, a.IsPending())
+
+	a = StateCompleted
+	require.False(t, a.IsPending())
+}

--- a/metrics-operator/api/v1alpha3/common_test.go
+++ b/metrics-operator/api/v1alpha3/common_test.go
@@ -30,6 +30,9 @@ func TestAnalysisState_IsPending(t *testing.T) {
 	a := StatePending
 	require.True(t, a.IsPending())
 
+	a = ""
+	require.True(t, a.IsPending())
+
 	a = StateCompleted
 	require.False(t, a.IsPending())
 }

--- a/metrics-operator/api/v1alpha3/common_test.go
+++ b/metrics-operator/api/v1alpha3/common_test.go
@@ -33,3 +33,11 @@ func TestAnalysisState_IsPending(t *testing.T) {
 	a = StateCompleted
 	require.False(t, a.IsPending())
 }
+
+func TestAnalysisState_IsCompleted(t *testing.T) {
+	a := StateCompleted
+	require.True(t, a.IsCompleted())
+
+	a = StateProgressing
+	require.False(t, a.IsCompleted())
+}

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
@@ -101,7 +101,7 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
-                description: State describes the current state of the Analysis
+                description: State describes the current state of the Analysis (Pending/Progressing/Completed)
                 type: string
               storedValues:
                 additionalProperties:

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .spec.analysisDefinition.name
       name: AnalysisDefinition
       type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
     - jsonPath: .status.warning
       name: Warning
       type: string

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
@@ -98,6 +98,7 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
+                default: Pending
                 description: State describes the current state of the Analysis
                 type: string
               storedValues:
@@ -133,9 +134,7 @@ spec:
                 description: Warning returns whether the analysis returned a warning
                 type: boolean
             required:
-            - pass
             - state
-            - warning
             type: object
         type: object
     served: true

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
@@ -97,6 +97,9 @@ spec:
               raw:
                 description: Raw contains the raw result of the SLO computation
                 type: string
+              state:
+                description: State describes the current state of the Analysis
+                type: string
               storedValues:
                 additionalProperties:
                   description: ProviderResult stores reference of already collected
@@ -129,6 +132,10 @@ spec:
               warning:
                 description: Warning returns whether the analysis returned a warning
                 type: boolean
+            required:
+            - pass
+            - state
+            - warning
             type: object
         type: object
     served: true

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_analyses.yaml
@@ -101,7 +101,6 @@ spec:
                 description: Raw contains the raw result of the SLO computation
                 type: string
               state:
-                default: Pending
                 description: State describes the current state of the Analysis
                 type: string
               storedValues:

--- a/metrics-operator/controllers/analysis/controller.go
+++ b/metrics-operator/controllers/analysis/controller.go
@@ -72,6 +72,10 @@ func (a *AnalysisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	if analysis.Status.State.IsCompleted() {
+		return ctrl.Result{}, nil
+	}
+
 	//find AnalysisDefinition to have the collection of Objectives
 	analysisDef, err := a.retrieveAnalysisDefinition(ctx, analysis)
 	if err != nil {

--- a/metrics-operator/controllers/analysis/controller_test.go
+++ b/metrics-operator/controllers/analysis/controller_test.go
@@ -51,6 +51,36 @@ func TestAnalysisReconciler_Reconcile_BasicControlLoop(t *testing.T) {
 		},
 	}
 
+	analysisCompleted := metricsapi.Analysis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-analysis",
+			Namespace: "default",
+		},
+		Spec: metricsapi.AnalysisSpec{
+			Timeframe: metricsapi.Timeframe{
+				From: metav1.Time{
+					Time: time.Now(),
+				},
+				To: metav1.Time{
+					Time: time.Now(),
+				},
+			},
+			Args: map[string]string{
+				"good": "good",
+				"dot":  ".",
+			},
+			AnalysisDefinition: metricsapi.ObjectReference{
+				Name:      "my-analysis-def",
+				Namespace: "default",
+			},
+		},
+		Status: metricsapi.AnalysisStatus{
+			State: metricsapi.StateCompleted,
+			Raw:   "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}",
+			Pass:  true,
+		},
+	}
+
 	analysisDef2 := metricsapi.AnalysisDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-analysis-def",
@@ -139,6 +169,11 @@ func TestAnalysisReconciler_Reconcile_BasicControlLoop(t *testing.T) {
 			status:      &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
 			res:         metricstypes.AnalysisResult{Pass: true},
 			mockFactory: mockFactory,
+		}, {
+			name:    "already completed analysis",
+			client:  fake2.NewClient(&analysisCompleted),
+			want:    controllerruntime.Result{},
+			wantErr: false,
 		}, {
 			name:        "succeeded - analysis in different namespace, status updated",
 			client:      fake2.NewClient(&analysis2, &analysisDef2, &template),

--- a/metrics-operator/controllers/analysis/controller_test.go
+++ b/metrics-operator/controllers/analysis/controller_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -73,46 +74,6 @@ func TestAnalysisReconciler_Reconcile_BasicControlLoop(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name    string
-		client  client.Client
-		req     controllerruntime.Request
-		want    controllerruntime.Result
-		wantErr bool
-		status  *metricsapi.AnalysisStatus
-		res     metricstypes.AnalysisResult
-	}{
-		{
-			name:    "analysis does not exist, reconcile no status update",
-			client:  fake2.NewClient(),
-			want:    controllerruntime.Result{},
-			wantErr: false,
-			status:  nil,
-			res:     metricstypes.AnalysisResult{},
-		}, {
-			name:    "analysisDefinition does not exist, requeue no status update",
-			client:  fake2.NewClient(&analysis),
-			want:    controllerruntime.Result{Requeue: true, RequeueAfter: 10 * time.Second},
-			wantErr: false,
-			status:  &metricsapi.AnalysisStatus{},
-			res:     metricstypes.AnalysisResult{Pass: false},
-		}, {
-			name:    "succeeded, status updated",
-			client:  fake2.NewClient(&analysis, &analysisDef, &template),
-			want:    controllerruntime.Result{},
-			wantErr: false,
-			status:  &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
-			res:     metricstypes.AnalysisResult{Pass: true},
-		}, {
-			name:    "succeeded - analysis in different namespace, status updated",
-			client:  fake2.NewClient(&analysis2, &analysisDef2, &template),
-			want:    controllerruntime.Result{},
-			wantErr: false,
-			status:  &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
-			res:     metricstypes.AnalysisResult{Pass: true},
-		},
-	}
-
 	req := controllerruntime.Request{
 		NamespacedName: types.NamespacedName{Namespace: "default", Name: "my-analysis"},
 	}
@@ -125,6 +86,70 @@ func TestAnalysisReconciler_Reconcile_BasicControlLoop(t *testing.T) {
 		return ctx, &mymock
 	}
 
+	tests := []struct {
+		name        string
+		client      client.Client
+		req         controllerruntime.Request
+		want        controllerruntime.Result
+		wantErr     bool
+		status      *metricsapi.AnalysisStatus
+		res         metricstypes.AnalysisResult
+		mockFactory NewWorkersPoolFactory
+	}{
+		{
+			name:        "analysis does not exist, reconcile no status update",
+			client:      fake2.NewClient(),
+			want:        controllerruntime.Result{},
+			wantErr:     false,
+			status:      nil,
+			res:         metricstypes.AnalysisResult{},
+			mockFactory: mockFactory,
+		}, {
+			name:    "analysisDefinition does not exist, requeue no status update",
+			client:  fake2.NewClient(&analysis),
+			want:    controllerruntime.Result{Requeue: true, RequeueAfter: 10 * time.Second},
+			wantErr: false,
+			status: &metricsapi.AnalysisStatus{
+				State: metricsapi.StatePending,
+			},
+			res:         metricstypes.AnalysisResult{Pass: false},
+			mockFactory: mockFactory,
+		}, {
+			name:    "mockfactory failed",
+			client:  fake2.NewClient(&analysis, &analysisDef, &template),
+			want:    controllerruntime.Result{Requeue: true, RequeueAfter: 10 * time.Second},
+			wantErr: false,
+			status: &metricsapi.AnalysisStatus{
+				State: metricsapi.StateProgressing,
+			},
+			res: metricstypes.AnalysisResult{Pass: false},
+			mockFactory: func(ctx context.Context, analysisMoqParam *metricsapi.Analysis, obj []metricsapi.Objective, numWorkers int, c client.Client, log logr.Logger, namespace string) (context.Context, IAnalysisPool) {
+				mymock := fake.IAnalysisPoolMock{
+					DispatchAndCollectFunc: func(ctx context.Context) (map[string]metricsapi.ProviderResult, error) {
+						return map[string]metricsapi.ProviderResult{}, fmt.Errorf("error")
+					},
+				}
+				return ctx, &mymock
+			},
+		}, {
+			name:        "succeeded, status updated",
+			client:      fake2.NewClient(&analysis, &analysisDef, &template),
+			want:        controllerruntime.Result{},
+			wantErr:     false,
+			status:      &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
+			res:         metricstypes.AnalysisResult{Pass: true},
+			mockFactory: mockFactory,
+		}, {
+			name:        "succeeded - analysis in different namespace, status updated",
+			client:      fake2.NewClient(&analysis2, &analysisDef2, &template),
+			want:        controllerruntime.Result{},
+			wantErr:     false,
+			status:      &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
+			res:         metricstypes.AnalysisResult{Pass: true},
+			mockFactory: mockFactory,
+		},
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &AnalysisReconciler{
@@ -132,7 +157,7 @@ func TestAnalysisReconciler_Reconcile_BasicControlLoop(t *testing.T) {
 				Scheme:                tt.client.Scheme(),
 				Log:                   testr.New(t),
 				MaxWorkers:            2,
-				NewWorkersPoolFactory: mockFactory,
+				NewWorkersPoolFactory: tt.mockFactory,
 				IAnalysisEvaluator: &fakeEvaluator.IAnalysisEvaluatorMock{
 					EvaluateFunc: func(values map[string]metricsapi.ProviderResult, ad *metricsapi.AnalysisDefinition) metricstypes.AnalysisResult {
 						return tt.res
@@ -234,6 +259,9 @@ func getTestCRDs() (metricsapi.Analysis, metricsapi.AnalysisDefinition, metricsa
 				Name:      "my-analysis-def",
 				Namespace: "default",
 			},
+		},
+		Status: metricsapi.AnalysisStatus{
+			State: metricsapi.StatePending,
 		},
 	}
 

--- a/metrics-operator/controllers/analysis/controller_test.go
+++ b/metrics-operator/controllers/analysis/controller_test.go
@@ -101,14 +101,14 @@ func TestAnalysisReconciler_Reconcile_BasicControlLoop(t *testing.T) {
 			client:  fake2.NewClient(&analysis, &analysisDef, &template),
 			want:    controllerruntime.Result{},
 			wantErr: false,
-			status:  &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true},
+			status:  &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
 			res:     metricstypes.AnalysisResult{Pass: true},
 		}, {
 			name:    "succeeded - analysis in different namespace, status updated",
 			client:  fake2.NewClient(&analysis2, &analysisDef2, &template),
 			want:    controllerruntime.Result{},
 			wantErr: false,
-			status:  &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true},
+			status:  &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted},
 			res:     metricstypes.AnalysisResult{Pass: true},
 		},
 	}
@@ -197,7 +197,7 @@ func TestAnalysisReconciler_ExistingAnalysisStatusIsFlushedWhenEvaluationFinishe
 		NamespacedName: types.NamespacedName{Namespace: "default", Name: "my-analysis"},
 	}
 
-	status := &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true}
+	status := &metricsapi.AnalysisStatus{Raw: "{\"objectiveResults\":null,\"totalScore\":0,\"maximumScore\":0,\"pass\":true,\"warning\":false}", Pass: true, State: metricsapi.StateCompleted}
 
 	got, err := a.Reconcile(context.TODO(), req)
 

--- a/metrics-operator/controllers/analysis/worker_pool_test.go
+++ b/metrics-operator/controllers/analysis/worker_pool_test.go
@@ -27,7 +27,12 @@ func TestNewWorkerPool(t *testing.T) {
 		numJobs:    1,
 	}
 
-	_, got := NewWorkersPool(context.TODO(), &analysis, objs, 4, nil, log, "default")
+	// no objectives to evaluate
+	_, got := NewWorkersPool(context.TODO(), &analysis, []metricsapi.Objective{}, 4, nil, log, "default")
+	require.Equal(t, 0, got.(WorkersPool).numWorkers)
+	require.Equal(t, 0, got.(WorkersPool).numJobs)
+
+	_, got = NewWorkersPool(context.TODO(), &analysis, objs, 4, nil, log, "default")
 	//make sure never to create more workers than needed
 	require.Equal(t, want.numJobs, got.(WorkersPool).numWorkers)
 	//make sure all objectives are processed

--- a/test/integration/analysis-controller/01-assert.yaml
+++ b/test/integration/analysis-controller/01-assert.yaml
@@ -7,5 +7,6 @@ spec:
     name: ed-my-proj-dev-svc1
 status:
   pass: true
+  state: Completed
   # yamllint disable-line rule:line-length
   raw: '{"objectiveResults":[{"result":{"failResult":{"operator":{"lessThan":{"fixedValue":"2"}},"fulfilled":false},"warnResult":{"operator":{"lessThan":{"fixedValue":"3"}},"fulfilled":false},"warning":false,"pass":true},"value":4,"score":1}],"totalScore":1,"maximumScore":1,"pass":true,"warning":false}'

--- a/test/integration/analysis/00-assert.yaml
+++ b/test/integration/analysis/00-assert.yaml
@@ -19,3 +19,5 @@ spec:
     foo: bar # can be any key/value pair; NOT only project/stage/service
   analysisDefinition:
     name: ed-my-proj-dev-svc1
+status:
+  state: Pending

--- a/test/integration/analysis/00-assert.yaml
+++ b/test/integration/analysis/00-assert.yaml
@@ -19,5 +19,3 @@ spec:
     foo: bar # can be any key/value pair; NOT only project/stage/service
   analysisDefinition:
     name: ed-my-proj-dev-svc1
-status:
-  state: Pending


### PR DESCRIPTION
## Changes
- introduce `.status.state` in `Analysis` CRD
- refactor analysis controller logic to make it testable
- add unit tests
- integration tests

Fixes: #2044 