### PR TITLE
docs: rename "Implementing..." section to "User Guides"

### DIFF
--- a/docs/content/en/docs/implementing/_index.md
+++ b/docs/content/en/docs/implementing/_index.md
@@ -1,13 +1,6 @@
 ---
-title: Implementing Keptn applications
-description: Learn how to implement your Keptn application
-layout: quickstart
+title: User Guides
+description: Learn how to implement metrics, observability, and release lifecycle management with Keptn
 weight: 40
-hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
-> **Note**
-This section is under development.
-Information that is published here has been reviewed for technical accuracy
-but the format and content is still evolving.
-We welcome your input!**

--- a/docs/content/en/docs/implementing/dora/_index.md
+++ b/docs/content/en/docs/implementing/dora/_index.md
@@ -1,7 +1,7 @@
 ---
 title: DORA metrics
 description: Access DORA metrics for your cluster
-weight: 65
+weight: 30
 ---
 
 DORA metrics are an industry-standard set of measurements

--- a/docs/content/en/docs/implementing/evaluatemetrics.md
+++ b/docs/content/en/docs/implementing/evaluatemetrics.md
@@ -1,7 +1,7 @@
 ---
 title: Keptn Metrics
 description: Implement Keptn metrics
-weight: 85
+weight: 20
 ---
 
 The Keptn Metrics Operator provides a single entry point

--- a/docs/content/en/docs/implementing/integrate/_index.md
+++ b/docs/content/en/docs/implementing/integrate/_index.md
@@ -2,7 +2,7 @@
 title: Integrate Keptn with your applications
 description: How to integrate Keptn into your Kubernetes cluster
 layout: quickstart
-weight: 45
+weight: 10
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry observability
 description: How to standardize access to OpenTelemetry observability data
-weight: 140
+weight: 40
 ---
 
 


### PR DESCRIPTION
This PR renames the section previously called "Implementing Keptn Applications" to be just "User Guides".  We discussed this in the 13 September 2023 Community Meeting and agreed that "User Guides" is a more accurate and more friendly name.

We decided to not subdivide this section by "Metrics", "Observability", and Release Lifecycle Management but to reorder some of the pages to be in a more logical order, so the first sections, in order, are:

* Integrate Keptn with your applications
* Keptn Metrics
* Dora Metrics
* OpenTelemetry observability

The remaining sections are all related to Release Lifecycle Management.