### PR TITLE
docs: add KeptnTask ref page; enhance guide chapter for keptn-no-k8s

### DIFF
--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -28,7 +28,6 @@ but this can be a very lightweight, single-node KinD cluster; see
 Keptn only triggers on-demand `KeptnTask` resources
 so resource utilization is minimal.
 
-
 ## Create a KeptnTaskDefinition
 
 When you have Keptn installed, create a

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -66,10 +66,9 @@ but you can also use the `deno-runtime` or `python-runtime` runners.
 
 You must manually create the
 [KeptnTask](../yaml-crd-ref/task.md)
-the resource.
+resource.
 In the standard operating mode, when Keptn is managing workloads,
 the creation of the `KeptnTask` resource is automatic.
-Here though, we must create it ourselves.
 
 Moreover, you must create a new (and uniquely named)
 `KeptnTask` resource

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -109,8 +109,8 @@ in the associated `KeptnTaskDefinition` resource.
 Use the following commands to show the current status of the jobs:
 
 ```shell
-kubectl get keptntasks 
-kubectl get pods
+kubectl get keptntasks -n my-keptn-annotated-namespace
+kubectl get pods -n my-keptn-annotated-namespace
 ```
 
 ## Re-run the KeptnTask

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -59,6 +59,9 @@ spec:
 
 This example uses the `container-runtime` runner,
 but you can instead use the `deno-runtime` or `python-runtime` runner.
+See
+[Runners and containers](tasks/#runners-and-containers)
+for more information.
 
 ## Create and apply a KeptnTask
 

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -146,6 +146,6 @@ spec:
 
 You can then apply this file with the following command:
 
-```yaml
+```shell
 kubectl apply -f test-task-2.yaml -n my-keptn-annotated-namespace
 ```

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -64,8 +64,7 @@ but you can instead use the `deno-runtime` or `python-runtime` runner.
 ## Create and apply a KeptnTask
 
 You must manually create the
-[KeptnTask](../yaml-crd-ref/task.md)
-resource.
+[KeptnTask](../yaml-crd-ref/task.md) resource.
 In the standard operating mode, when Keptn is managing workloads,
 the creation of the `KeptnTask` resource is automatic.
 

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -120,7 +120,7 @@ the `KeptnTask` name and version fields must be unique,
 so copy the `KeptnTask` yaml file you have and update the
 `metadata.name` field.
 
-A standard practice is to just increment the value of is field.
+A standard practice is to just increment the value of the suffix field.
 For example, you could create a `test-task-2.yaml` file
 with the `metadata.name` field set to `runhelloworld2`:
 

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -28,7 +28,6 @@ but this can be a very lightweight, single-node KinD cluster; see
 Keptn only triggers on-demand `KeptnTask` resources
 so resource utilization is minimal.
 
-TODO: How is this cluster associated with the VM
 where the deployment is running?
 
 ## Create a KeptnTaskDefinition

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -98,7 +98,7 @@ spec:
 
 You can then apply this YAML file with the following command:
 
-```yaml
+```shell
 kubectl apply -f test-task.yaml -n my-keptn-annotated-namespace
 ```
 

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -68,8 +68,7 @@ In the standard operating mode, when Keptn is managing workloads,
 the creation of the `KeptnTask` resource is automatic.
 
 Moreover, each time you want to execute a `KeptnTask` resource,
-you must manually create a a new (and uniquely named) YAML file
-that describes that resource.
+you must manually create a a new (and uniquely named) `KeptnTask` resource.
 
 The `KeptnTask` resource references the `KeptnTaskDefinition`
 that you created above

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -77,7 +77,7 @@ each time you want to rerun this task
 Each time you want to execute a `KeptnTask` resource,
 you must manually create a
 a new (and uniquely named)
-[KeptnTask](../yaml-crd-ref/task)
+[KeptnTask](../yaml-crd-ref/task.md)
 YAML file to describe that resource.
 
 The `KeptnTask` references the `KeptnTaskDefinition`

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -118,7 +118,7 @@ kubectl get pods
 For subsequent KeptnTask runs,
 the `KeptnTask` name and version fields must be unique,
 so copy the `KeptnTask` yaml file you have and update the
-`metadata.name` field:
+`metadata.name` field.
 
 A standard practice is to just increment the value of is field.
 For example, you could create a `test-task-2.yaml` file

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -13,7 +13,7 @@ To do this:
 
 1. [Install and enable a Kubernetes cluster](#install-and-enable-a-kubernetes-cluster)
 1. [Create a KeptnTaskDefinition](#create-a-keptntaskdefinition)
-1. [Create a KeptnTask](#create-and-appy-a-keptntask)
+1. [Create and apply a KeptnTask](#create-and-apply-a-keptntask)
 1. [Re-run the KeptnTask](#re-run-the-keptntask)
 
 ## Install and enable a Kubernetes cluster
@@ -79,7 +79,6 @@ you must manually create a
 a new (and uniquely named)
 [KeptnTask](../yaml-crd-ref/task)
 YAML file to describe that resource.
-
 
 The `KeptnTask` references the `KeptnTaskDefinition`
 in the `spec.taskDefinition` field.
@@ -168,5 +167,3 @@ You can then apply this file with the following command:
 ```yaml
 kubectl --apply test-task-2.yaml
 ```
-
-

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -28,7 +28,6 @@ but this can be a very lightweight, single-node KinD cluster; see
 Keptn only triggers on-demand `KeptnTask` resources
 so resource utilization is minimal.
 
-where the deployment is running?
 
 ## Create a KeptnTaskDefinition
 

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -99,7 +99,7 @@ spec:
 You can then apply this YAML file with the following command:
 
 ```yaml
-kubectl --apply test-task.yaml
+kubectl apply -f test-task.yaml -n my-keptn-annotated-namespace
 ```
 
 Applying this file causes Keptn to create a Job and a Pod

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -68,7 +68,7 @@ You must manually create the
 In the standard operating mode, when Keptn is managing workloads,
 the creation of the `KeptnTask` resource is automatic.
 
-Moreover, each time you want to execute a `KeptnTask` resource,
+Moreover, each time you want to execute a `KeptnTask`,
 you must manually create a a new (and uniquely named) `KeptnTask` resource.
 
 The `KeptnTask` resource references the `KeptnTaskDefinition`

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -147,5 +147,5 @@ spec:
 You can then apply this file with the following command:
 
 ```yaml
-kubectl --apply test-task-2.yaml
+kubectl apply -f test-task-2.yaml -n my-keptn-annotated-namespace
 ```

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -19,12 +19,12 @@ To do this:
 ## Install and enable a Kubernetes cluster
 
 You must still
-[install](../install/install/#use-helm-chart)
+[install](../install/install.md/#use-helm-chart)
 and
-[enable](../install/install/#enable-keptn-for-your-cluster)
+[enable](../install/install.md/#enable-keptn-for-your-cluster)
 Keptn on a Kubernetes cluster,
 but this can be a very lightweight, single-node KinD cluster; see
-[Create local Kubernetes cluster](../install/k8s/#create-local-kubernetes-cluster).
+[Create local Kubernetes cluster](../install/k8s.md/#create-local-kubernetes-cluster).
 Keptn only triggers on-demand `KeptnTask` resources
 so resource utilization is minimal.
 
@@ -34,7 +34,7 @@ where the deployment is running?
 ## Create a KeptnTaskDefinition
 
 When you have Keptn installed, create a
-[KeptnTaskDefinition](../yaml-crd-ref/taskdefinition/)
+[KeptnTaskDefinition](../yaml-crd-ref/taskdefinition.md/)
 YAML file that defines what you want to execute.
 See
 [Deployment tasks](../implementing/tasks/)
@@ -65,7 +65,7 @@ but you can also use the `deno-runtime` or `python-runtime` runners.
 ## Create and apply a KeptnTask
 
 You must manually create the
-[KeptnTask](../yaml-crd-ref/task)
+[KeptnTask](../yaml-crd-ref/task.md)
 the resource.
 In the standard operating mode, when Keptn is managing workloads,
 the creation of the `KeptnTask` resource is automatic.

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -20,8 +20,6 @@ To do this:
 
 You must still
 [install](../install/install.md/#use-helm-chart)
-and
-[enable](../install/install.md/#enable-keptn-for-your-cluster)
 Keptn on a Kubernetes cluster,
 but this can be a very lightweight, single-node KinD cluster; see
 [Create local Kubernetes cluster](../install/k8s.md/#create-local-kubernetes-cluster).

--- a/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
+++ b/docs/content/en/docs/implementing/tasks-non-k8s-apps.md
@@ -34,11 +34,13 @@ where the deployment is running?
 ## Create a KeptnTaskDefinition
 
 When you have Keptn installed, create a
-[KeptnTaskDefinition](../yaml-crd-ref/taskdefinition.md/)
-YAML file that defines what you want to execute.
+YAML file that defines what you want to execute
+as a `KeptnTaskDefinition` resource..
 See
 [Deployment tasks](../implementing/tasks/)
-for more information.
+and the
+[KeptnTaskDefinition](../yaml-crd-ref/taskdefinition.md/)
+reference page for more information.
 
 For example, you might create a `test-task-definition.yaml` file
 with the following content:
@@ -58,9 +60,8 @@ spec:
       - 'hello world'
 ```
 
-This example uses the `container-runtime` runner
-because it allows the most flexibility
-but you can also use the `deno-runtime` or `python-runtime` runners.
+This example uses the `container-runtime` runner,
+but you can instead use the `deno-runtime` or `python-runtime` runner.
 
 ## Create and apply a KeptnTask
 
@@ -70,16 +71,12 @@ resource.
 In the standard operating mode, when Keptn is managing workloads,
 the creation of the `KeptnTask` resource is automatic.
 
-Moreover, you must create a new (and uniquely named)
-`KeptnTask` resource
-each time you want to rerun this task
-Each time you want to execute a `KeptnTask` resource,
-you must manually create a
-a new (and uniquely named)
-[KeptnTask](../yaml-crd-ref/task.md)
-YAML file to describe that resource.
+Moreover, each time you want to execute a `KeptnTask` resource,
+you must manually create a a new (and uniquely named) YAML file
+that describes that resource.
 
-The `KeptnTask` references the `KeptnTaskDefinition`
+The `KeptnTask` resource references the `KeptnTaskDefinition`
+that you created above
 in the `spec.taskDefinition` field.
 For example, you might create a `test-task.yaml` file
 with the following content:
@@ -104,10 +101,6 @@ spec:
     workloadVersion: "1.0.0"
 ```
 
-TODO: This file does not match what I see in the API Reference.
-See specific comments in the `KeptnTask` reference page.
-When we resolve those issues, I will modify this file appropriately.
-
 You can then apply this YAML file with the following command:
 
 ```yaml
@@ -129,17 +122,12 @@ kubectl get pods
 
 For subsequent KeptnTask runs,
 the `KeptnTask` name and version fields must be unique,
-so copy the `KeptnTask` file you have and update the following fields:
+so copy the `KeptnTask` yaml file you have and update the
+`metadata.name` field:
 
-- `name`
-- `spec.appVersion`
-- `spec.workloadVersion`
-- `spec.context.appVersion`
-- `spec.context.workloadVersion`
-
-A standard practice is to just increment the values of these fields.
+A standard practice is to just increment the value of is field.
 For example, you could create a `test-task-2.yaml` file
-with the following content:
+with the `metadata.name` field set to `runhelloworld2`:
 
 ```yaml
 apiVersion: lifecycle.keptn.sh/v1alpha3

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -82,7 +82,7 @@ spec:
   or in the Keptn name space.
     * **context** - Contextual information about the task execution
       * **appName** - Name of the
-          [KeptnApp](../yaml-crd-ref/app) resource
+          [KeptnApp](../yaml-crd-ref/app.md) resource
           for which the `KeptnTask` is being executed.
       * **appVersion** - Version of the `KeptnApp` resource
           for which the `KeptnTask` is being executed.

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -142,7 +142,7 @@ to use in the metadata.name field?
 
 For a full example of how to create a `KeptnTask` resource
 to use for a deployment being done outside of Kubernetes, see
-[Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps/).
+[Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps.md).
 
 ## Files
 

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -60,7 +60,7 @@ spec:
   * **workloadVersion** - `KeptnWorkload` version
       for which the `KeptnTask` is being executed.
   * **appName** - Name of the
-      [KeptnApp](../yaml-crd-ref/app) resource
+      [KeptnApp](../yaml-crd-ref/app.md) resource
       for which the `KeptnTask` is being executed.
   * **appVersion** - Version of the `KeptnApp` resource
       for which the `KeptnTask` is being executed.
@@ -203,5 +203,5 @@ spec:
 
 ## See also
 
-* [KeptnTaskDefinition](taskdefinition)
-* [Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps)
+* [KeptnTaskDefinition](taskdefinition.md)
+* [Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps.md)

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -4,12 +4,12 @@ description: Define a run of a KeptnTaskDefinition
 weight: 85
 ---
 
-Keptn populates the `KeptnTask` resource
-for tasks that deploy software on Kubernetes.
 When using Keptn to run tasks for software
 that is deployed outside of Kubernetes,
 you must create the `KeptnTask` definition manually
 and modify it manually for each new run.
+Keptn automatically populates the `KeptnTask` resource
+for tasks that deploy software on Kubernetes.
 
 ## Synopsis
 
@@ -19,10 +19,6 @@ kind: KeptnTask
 metadata:
   name: <name-of-this-run>
 spec:
-  workload: "my-workload"
-  workloadVersion: "1.0.0"
-  appVersion: "1.0.0"
-  app: "my-app"
   taskDefinition: <name-of-KeptnTaskDefinition resource>
   context:
     appName: "<name-of-KeptnApp-resource>""
@@ -31,6 +27,11 @@ spec:
     taskType: ""
     workloadName: "my-workload"
     workloadVersion: "1.0.0"
+  parameters: <parameters to pass to job>
+  secureParameters: <secure parameters to pass to job>
+  checkType: ""
+  retries: <integer>
+  timeout: <duration-in-seconds>
 ```
 
 ## Fields
@@ -44,7 +45,6 @@ spec:
   * **name** -- Unique name of this run of the task.
     This name must be modified each time you run this `KeptnTask`,
     so a common practice is to add a number to the end of the string
-    used for the `name` field of the `KeptnTaskDefinition` resource
     so you can increment the number for each run.
     Names must comply with the
     [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
@@ -53,10 +53,6 @@ spec:
   * **workload** - Name of the
       [KeptnWorkload](../crd-ref/lifecycle/v1alpha3/#keptnworkload)
       resource for which the `KeptnTask` is being executed.
-
-      TODO: API ref shows `workloadName` and `workloadVersion`
-      in `TaskContext`, not directly in `spec`.
-      And I don't see a plain `workload` field.
 
   * **workloadVersion** - `KeptnWorkload` version
       for which the `KeptnTask` is being executed.
@@ -68,45 +64,61 @@ spec:
 
       TODO: So I can create a `KeptnApp` resource that lists multiple workloads
       to be processed?
-       Do I need to annotate the Workloads
+      Do I need to annotate the Workloads
       and can I autocreate the `KeptnApp` or do I need to do it manually?
 
-      TODO: API reference shows `appName` and `appVersion` in `TaskContext`
-
-      TODO: API reference shows `parameters` and `secureParameters` here.
-      Should they be added to this list?
-
-      TODO: API reference also shows `CheckType`, `retries`, and `timeout` here.
-
   * **taskDefinition** - Name of the corresponding `KeptnTaskDefinition` resource.
-  This `KeptnTaskDefinition` can be located in the same namespace
-  or in the Keptn name space.
-    * **context** - Contextual information about the task execution
-      * **appName** - Name of the
-          [KeptnApp](../yaml-crd-ref/app.md) resource
-          for which the `KeptnTask` is being executed.
-      * **appVersion** - Version of the `KeptnApp` resource
-          for which the `KeptnTask` is being executed.
+    This `KeptnTaskDefinition` can be located in the same namespace
+    or in the `Keptn` name space.
+  * **context** - Contextual information about the task execution
+    * **appName** - Name of the
+      [KeptnApp](../yaml-crd-ref/app.md) resource
+      for which the `KeptnTask` is being executed.
+    * **appVersion** - Version of the `KeptnApp` resource
+      for which the `KeptnTask` is being executed.
 
-          TODO: So I can create a `KeptnApp` resource that lists multiple workloads
-          to be processed?
-           Do I need to annotate the Workloads
-          and can I autocreate the `KeptnApp` or do I need to do it manually?
-      * **objectType** - Indicates whether this `KeptnTask`
-          is being executed for a `KeptnApp` or a `KeptnWorkload` resource.
+      TODO: So I can create a `KeptnApp` resource that lists multiple workloads
+      to be processed?
+      Do I need to annotate the Workloads
+      and can I autocreate the `KeptnApp` or do I need to do it manually?
 
-          TODO: So why is this set to null (`""`) in the example?
-      * **taskType** Indicates whether this `KeptnTask`
-          is part of the pre- or post-deployment phase
+    * **objectType** - Indicates whether this `KeptnTask`
+      is being executed for a `KeptnApp` or a `KeptnWorkload` resource.
+      When populating this resource manually
+      to run a task for a non-Kubernetes deployment,
+      set this value to `""`:
+      Keptn populates this field based on annotations
+      to the `KeptnWorkload` and `KeptnApp` resources.
 
-          TODO: So why is this set to null (`""`) in the example?
+    * **taskType** Indicates whether this `KeptnTask`
+      is part of the pre- or post-deployment phase.
+      When populating this resource manually
+      to run a task for a non-Kubernetes deployment,,
+u     set this value to `""`:
+      Keptn populates this field based on annotations
+      to the `KeptnWorkload` and `KeptnApp` resources.
 
-      * **workloadName** - Name of the `KeptnWorkload`
-          for which the `KeptnTask` is being executed
-      * **workloadVersion** - Version of the `KeptnWorkload`
-          for which the `KeptnTask` is being executed
-
-          TODO: Why are these fields both here and directly in `spec` above?
+    * **workloadName** - Name of the `KeptnWorkload`
+      for which the `KeptnTask` is being executed
+    * **workloadVersion** - Version of the `KeptnWorkload`
+      for which the `KeptnTask` is being executed
+  * **parameters** (optional) -- Parameters that are passed to the job
+    that executes the `KeptnTask`.
+  * **secureParameters** (optional) -- Secure parameters that are passed
+    to the job that executes the `KeptnTask`.
+    These are stored and accessed as secrets in the cluster.
+    See [Working with secrets](../implementing/tasks/#working-with-secrets)
+    for more information.
+  * **checkType** -- Defines whether task is part of pre- or post-deployment phase.
+    Keptn populates this field based on annotations
+    to the `KeptnWorkload` and `KeptnApp` resources.
+  * **retries** (optional) -- If errors occur,
+    this defines the number of attempts made
+    before the `KeptnTask` is considered to be failed.
+  * **timeout** (optional) -- Specifies the time, in seconds,
+    to wait for the `KeptnTask` to complete successfully.
+    If the `KeptnTask` does not complete successfully in this timeframe,
+    it is considered to be failed.
 
 ## Usage
 
@@ -121,85 +133,25 @@ kubectl get pods
 ```
 
 Each time you want to rerun the `KeptnTask` resource,
-you must update the following fields
-to create a unique `KeptnTask` resource:
+you must update the value of the `metadata.name` field.
+A common practice is to just increment the value incrementally,
+so `helloworldtask-1` becomes `helloworldtask-2`, etc.
 
-* `name`
-* `spec.appVersion`
-* `spec.workloadVersion`
-* `spec.context.appVersion`
-* `spec.context.workloadVersion`
+TODO: Is there a way to capture the commit number or something
+to use in the metadata.name field?
 
-A common practice is to just increment the value of each field.
-
-## Examples
-
-For this example, the `KeptnTaskDefinition` resource is:
-
-```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnTaskDefinition 
-metadata:
-  name: helloworldtask
-spec:
-  retries: 0
-  timeout: 30s
-  container:
-    name: cowsay
-    image: rancher/cowsay:latest
-    args:
-      - 'hello world'
-```
-
-And the `KeptnTask` resource for the first run is:
-
-```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnTask
-metadata:
-  name: runhelloworld1
-spec:
-  workload: "my-workload"
-  workloadVersion: "1.0.0"
-  appVersion: "1.0.0"
-  app: "my-app"
-  taskDefinition: helloworldtask
-  context:
-    appName: "my-app"
-    appVersion: "1.0.0"
-    objectType: ""
-    taskType: ""
-    workloadName: "my-workload"
-    workloadVersion: "1.0.0"
-```
-
-The `KeptnTask resource for the second run is:
-
-```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
-kind: KeptnTask
-metadata:
-  name: runhelloworld2
-spec:
-  workload: "my-workload"
-  workloadVersion: "1.0.1"
-  appVersion: "1.0.1"
-  app: "my-app"
-  taskDefinition: helloworldtask
-  context:
-    appName: "my-app"
-    appVersion: "1.0.1"
-    objectType: ""
-    taskType: ""
-    workloadName: "my-workload"
-    workloadVersion: "1.0.1"
-```
+For a full example of how to create a `KeptnTask` resource
+to use for a deployment being done outside of Kubernetes, see
+[Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps/).
 
 ## Files
 
 [API reference](../crd-ref/lifecycle/v1alpha3/#keptntaskspec)
 
 ## Differences between versions
+
+The syntax of the `KeptnTask` resource changed significantly
+in Keptn v0.8.0.
 
 ## See also
 

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -49,7 +49,7 @@ spec:
     Names must comply with the
     [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
     specification.
-* **spec** - Defines the desired state of this `KeptnTask` resource
+* **spec** - Defines the speficication of this `KeptnTask` resource
   * **workload** - Name of the
       [KeptnWorkload](../crd-ref/lifecycle/v1alpha3/#keptnworkload)
       resource for which the `KeptnTask` is being executed.

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -205,4 +205,3 @@ spec:
 
 * [KeptnTaskDefinition](taskdefinition)
 * [Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps)
-

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -21,7 +21,7 @@ metadata:
 spec:
   taskDefinition: <name-of-KeptnTaskDefinition resource>
   context:
-    appName: "<name-of-KeptnApp-resource>""
+    appName: "<name-of-KeptnApp-resource>"
     appVersion: "1.0.0"
     objectType: ""
     taskType: ""
@@ -62,11 +62,6 @@ spec:
   * **appVersion** - Version of the `KeptnApp` resource
       for which the `KeptnTask` is being executed.
 
-      TODO: So I can create a `KeptnApp` resource that lists multiple workloads
-      to be processed?
-      Do I need to annotate the Workloads
-      and can I autocreate the `KeptnApp` or do I need to do it manually?
-
   * **taskDefinition** - Name of the corresponding `KeptnTaskDefinition` resource.
     This `KeptnTaskDefinition` can be located in the same namespace
     or in the `Keptn` name space.
@@ -76,11 +71,6 @@ spec:
       for which the `KeptnTask` is being executed.
     * **appVersion** - Version of the `KeptnApp` resource
       for which the `KeptnTask` is being executed.
-
-      TODO: So I can create a `KeptnApp` resource that lists multiple workloads
-      to be processed?
-      Do I need to annotate the Workloads
-      and can I autocreate the `KeptnApp` or do I need to do it manually?
 
     * **objectType** - Indicates whether this `KeptnTask`
       is being executed for a `KeptnApp` or a `KeptnWorkload` resource.
@@ -136,9 +126,6 @@ Each time you want to rerun the `KeptnTask` resource,
 you must update the value of the `metadata.name` field.
 A common practice is to just increment the value incrementally,
 so `helloworldtask-1` becomes `helloworldtask-2`, etc.
-
-TODO: Is there a way to capture the commit number or something
-to use in the metadata.name field?
 
 For a full example of how to create a `KeptnTask` resource
 to use for a deployment being done outside of Kubernetes, see

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -50,18 +50,6 @@ spec:
     [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
     specification.
 * **spec** - Defines the speficication of this `KeptnTask` resource
-  * **workload** - Name of the
-      [KeptnWorkload](../crd-ref/lifecycle/v1alpha3/#keptnworkload)
-      resource for which the `KeptnTask` is being executed.
-
-  * **workloadVersion** - `KeptnWorkload` version
-      for which the `KeptnTask` is being executed.
-  * **appName** - Name of the
-      [KeptnApp](../yaml-crd-ref/app.md) resource
-      for which the `KeptnTask` is being executed.
-  * **appVersion** - Version of the `KeptnApp` resource
-      for which the `KeptnTask` is being executed.
-
   * **taskDefinition** - Name of the corresponding `KeptnTaskDefinition` resource.
     This `KeptnTaskDefinition` can be located in the same namespace
     or in the Keptn installation namespace.

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -1,0 +1,208 @@
+---
+title: KeptnTask
+description: Define a run of a KeptnTaskDefinition
+weight: 85
+---
+
+Keptn populates the `KeptnTask` resource
+for tasks that deploy software on Kubernetes.
+When using Keptn to deploy software built on a virtual machine,
+you must manually populate the `KeptnTask` definition
+and modify it manually for each new run.
+
+## Synopsis
+
+```yaml
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnTask
+metadata:
+  name: <name-of-this-run>
+spec:
+  workload: "my-workload"
+  workloadVersion: "1.0.0"
+  appVersion: "1.0.0"
+  app: "my-app"
+  taskDefinition: helloworldtask
+  context:
+    appName: "my-app"
+    appVersion: "1.0.0"
+    objectType: ""
+    taskType: ""
+    workloadName: "my-workload"
+    workloadVersion: "1.0.0"
+```
+
+## Fields
+
+* **apiVersion** -- API version being used.
+`
+* **kind** -- Resource type.
+   Must be set to `KeptnTask`
+
+* **metadata**
+  * **name** -- Unique name of this run of the task.
+    This name must be modified each time you run this `KeptnTask`,
+    so a common practice is to add a number to the end of the string
+    used for the `name` field of the `KeptnTaskDefinition` resource
+    so you can increment the number for each run.
+    Names must comply with the
+    [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+    specification.
+* **spec** - Defines the desired state of this `KeptnTask` resource
+  * **workload** - Name of the
+      [KeptnWorkload](../crd-ref/lifecycle/v1alpha3/#keptnworkload)
+      resource for which the `KeptnTask` is being executed.
+
+      TODO: API ref shows `workloadName` and `workloadVersion`
+      in `TaskContext`, not directly in `spec`.
+      And I don't see a plain `workload` field.
+
+  * **workloadVersion** - `KeptnWorkload` version
+      for which the `KeptnTask` is being executed.
+  * **appName** - Name of the
+      [KeptnApp](../yaml-crd-ref/app) resource
+      for which the `KeptnTask` is being executed.
+  * **appVersion** - Version of the `KeptnApp` resource
+      for which the `KeptnTask` is being executed.
+
+      TODO: So I can create a `KeptnApp` resource that lists multiple workloads
+      to be processed?
+       Do I need to annotate the Workloads
+      and can I autocreate the `KeptnApp` or do I need to do it manually?
+
+      TODO: API reference shows `appName` and `appVersion` in `TaskContext`
+
+      TODO: API reference shows `parameters` and `secureParameters` here.
+      Should they be added to this list?
+
+      TODO: API reference also shows `CheckType`, `retries`, and `timeout` here.
+
+  * **taskDefinition** - Name of the corresponding `KeptnTaskDefinition` resource.
+  This `KeptnTaskDefinition` can be located in the same namespace
+  or in the Keptn name space.
+    * **context** - Contextual information about the task execution
+      * **appName** - Name of the
+          [KeptnApp](../yaml-crd-ref/app) resource
+          for which the `KeptnTask` is being executed.
+      * **appVersion** - Version of the `KeptnApp` resource
+          for which the `KeptnTask` is being executed.
+
+          TODO: So I can create a `KeptnApp` resource that lists multiple workloads
+          to be processed?
+           Do I need to annotate the Workloads
+          and can I autocreate the `KeptnApp` or do I need to do it manually?
+      * **objectType** - Indicates whether this `KeptnTask`
+          is being executed for a `KeptnApp` or a `KeptnWorkload` resource.
+
+          TODO: So why is this set to null (`""`) in the example?
+      * **taskType** Indicates whether this `KeptnTask`
+          is part of the pre- or post-deployment phase
+
+          TODO: So why is this set to null (`""`) in the example?
+
+      * **workloadName** - Name of the `KeptnWorkload`
+          for which the `KeptnTask` is being executed
+      * **workloadVersion** - Version of the `KeptnWorkload`
+          for which the `KeptnTask` is being executed
+
+          TODO: Why are these fields both here and directly in `spec` above?
+
+## Usage
+
+Applying this file causes Keptn to create a Job and a Pod
+and run the associated `KeptnTaskDefinition`.
+
+Use the following commands to show the current status of the jobs:
+
+```shell
+kubectl get keptntasks
+kubectl get pods
+```
+
+Each time you want to rerun the `KeptnTask` resource,
+you must update the follow fields
+to create a unique `KeptnTask` name
+the `KeptnTask` name needs to be unique, update the follow fields:
+
+* `name`
+* `spec.appVersion`
+* `spec.workloadVersion`
+* `spec.context.appVersion`
+* `spec.context.workloadVersion`
+
+A common practice is to just increment the value of each field.
+
+## Examples
+
+For this example, the `KeptnTaskDefinition` resource is:
+
+```yaml
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnTaskDefinition 
+metadata:
+  name: helloworldtask
+spec:
+  retries: 0
+  timeout: 30s
+  container:
+    name: cowsay
+    image: rancher/cowsay:latest
+    args:
+      - 'hello world'
+```
+
+And the `KeptnTask` resource for the first run is:
+
+```yaml
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnTask
+metadata:
+  name: runhelloworld1
+spec:
+  workload: "my-workload"
+  workloadVersion: "1.0.0"
+  appVersion: "1.0.0"
+  app: "my-app"
+  taskDefinition: helloworldtask
+  context:
+    appName: "my-app"
+    appVersion: "1.0.0"
+    objectType: ""
+    taskType: ""
+    workloadName: "my-workload"
+    workloadVersion: "1.0.0"
+```
+
+The `KeptnTask resource for the second run is:
+
+```yaml
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnTask
+metadata:
+  name: runhelloworld2
+spec:
+  workload: "my-workload"
+  workloadVersion: "1.0.1"
+  appVersion: "1.0.1"
+  app: "my-app"
+  taskDefinition: helloworldtask
+  context:
+    appName: "my-app"
+    appVersion: "1.0.1"
+    objectType: ""
+    taskType: ""
+    workloadName: "my-workload"
+    workloadVersion: "1.0.1"
+```
+
+## Files
+
+[API reference](../crd-ref/lifecycle/v1alpha3/#keptntaskspec)
+
+## Differences between versions
+
+## See also
+
+* [KeptnTaskDefinition](taskdefinition)
+* [Keptn for Non-Kubernetes Applications](../implementing/tasks-non-k8s-apps)
+

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -6,7 +6,8 @@ weight: 85
 
 Keptn populates the `KeptnTask` resource
 for tasks that deploy software on Kubernetes.
-When using Keptn to deploy software built on a virtual machine,
+When using Keptn to run tasks for software
+that is deployed outside of Kubernetes,
 you must manually populate the `KeptnTask` definition
 and modify it manually for each new run.
 

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -89,9 +89,9 @@ spec:
       to the `KeptnWorkload` and `KeptnApp` resources.
 
     * **workloadName** - Name of the `KeptnWorkload`
-      for which the `KeptnTask` is being executed
+      for which the `KeptnTask` is being executed.
     * **workloadVersion** - Version of the `KeptnWorkload`
-      for which the `KeptnTask` is being executed
+      for which the `KeptnTask` is being executed.
   * **parameters** (optional) -- Parameters that are passed to the job
     that executes the `KeptnTask`.
   * **secureParameters** (optional) -- Secure parameters that are passed

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -120,9 +120,8 @@ kubectl get pods
 ```
 
 Each time you want to rerun the `KeptnTask` resource,
-you must update the follow fields
-to create a unique `KeptnTask` name
-the `KeptnTask` name needs to be unique, update the follow fields:
+you must update the following fields
+to create a unique `KeptnTask` resource:
 
 * `name`
 * `spec.appVersion`

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -64,7 +64,7 @@ spec:
 
   * **taskDefinition** - Name of the corresponding `KeptnTaskDefinition` resource.
     This `KeptnTaskDefinition` can be located in the same namespace
-    or in the `Keptn` name space.
+    or in the Keptn installation namespace.
   * **context** - Contextual information about the task execution
     * **appName** - Name of the
       [KeptnApp](../yaml-crd-ref/app.md) resource

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -8,7 +8,7 @@ Keptn populates the `KeptnTask` resource
 for tasks that deploy software on Kubernetes.
 When using Keptn to run tasks for software
 that is deployed outside of Kubernetes,
-you must manually populate the `KeptnTask` definition
+you must create the `KeptnTask` definition manually
 and modify it manually for each new run.
 
 ## Synopsis
@@ -23,9 +23,9 @@ spec:
   workloadVersion: "1.0.0"
   appVersion: "1.0.0"
   app: "my-app"
-  taskDefinition: helloworldtask
+  taskDefinition: <name-of-KeptnTaskDefinition resource>
   context:
-    appName: "my-app"
+    appName: "<name-of-KeptnApp-resource>""
     appVersion: "1.0.0"
     objectType: ""
     taskType: ""

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -6,7 +6,7 @@ weight: 85
 
 When using Keptn to run tasks for software
 that is deployed outside of Kubernetes,
-you must create the `KeptnTask` definition manually
+you must create the `KeptnTask` resource manually
 and modify it manually for each new run.
 Keptn automatically populates the `KeptnTask` resource
 for tasks that deploy software on Kubernetes.

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -83,8 +83,8 @@ spec:
     * **taskType** Indicates whether this `KeptnTask`
       is part of the pre- or post-deployment phase.
       When populating this resource manually
-      to run a task for a non-Kubernetes deployment,,
-u     set this value to `""`:
+      to run a task for a non-Kubernetes deployment,
+      set this value to `""`:
       Keptn populates this field based on annotations
       to the `KeptnWorkload` and `KeptnApp` resources.
 

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -96,7 +96,7 @@ spec:
     that executes the `KeptnTask`.
   * **secureParameters** (optional) -- Secure parameters that are passed
     to the job that executes the `KeptnTask`.
-    These are stored and accessed as secrets in the cluster.
+    These are stored and accessed as Kubernetes `Secrets` in the cluster.
     See [Working with secrets](../implementing/tasks/#working-with-secrets)
     for more information.
   * **checkType** -- Defines whether task is part of pre- or post-deployment phase.


### PR DESCRIPTION
This PR and https://github.com/keptn/lifecycle-toolkit/pull/2089 replace https://github.com/keptn/lifecycle-toolkit/pull/2086 .

This PR:

* Expands the content of the "Keptn for non-Kubernetes Applications" guide chapter a bit.
* Creates a reference page for `KeptnTask` in the yaml-crd-ref section.  Normally, `KeptnTask` is generated automatically but, in this case, the user must populate and maintain it manually so we need to document the YAML syntax.
* The reference page no longer has an example but instead links to the guide chapter.  We do not need to be maintaining two examples and, in this case, it makes more sense to have the `KeptnTask` example presented in the context of running a `KeptnTask` for a non-k8s deployment.

28 September review notes:
* The initial draft was based on outdated API info.  That has been corrected.
* Please verify that I got the descriptions of the fields correct on the reference page.  I improved a bit.
* I think some steps are missing from the guide procedure:
  * When I apply my `KeptnTask` resource from my KinD cluster, how does it know which VM/whatever to target?
  * Instructions say nothing about populating `KeptnApp` or workload resources yet the `KeptnTask` yaml file does have fields for these.  How does the user know what value to use for those fields?  Or maybe some of these fields are ignored in this case?  We need to clarify this.
  * What about `KeptnTask` fields (such as `timeout`) that are also in `KeptnTaskDefintion`?  If the user uses these, do they need to be sure that `KeptnTask` and the corresponding `KeptnTaskDefinition` assign the same value to that field or does Keptn reconcile them or does one of them take precedence over the other?