### PR TITLE
docs: correct link to Helm CLI installation info

### DIFF
--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -11,7 +11,7 @@ The following is an imperative walkthrough.
 
 - [Docker](https://docs.docker.com/get-started/overview/)
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/)
-- [Helm CLI](https://helm.sh/docs/intro/install/)
+- [Helm](https://helm.sh/docs/intro/install/)
 - A Kubernetes cluster >= 1.24 (we recommend [Kubernetes kind](https://kind.sigs.k8s.io/docs/user/quick-start/))
   (`kind create cluster`)
 

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -11,9 +11,9 @@ The following is an imperative walkthrough.
 
 - [Docker](https://docs.docker.com/get-started/overview/)
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/)
+- [Helm CLI](https://helm.sh/docs/intro/install/)
 - A Kubernetes cluster >= 1.24 (we recommend [Kubernetes kind](https://kind.sigs.k8s.io/docs/user/quick-start/))
   (`kind create cluster`)
-- [Helm](https://helm.io)
 
 ## Objectives
 

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -67,7 +67,7 @@ Your cluster should include the following:
 
 * [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
-* [Helm CLI](https://helm.sh/docs/intro/install/)
+* [Helm](https://helm.sh/docs/intro/install/)
 
 * Metric provider such as
   [Prometheus](https://prometheus.io/),

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -67,6 +67,8 @@ Your cluster should include the following:
 
 * [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
+* [Helm CLI](https://helm.sh/docs/intro/install/)
+
 * Metric provider such as
   [Prometheus](https://prometheus.io/),
   [Dynatrace](https://www.dynatrace.com/),


### PR DESCRIPTION
The new getting-started exercise references helm.io which is a bogus site that is sometimes causing markdownlint to complain.  I fixed that link to point to the installation instructions for Helm CLI, and also added that link to the installation page that lists software that should be installed to use Keptn.