### PR TITLE
docs: fix YAML typo

### DIFF
--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -131,8 +131,6 @@ spec:
         ports:
         - containerPort: 80
 ---
-apiVersion: apps/v1
-kind: Service
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
This PR:

- Fixes a typo on the getting started guide
- Remove the duplicate `api` and `kind` fields in the `Service` YAML