### PR TITLE
docs: remove yaml-crd-ref/evaluationprovider.md

### DIFF
--- a/docs/content/en/docs/yaml-crd-ref/evaluationprovider.md
+++ b/docs/content/en/docs/yaml-crd-ref/evaluationprovider.md
@@ -1,5 +1,0 @@
----
-title: KeptnEvaluationProvider
-description: Define the evaluation provider
-weight: 28
----


### PR DESCRIPTION
The `KeptnEvaluationProvider` CRD was deprecated a few releases ago and nobody should be running Keptn releases that use it so time to delete the content-free reference page.