### PR TITLE
docs: add content to implementing/evaluations

### DIFF
--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -72,6 +72,6 @@ Note the following:
   These evaluations run in parallel so the failure of one evaluation
   has no effect on whether other evaluations are completed.
 * The results of each evaluation
-  are written to a
+  is written to a
   [KeptnEvaluation](../crd-ref/lifecycle/v1alpha3/#keptnevaluation)
   resource.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -6,7 +6,7 @@ weight: 150
 
 A
 [KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
-resource contains a series of `objectives`,
+resource contains a list of `objectives`,
 each of which checks whether a defined `KeptnMetric` resource
 meets a defined target value.
 The example

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -70,7 +70,7 @@ Note the following:
 * You can define multiple `KeptnEvaluationDefinition` resources
   for each stage (pre- and post-deployment).
   These evaluations run in parallel so the failure of one evaluation
-  has no effect on whether other `KeptnEvaluationDefinition` resources are completed.
+  has no effect on whether other evaluations are completed.
 * The results of each `KeptnEvaluationDefinition` execution
   are written to a
   [KeptnEvaluation](../crd-ref/lifecycle/v1alpha3/#keptnevaluation)

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -28,7 +28,7 @@ spec:
 The `evaluationTarget` is set to be `>4`,
 so this evaluation ensures that more than 4 CPUs are available
 before the workload or application is deployed.
- 
+
 The example
 [metric.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/metric.yaml)
 file defines the

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -60,7 +60,7 @@ Note the following:
 * The `KeptnMetric` resources that are referenced
   in a `KeptnEvaluationDefinition` resource
   * can be defined on different namespaces in the cluster
-  * can query different instances of different types of data providers
+  * can query different instances of different types of metric providers
 * All objectives within a `KeptnEvaluationDefinition` resource
   are evaluated in order.
   If the evaluation of an objective fails,

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -3,7 +3,7 @@ title: Evaluations
 description: Understand Keptn evaluations and how to use them
 weight: 150
 ---
-A `KeptnEvaluation` is a `KeptnMetric` that has a defined target value.
+A `KeptnEvaluation` checks whether a `KeptnMetric` meets a defined target value.
 A `KeptnEvaluation` resource is defined in a
 [KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
 yaml file.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -3,10 +3,12 @@ title: Evaluations
 description: Understand Keptn evaluations and how to use them
 weight: 150
 ---
-A `KeptnEvaluation` checks whether a value in `KeptnMetric` meets a defined target value defined in `KeptnEvaluationDefinition`.
-A `KeptnEvaluationDefinition` resource is defined in a
+
+A
 [KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
-yaml file.
+resource contains a series of `objectives`,
+each of which checks whether a defined `KeptnMetric` resource
+meets a defined target value.
 The example
 [app-pre-deploy-eval.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-3/app-pre-deploy-eval.yaml)
 file specifies the `app-pre-deploy-eval-2` evaluation as follows:
@@ -37,14 +39,15 @@ you must:
   [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
   and
   [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
-  to include each evaluation and task you want to run
+  to identify the `KeptnEvaluationDefinition` resource you want to run
   pre- and post-deployment for the specific workloads.
 * Manually edit all
   [KeptnApp](../yaml-crd-ref/app.md) resources
-  to specify the evaluations to be run
+  to specify the `KeptnEvaluationDefinition` to be run
   pre- and post-deployment for the `KeptnApp` itself.
 
-See [Pre- and post-deployment checks](../implementing/integrate/#pre--and-post-deployment-checks)
+See
+[Pre- and post-deployment checks](../implementing/integrate/#pre--and-post-deployment-checks)
 for details.
 
 Note the following:
@@ -55,15 +58,19 @@ Note the following:
   available memory, disk space, and other resources
   that are required for the deployment.
 * The `KeptnMetric` resources that are referenced
-  in a `KeptnEvaluationDefinition` resource
-  can be defined on different namespaces in the cluster.
-* All `KeptnEvaluation` resources
-  that are defined by `KeptnEvaluationDefinition` resources at the same level
-  (either pre-deployment or post-deployment)
-  execute in parallel.
+  in a `KeptnMetricDefinition` resource
+  * can be defined on different namespaces in the cluster
+  * can query different instances of different types of data providers
+* Each deployment has a single
+  `KeptnEvaluationDefinition` resource for pre-deployment
+  and another for post-deployment.
 * All objectives within a `KeptnEvaluationDefinition` resource
   are evaluated in order.
   If the evaluation of an objective fails,
   the `KeptnEvaluation` itself fails
   and the objectives listed after the failed objection
   are not evaluated.
+* The results of the `KeptnEvaluationDefinition` executions
+  are written to a
+  [KeptnEvaluation](../../crd-ref/lifecycle/v1alpha3/#keptnevaluation)
+  resource.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -72,5 +72,5 @@ Note the following:
   are not evaluated.
 * The results of the `KeptnEvaluationDefinition` executions
   are written to a
-  [KeptnEvaluation](../../crd-ref/lifecycle/v1alpha3/#keptnevaluation)
+  [KeptnEvaluation](../crd-ref/lifecycle/v1alpha3/#keptnevaluation)
   resource.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -61,16 +61,17 @@ Note the following:
   in a `KeptnMetricDefinition` resource
   * can be defined on different namespaces in the cluster
   * can query different instances of different types of data providers
-* Each deployment has a single
-  `KeptnEvaluationDefinition` resource for pre-deployment
-  and another for post-deployment.
 * All objectives within a `KeptnEvaluationDefinition` resource
   are evaluated in order.
   If the evaluation of an objective fails,
   the `KeptnEvaluation` itself fails
   and the objectives listed after the failed objection
   are not evaluated.
-* The results of the `KeptnEvaluationDefinition` executions
+* You can define multiple `KeptnEvaluationDefinition` resources
+  for each stage (pre- and post-deployment).
+  These evaluations run in parallel so the failure of one `KeptnEvaluationDefinition` resource
+  has no effect on whether other `KeptnEvaluationDefinition` resources are completed.
+* The results of each `KeptnEvaluationDefinition` execution
   are written to a
   [KeptnEvaluation](../crd-ref/lifecycle/v1alpha3/#keptnevaluation)
   resource.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -69,7 +69,7 @@ Note the following:
   are not evaluated.
 * You can define multiple `KeptnEvaluationDefinition` resources
   for each stage (pre- and post-deployment).
-  These evaluations run in parallel so the failure of one `KeptnEvaluationDefinition` resource
+  These evaluations run in parallel so the failure of one evaluation
   has no effect on whether other `KeptnEvaluationDefinition` resources are completed.
 * The results of each `KeptnEvaluationDefinition` execution
   are written to a

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -32,7 +32,7 @@ before the workload or application is deployed.
 The example
 [metric.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/metric.yaml)
 file defines the
-[KeptnMetric](../yaml-crd-ref/metric) resource
+[KeptnMetric](../yaml-crd-ref/metric.md) resource
 that is named  `available-cpus`:
 
 ```yaml
@@ -58,7 +58,7 @@ To integrate your `KeptnEvaluation` resource, you must:
   to include each evaluation and task you want to run
   pre- and post-deployment for the specific workloads.
 * Manually edit all
-  [KeptnApp](../../yaml-crd-ref/app.md) resources
+  [KeptnApp](../yaml-crd-ref/app.md) resources
   to specify the evaluations to be run
   pre- and post-deployment for the `KeptnApp` itself.
 

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -4,7 +4,7 @@ description: Understand Keptn evaluations and how to use them
 weight: 150
 ---
 A `KeptnEvaluation` checks whether a value in `KeptnMetric` meets a defined target value defined in `KeptnEvaluationDefinition`.
-A `KeptnEvaluation` resource is defined in a
+A `KeptnEvaluationDefinition` resource is defined in a
 [KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
 yaml file.
 The example

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -71,7 +71,7 @@ Note the following:
   for each stage (pre- and post-deployment).
   These evaluations run in parallel so the failure of one evaluation
   has no effect on whether other evaluations are completed.
-* The results of each `KeptnEvaluationDefinition` execution
+* The results of each evaluation
   are written to a
   [KeptnEvaluation](../crd-ref/lifecycle/v1alpha3/#keptnevaluation)
   resource.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -12,21 +12,11 @@ The example
 file specifies the `app-pre-deploy-eval-2` evaluation as follows:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnEvaluationDefinition
-metadata:
-  name: app-pre-deploy-eval-2
-  namespace: podtato-kubectl
-spec:
-  objectives:
-    - keptnMetricRef:
-        name: available-cpus
-        namespace: podtato-kubectl
-      evaluationTarget: ">4"`
+{{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
 ```
 
-The `evaluationTarget` is set to be `>4`,
-so this evaluation ensures that more than 4 CPUs are available
+The `evaluationTarget` is set to be `>1`,
+so this evaluation ensures that more than 1 CPU is available
 before the workload or application is deployed.
 
 The example
@@ -36,19 +26,17 @@ file defines the
 that is named  `available-cpus`:
 
 ```yaml
-apiVersion: metrics.keptn.sh/v1alpha3
-kind: KeptnMetric
-metadata:
-  name: available-cpus
-  namespace: podtato-kubectl
-spec:
-  provider:
-    name: my-provider
-  query: "sum(kube_node_status_capacity{resource='cpu'})"
-  fetchIntervalSeconds: 10
+{{< embed path="/examples/sample-app/base/metric.yaml" >}}
 ```
 
-To integrate your `KeptnEvaluation` resource, you must:
+To run an evaluation on one of your 
+[Workloads](https://kubernetes.io/docs/concepts/workloads/)
+([Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
+[StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
+[DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/),
+or
+[ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/),
+you must:
 
 * Annotate your [Workloads](https://kubernetes.io/docs/concepts/workloads/)
   [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -18,11 +18,12 @@ The `evaluationTarget` is set to be `>1`,
 so this evaluation ensures that more than 1 CPU is available
 before the workload or application is deployed.
 
-The example
-[metric.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/metric.yaml)
-file defines the
+This evaluation references the
 [KeptnMetric](../yaml-crd-ref/metric.md) resource
-that is named  `available-cpus`:
+that is named  `available-cpus`.
+This is defined in the example
+[metric.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/metric.yaml)
+file:
 {{< embed path="/examples/sample-app/base/metric.yaml" >}}
 
 To run an evaluation on one of your
@@ -34,11 +35,7 @@ or
 [ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/),
 you must:
 
-* Annotate your [Workloads](https://kubernetes.io/docs/concepts/workloads/)
-  [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
-  [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
-  and
-  [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+* Annotate your `Workloads`
   to identify the `KeptnEvaluationDefinition` resource you want to run
   pre- and post-deployment for the specific workloads.
 * Manually edit all

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -44,7 +44,7 @@ you must:
 * Manually edit all
   [KeptnApp](../yaml-crd-ref/app.md) resources
   to specify the `KeptnEvaluationDefinition` to be run
-  pre- and post-deployment for the `KeptnApp` itself.
+  pre- and post-deployment evaluations for the `KeptnApp` itself.
 
 See
 [Pre- and post-deployment checks](../implementing/integrate/#pre--and-post-deployment-checks)

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -63,10 +63,8 @@ Note the following:
   * can query different instances of different types of metric providers
 * All objectives within a `KeptnEvaluationDefinition` resource
   are evaluated in order.
-  If the evaluation of an objective fails,
-  the `KeptnEvaluation` itself fails
-  and the objectives listed after the failed objection
-  are not evaluated.
+  If the evaluation of any objective fails,
+  the `KeptnEvaluation` itself fails.
 * You can define multiple `KeptnEvaluationDefinition` resources
   for each stage (pre- and post-deployment).
   These evaluations run in parallel so the failure of one evaluation

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -55,7 +55,7 @@ Note the following:
   available memory, disk space, and other resources
   that are required for the deployment.
 * The `KeptnMetric` resources that are referenced
-  in a `KeptnMetricDefinition` resource
+  in a `KeptnEvaluationDefinition` resource
   can be defined on different namespaces in the cluster.
 * All `KeptnEvaluation` resources
   that are defined by `KeptnEvaluationDefinition` resources at the same level

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -10,10 +10,7 @@ yaml file.
 The example
 [app-pre-deploy-eval.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-3/app-pre-deploy-eval.yaml)
 file specifies the `app-pre-deploy-eval-2` evaluation as follows:
-
-```yaml
 {{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
-```
 
 The `evaluationTarget` is set to be `>1`,
 so this evaluation ensures that more than 1 CPU is available
@@ -24,10 +21,7 @@ The example
 file defines the
 [KeptnMetric](../yaml-crd-ref/metric.md) resource
 that is named  `available-cpus`:
-
-```yaml
 {{< embed path="/examples/sample-app/base/metric.yaml" >}}
-```
 
 To run an evaluation on one of your
 [Workloads](https://kubernetes.io/docs/concepts/workloads/)

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -3,3 +3,85 @@ title: Evaluations
 description: Understand Keptn evaluations and how to use them
 weight: 150
 ---
+A `KeptnEvaluation` is a `KeptnMetric` that has a defined target value.
+A `KeptnEvaluation` resource is defined in a
+[KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
+yaml file.
+The example
+[app-pre-deploy-eval.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-3/app-pre-deploy-eval.yaml)
+file specifies the `app-pre-deploy-eval-2` evaluation as follows:
+
+```yaml
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnEvaluationDefinition
+metadata:
+  name: app-pre-deploy-eval-2
+  namespace: podtato-kubectl
+spec:
+  objectives:
+    - keptnMetricRef:
+        name: available-cpus
+        namespace: podtato-kubectl
+      evaluationTarget: ">4"`
+```
+
+The `evaluationTarget` is set to be `>4`,
+so this evaluation ensures that more than 4 CPUs are available
+before the workload or application is deployed.
+ 
+The example
+[metric.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/base/metric.yaml)
+file defines the
+[KeptnMetric](../yaml-crd-ref/metric) resource
+that is named  `available-cpus`:
+
+```yaml
+apiVersion: metrics.keptn.sh/v1alpha3
+kind: KeptnMetric
+metadata:
+  name: available-cpus
+  namespace: podtato-kubectl
+spec:
+  provider:
+    name: my-provider
+  query: "sum(kube_node_status_capacity{resource='cpu'})"
+  fetchIntervalSeconds: 10
+```
+
+To integrate your `KeptnEvaluation` resource, you must:
+
+* Annotate your [Workloads](https://kubernetes.io/docs/concepts/workloads/)
+  [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
+  [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
+  and
+  [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+  to include each evaluation and task you want to run
+  pre- and post-deployment for the specific workloads.
+* Manually edit all
+  [KeptnApp](../../yaml-crd-ref/app.md) resources
+  to specify the evaluations to be run
+  pre- and post-deployment for the `KeptnApp` itself.
+
+See [Pre- and post-deployment checks](../implementing/integrate/#pre--and-post-deployment-checks)
+for details.
+
+Note the following:
+
+* One `KeptnEvaluationDefinition` resource can include
+  multiple `objective` fields that reference additional metrics.
+  In this example, you might want to also query
+  available memory, disk space, and other resources
+  that are required for the deployment.
+* The `KeptnMetric` resources that are referenced
+  in a `KeptnMetricDefinition` resource
+  can be defined on different namespaces in the cluster.
+* All `KeptnEvaluation` resources
+  that are defined by `KeptnEvaluationDefinition` resources at the same level
+  (either pre-deployment or post-deployment)
+  execute in parallel.
+* All objectives within a `KeptnEvaluationDefinition` resource
+  are evaluated in order.
+  If the evaluation of an objective fails,
+  the `KeptnEvaluation` itself fails
+  and the objectives listed after the failed objection
+  are not evaluated.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -62,7 +62,7 @@ Note the following:
   are evaluated in order.
   If the evaluation of any objective fails,
   the `KeptnEvaluation` itself fails.
-* You can define multiple `KeptnEvaluationDefinition` resources
+* You can define multiple evaluations
   for each stage (pre- and post-deployment).
   These evaluations run in parallel so the failure of one evaluation
   has no effect on whether other evaluations are completed.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -29,7 +29,7 @@ that is named  `available-cpus`:
 {{< embed path="/examples/sample-app/base/metric.yaml" >}}
 ```
 
-To run an evaluation on one of your 
+To run an evaluation on one of your
 [Workloads](https://kubernetes.io/docs/concepts/workloads/)
 ([Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
 [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -3,7 +3,7 @@ title: Evaluations
 description: Understand Keptn evaluations and how to use them
 weight: 150
 ---
-A `KeptnEvaluation` checks whether a `KeptnMetric` meets a defined target value.
+A `KeptnEvaluation` checks whether a value in `KeptnMetric` meets a defined target value defined in `KeptnEvaluationDefinition`.
 A `KeptnEvaluation` resource is defined in a
 [KeptnEvaluationDefinition](../yaml-crd-ref/evaluationdefinition.md)
 yaml file.

--- a/docs/content/en/docs/implementing/evaluations.md
+++ b/docs/content/en/docs/implementing/evaluations.md
@@ -58,7 +58,7 @@ Note the following:
   available memory, disk space, and other resources
   that are required for the deployment.
 * The `KeptnMetric` resources that are referenced
-  in a `KeptnMetricDefinition` resource
+  in a `KeptnEvaluationDefinition` resource
   * can be defined on different namespaces in the cluster
   * can query different instances of different types of data providers
 * All objectives within a `KeptnEvaluationDefinition` resource


### PR DESCRIPTION
This copies the information about evaluations from the intro/usecase-orchestrate.md file that is a remnant of an old getting-started guide.  The goal is to eventually delete the intro/usercase-orchestrate.md file.

The following changes were made to the content:

* Replaced the examples from Andi's example with examples from the official PodtatoHead example
* Added some notes about implementing evaluations.  **Please verify that the items in the last bullet list are accurate!!!**
* A bit of word-smithing