### PR TITLE
fix: add uid fields to Grafana dashboard datasources

### DIFF
--- a/dashboards/grafana/configmap/grafana-dashboard-keptn-applications.yaml
+++ b/dashboards/grafana/configmap/grafana-dashboard-keptn-applications.yaml
@@ -33,7 +33,8 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -82,8 +83,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "keptn_app_count_total{keptn_deployment_app_status=\"Succeeded\", keptn_deployment_app_name=\"$Application\"}",
@@ -117,7 +118,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -165,7 +167,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_app_active{keptn_deployment_app_name=\"$Application\"})",
@@ -179,7 +182,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -228,7 +232,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "keptn_app_count_total{keptn_deployment_app_status=\"Failed\", keptn_deployment_app_name=\"$Application\"}",
@@ -264,7 +269,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -314,8 +320,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_app_previousversion, keptn_deployment_app_version) (keptn_app_deploymentinterval{keptn_deployment_app_name=\"$Application\"})",
@@ -330,7 +336,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -383,7 +390,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_workload_previousversion) (keptn_app_deploymentinterval{keptn_deployment_app_name=\"$Application\"})",
@@ -398,7 +406,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -447,7 +456,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max by(keptn_deployment_app_version) (keptn_app_deploymentduration{keptn_deployment_app_name=\"$Application\"})",
@@ -462,7 +472,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -538,7 +549,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_app_active{keptn_deployment_app_name=\"$Application\"})",
@@ -605,6 +617,7 @@ data:
             {
               "datasource": {
                 "type": "jaeger",
+                "uid": "jaeger"
               },
               "operation": "AppPreDeployTasks",
               "queryType": "search",
@@ -618,7 +631,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -681,7 +695,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "keptn_deployment_deploymentduration{keptn_deployment_app_name=\"$Application\"}",
@@ -740,7 +755,8 @@ data:
               "value": "podtato-head"
             },
             "datasource": {
-              "type": "prometheus"
+              "type": "prometheus",
+              "uid": "prometheus"
             },
             "definition": "label_values(keptn_deployment_app_name)",
             "hide": 0,
@@ -760,7 +776,8 @@ data:
           },
           {
             "datasource": {
-              "type": "prometheus"
+              "type": "prometheus",
+              "uid": "prometheus"
             },
             "filters": [],
             "hide": 0,

--- a/dashboards/grafana/configmap/grafana-dashboard-keptn-overview.yaml
+++ b/dashboards/grafana/configmap/grafana-dashboard-keptn-overview.yaml
@@ -33,8 +33,8 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -110,8 +110,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_task_active{job=\"otel-collector\"})",
@@ -125,8 +125,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -202,8 +202,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_evaluation_active{job=\"otel-collector\"})",
@@ -217,8 +217,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -294,8 +294,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_task_count{job=\"otel-collector\"})",
@@ -309,8 +309,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -386,8 +386,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_evaluation_count_total{job=\"otel-collector\"})",
@@ -401,8 +401,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -451,8 +451,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "exemplar": false,
@@ -496,8 +496,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -546,8 +546,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "exemplar": false,
@@ -591,8 +591,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -668,8 +668,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_deployment_active{job=\"otel-collector\"})",
@@ -759,8 +759,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_deployment_count{job=\"otel-collector\"})",
@@ -774,8 +774,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -823,8 +823,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "exemplar": false,

--- a/dashboards/grafana/configmap/grafana-dashboard-keptn-workloads.yaml
+++ b/dashboards/grafana/configmap/grafana-dashboard-keptn-workloads.yaml
@@ -33,8 +33,8 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -80,8 +80,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "count(keptn_deployment_count{keptn_deployment_workload_name=\"$Workload\", keptn_deployment_workload_status=\"Succeeded\"})",
@@ -95,8 +95,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -149,8 +149,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_workload_previousversion, keptn_deployment_workload_version) (keptn_deployment_deploymentinterval{keptn_deployment_workload_name=\"$Workload\"})",
@@ -165,8 +165,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -215,7 +215,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "count(keptn_deployment_count{keptn_deployment_workload_name=\"$Workload\", keptn_deployment_workload_status=\"Failed\"})",
@@ -229,7 +230,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -279,8 +281,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max by(keptn_deployment_workload_version) (keptn_deployment_deploymentduration{keptn_deployment_workload_name=\"$Workload\"})",
@@ -296,8 +298,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -345,8 +347,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_deployment_active{keptn_deployment_workload_name=\"$Workload\"})",
@@ -360,8 +362,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -411,8 +413,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_workload_previousversion, keptn_deployment_workload_version) (keptn_deployment_deploymentinterval{keptn_deployment_workload_name=\"$Workload\"})",
@@ -493,8 +495,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -570,8 +572,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_deployment_active{keptn_deployment_workload_name=\"$Workload\"})",
@@ -599,8 +601,8 @@ data:
               "value": ""
             },
             "datasource": {
-              "type": "prometheus"
-              
+              "type": "prometheus",
+              "uid": "prometheus"
             },
             "definition": "label_values(keptn_deployment_workload_name)",
             "hide": 0,

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
@@ -33,8 +33,8 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -83,8 +83,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "keptn_app_count_total{keptn_deployment_app_status=\"Succeeded\", keptn_deployment_app_name=\"$Application\"}",
@@ -118,8 +118,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -167,8 +167,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_app_active{keptn_deployment_app_name=\"$Application\"})",
@@ -182,8 +182,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -232,8 +232,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "keptn_app_count_total{keptn_deployment_app_status=\"Failed\", keptn_deployment_app_name=\"$Application\"}",
@@ -269,8 +269,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -320,8 +320,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_app_previousversion, keptn_deployment_app_version) (keptn_app_deploymentinterval{keptn_deployment_app_name=\"$Application\"})",
@@ -336,8 +336,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -390,8 +390,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_workload_previousversion) (keptn_app_deploymentinterval{keptn_deployment_app_name=\"$Application\"})",
@@ -406,8 +406,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -456,8 +456,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max by(keptn_deployment_app_version) (keptn_app_deploymentduration{keptn_deployment_app_name=\"$Application\"})",
@@ -472,8 +472,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -549,8 +549,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_app_active{keptn_deployment_app_name=\"$Application\"})",
@@ -632,8 +632,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -696,8 +696,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "keptn_deployment_deploymentduration{keptn_deployment_app_name=\"$Application\"}",
@@ -756,8 +756,8 @@ data:
               "value": "podtato-head"
             },
             "datasource": {
-              "type": "prometheus"
-              
+              "type": "prometheus",
+              "uid": "prometheus"
             },
             "definition": "label_values(keptn_deployment_app_name)",
             "hide": 0,
@@ -777,8 +777,8 @@ data:
           },
           {
             "datasource": {
-              "type": "prometheus"
-              
+              "type": "prometheus",
+              "uid": "prometheus"
             },
             "filters": [],
             "hide": 0,

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
@@ -33,8 +33,8 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -110,8 +110,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_task_active{job=\"otel-collector\"})",
@@ -125,8 +125,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -202,8 +202,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_evaluation_active{job=\"otel-collector\"})",
@@ -217,8 +217,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -294,8 +294,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_task_count{job=\"otel-collector\"})",
@@ -309,8 +309,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -386,8 +386,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_evaluation_count_total{job=\"otel-collector\"})",
@@ -401,8 +401,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -451,8 +451,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "exemplar": false,
@@ -496,8 +496,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -546,8 +546,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "exemplar": false,
@@ -591,8 +591,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -668,8 +668,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_deployment_active{job=\"otel-collector\"})",
@@ -683,8 +683,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -759,8 +759,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "sum by(job) (keptn_deployment_count{job=\"otel-collector\"})",
@@ -774,8 +774,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -823,8 +823,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "exemplar": false,

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
@@ -33,8 +33,8 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -80,8 +80,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "count(keptn_deployment_count{keptn_deployment_workload_name=\"$Workload\", keptn_deployment_workload_status=\"Succeeded\"})",
@@ -95,8 +95,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -149,8 +149,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_workload_previousversion, keptn_deployment_workload_version) (keptn_deployment_deploymentinterval{keptn_deployment_workload_name=\"$Workload\"})",
@@ -165,8 +165,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -215,8 +215,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "count(keptn_deployment_count{keptn_deployment_workload_name=\"$Workload\", keptn_deployment_workload_status=\"Failed\"})",
@@ -230,8 +230,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -281,8 +281,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max by(keptn_deployment_workload_version) (keptn_deployment_deploymentduration{keptn_deployment_workload_name=\"$Workload\"})",
@@ -298,8 +298,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -347,8 +347,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_deployment_active{keptn_deployment_workload_name=\"$Workload\"})",
@@ -362,8 +362,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -413,8 +413,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "avg by(keptn_deployment_workload_previousversion, keptn_deployment_workload_version) (keptn_deployment_deploymentinterval{keptn_deployment_workload_name=\"$Workload\"})",
@@ -495,8 +495,8 @@ data:
         },
         {
           "datasource": {
-            "type": "prometheus"
-            
+            "type": "prometheus",
+            "uid": "prometheus"
           },
           "fieldConfig": {
             "defaults": {
@@ -572,8 +572,8 @@ data:
           "targets": [
             {
               "datasource": {
-                "type": "prometheus"
-                
+                "type": "prometheus",
+                "uid": "prometheus"
               },
               "editorMode": "builder",
               "expr": "max(keptn_deployment_active{keptn_deployment_workload_name=\"$Workload\"})",
@@ -601,8 +601,8 @@ data:
               "value": ""
             },
             "datasource": {
-              "type": "prometheus"
-              
+              "type": "prometheus",
+              "uid": "prometheus"
             },
             "definition": "label_values(keptn_deployment_workload_name)",
             "hide": 0,


### PR DESCRIPTION
Closes #2081 

Adding the `uid` properties to the datasources again resulted in the values to be retrieved and displayed correctly again