### PR TITLE
feat: add test and lint cmd to makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,26 @@ install-prometheus:
 	kubectl wait --for=condition=available deployment/kube-state-metrics -n monitoring --timeout=120s
 	kubectl wait pod/prometheus-k8s-0 --for=condition=ready --timeout=120s -n monitoring
 
+.PHONY: metrics-operator-test
+metrics-operator-test:
+	$(MAKE) -C metrics-operator test
+
+.PHONY: certmanager-test
+certmanager-test:
+	$(MAKE) -C klt-cert-manager test
+
+.PHONY: operator-test
+operator-test:
+	$(MAKE) -C lifecycle-operator test
+
+.PHONY: scheduler-test
+scheduler-test:
+	$(MAKE) -C scheduler test
+
+#command(make test) to run all tests 
+.PHONY: test
+test: metrics-operator-test certmanager-test operator-test scheduler-test integration-test
+
 .PHONY: cleanup-manifests
 cleanup-manifests:
 	rm -rf manifests
@@ -101,3 +121,25 @@ include docs/Makefile
 
 yamllint:
 	@docker run --rm -t -v $(PWD):/data cytopia/yamllint:$(YAMLLINT_VERSION) .
+
+##Run lint for the subfiles
+.PHONY: metrics-operator-lint
+metrics-operator-lint:
+	$(MAKE) -C metrics-operator lint
+
+.PHONY: certmanager-lint
+certmanager-lint:
+	$(MAKE) -C klt-cert-manager lint
+
+.PHONY: operator-lint
+operator-lint:
+	$(MAKE) -C lifecycle-operator lint
+
+.PHONY: scheduler-lint
+scheduler-lint:
+	$(MAKE) -C scheduler lint
+
+.PHONY: lint
+lint: 
+	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	metrics-operator-lint certmanager-lint operator-lint scheduler-lint

--- a/klt-cert-manager/Makefile
+++ b/klt-cert-manager/Makefile
@@ -77,6 +77,9 @@ vet: ## Run go vet against code.
 unit-test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
+#command(make test) to run all tests 
+.PHONY: test
+test: unit-test
 ##@ Build
 
 .PHONY: build
@@ -187,3 +190,8 @@ push-local:
 release-manifests:
 	kustomize build config/default > config/rendered/release.yaml
 	envsubst < config/rendered/release.yaml > tmp.yaml; mv tmp.yaml config/rendered/release.yaml
+
+##golangci-lint
+.PHONY: lint
+lint:
+	${GOPATH}/bin/golangci-lint run --config ../.golangci.yml -v

--- a/lifecycle-operator/Makefile
+++ b/lifecycle-operator/Makefile
@@ -125,6 +125,10 @@ performance-test: manifests generate envtest ## Run tests.
 e2e-test: manifests generate envtest ## Run tests.
 	go test ./test/e2e -v -coverprofile cover.out --ginkgo.focus="E2E"
 
+#command(make test) to run all tests 
+.PHONY: test
+test: unit-test component-test performance-test e2e-test 
+
 ##@ Build
 .PHONY: build
 build: generate ## Build manager binary.
@@ -244,3 +248,8 @@ push-local:
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 ;\
 	fi
 	docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)
+
+##golangci-lint
+.PHONY: lint
+lint:
+	${GOPATH}/bin/golangci-lint run --config ../.golangci.yml -v

--- a/metrics-operator/Makefile
+++ b/metrics-operator/Makefile
@@ -86,6 +86,10 @@ vet: ## Run go vet against code.
 unit-test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+#command(make test) to run all tests 
+.PHONY: test
+test: unit-test
+
 ##@ Build
 .PHONY: build
 build: generate ## Build manager binary.
@@ -205,3 +209,8 @@ push-local:
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 ;\
 	fi
 	docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)
+
+##golangci-lint
+.PHONY: lint
+lint:
+	${GOPATH}/bin/golangci-lint run --config ../.golangci.yml -v

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -92,6 +92,10 @@ unit-test: manifests fmt vet envtest## Run tests.
 	cat cover-main.out cover-pkg.out >> cover.out
 	rm cover-pkg.out cover-main.out
 
+#command(make test) to run all tests 
+.PHONY: test
+test: e2e-test unit-test
+
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -172,3 +176,8 @@ push-local:
 		docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)-arm64 ;\
 	fi
 	docker push $(RELEASE_REGISTRY)/$(RELEASE_IMAGE)
+
+##golangci-lint
+.PHONY: lint
+lint:
+	${GOPATH}/bin/golangci-lint run --config ../.golangci.yml -v


### PR DESCRIPTION
fixes: #1935
* add golangci-lint cmd in subfiles as well as in root makefile
* add test cmd for in subfiles as well as in root makefile