### PR TITLE
docs: how to embed a file in docs

### DIFF
--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -61,7 +61,7 @@ that are relevant only to documentation
   the syntax is:
 
   ```md
-    \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >\}\}
+{{</* embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" */>}}
   ```
 
 * `markdownlint` enforces limits on line length.

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -51,7 +51,7 @@ that are relevant only to documentation
     for the same reason.
 
 * When you want to display a sample file that exists in the repository,
-  use the `embed path` syntax
+  use the `embed path` shortcode syntax
   (which automatically pulls the current version of the file into your document)
   rather than copying the text.
   This ensures that, when the sample file is updated,
@@ -60,7 +60,9 @@ that are relevant only to documentation
   For example, to embed the `examples/sample-app/version3/app-pre-deploy-eval.yaml` file,
   the syntax is:
 
-  \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
+     ```md
+     {{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
+     ```
 
 * `markdownlint` enforces limits on line length.
   Links to other documents are exempted from this limit

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -61,7 +61,8 @@ that are relevant only to documentation
   the syntax is:
 
   ```md
-{{</* embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" */>}}
+  {{</*embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml"*/>}}
+
   ```
 
 * `markdownlint` enforces limits on line length.

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -60,9 +60,9 @@ that are relevant only to documentation
   For example, to embed the `examples/sample-app/version3/app-pre-deploy-eval.yaml` file,
   the syntax is:
 
-     ```md
-     \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
-     ```
+  ```md
+    \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
+  ```
 
 * `markdownlint` enforces limits on line length.
   Links to other documents are exempted from this limit

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -61,7 +61,7 @@ that are relevant only to documentation
   the syntax is:
 
      ```md
-     {{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
+     \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
      ```
 
 * `markdownlint` enforces limits on line length.

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -61,7 +61,7 @@ that are relevant only to documentation
   the syntax is:
 
   ```md
-    \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
+    {{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
   ```
 
 * `markdownlint` enforces limits on line length.

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -61,7 +61,7 @@ that are relevant only to documentation
   the syntax is:
 
   ```md
-    {{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
+    \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >\}\}
   ```
 
 * `markdownlint` enforces limits on line length.

--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -32,7 +32,7 @@ that are relevant only to documentation
 * Avoid using FAQ's in documentation.
   In general, they say "here is some miscellaneous information
   that I was too lazy to organize logically for you."
-  In rare occasions, they may be appropriate,
+  On rare occasions, they may be appropriate,
   such as if you need a quick reference to a large, complicated document
   and include links to detailed documentation about the topic.
 
@@ -49,6 +49,18 @@ that are relevant only to documentation
     to the full installation documentation which has more details.
   * The Getting Started Guide also includes this information
     for the same reason.
+
+* When you want to display a sample file that exists in the repository,
+  use the `embed path` syntax
+  (which automatically pulls the current version of the file into your document)
+  rather than copying the text.
+  This ensures that, when the sample file is updated,
+  your document is also updated.
+
+  For example, to embed the `examples/sample-app/version3/app-pre-deploy-eval.yaml` file,
+  the syntax is:
+
+  \{\{< embed path="/examples/sample-app/version-3/app-pre-deploy-eval.yaml" >}}
 
 * `markdownlint` enforces limits on line length.
   Links to other documents are exempted from this limit


### PR DESCRIPTION
Adds a note to `contribute/docs/contrib-guidelines-docs`  about using the `embed path` shortcode to pull a sample file into the documentation.

Note that the formatting here is not great.  I could not successfully escape the shortcode when it was in a code block or within tics.  If anyone knows the trick to do this right, please let me know.