### PR TITLE
docs: move tasks-non-k8s-apps to implementing from tutorials

### DIFF
--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -1,7 +1,7 @@
 ---
 title: Keptn for Non-Kubernetes Applications
 description: Using Keptn with Non-Kubernetes Applications
-weight: 20
+weight: 95
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 


### PR DESCRIPTION
This PR moves the "Keptn for non-Kubernetes applications" page from the "tutorials" section to the "implementing" section.

Originally, I did https://github.com/keptn/lifecycle-toolkit/pull/2086 to move and expand the information in this page.  The "expanding" is more complicated than I had anticpated so let's just move this file as is into the new location.  I will then do another PR that enhances the content.