### PR TITLE
deps: bump image version of python-runtime

### DIFF
--- a/runtimes/python-runtime/Dockerfile
+++ b/runtimes/python-runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine AS production
+FROM python:3.11.5-alpine AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \


### PR DESCRIPTION
Fixes: #2164 

Security scan: https://github.com/keptn/lifecycle-toolkit/actions/runs/6337202206