### PR TITLE
feat(lifecycle-operator): automatically decide for scheduler installation based on k8s version

### DIFF
--- a/docs/assets/scheduler-gates/gate-removed.yaml
+++ b/docs/assets/scheduler-gates/gate-removed.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    keptn.sh/scheduling-gate-removed: "true"

--- a/docs/assets/scheduler-gates/gated.yaml
+++ b/docs/assets/scheduler-gates/gated.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  schedulingGates:
+    - name: "keptn-prechecks-gate"

--- a/docs/assets/scheduler-gates/scheduler.yaml
+++ b/docs/assets/scheduler-gates/scheduler.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  schedulerName: keptn-scheduler

--- a/docs/content/en/docs/architecture/_index.md
+++ b/docs/content/en/docs/architecture/_index.md
@@ -3,7 +3,6 @@ title: Architecture
 linktitle: Architecture
 description: Understand the details of how Keptn works
 weight: 50
-cascade:
 ---
 
 ### Keptn Components

--- a/docs/content/en/docs/architecture/components/_index.md
+++ b/docs/content/en/docs/architecture/components/_index.md
@@ -3,7 +3,6 @@ title: Keptn Components
 linktitle: Components
 description: Basic understanding of Keptn Components
 weight: 20
-cascade:
 ---
 
 ### Keptn Components

--- a/docs/content/en/docs/architecture/components/lifecycle-operator/_index.md
+++ b/docs/content/en/docs/architecture/components/lifecycle-operator/_index.md
@@ -3,7 +3,6 @@ title: Keptn Lifecycle Operator
 linktitle: Lifecycle Operator
 description: Basic understanding of the Keptn Lifecycle Operator
 weight: 80
-cascade:
 ---
 
 

--- a/docs/content/en/docs/architecture/components/metrics-operator/_index.md
+++ b/docs/content/en/docs/architecture/components/metrics-operator/_index.md
@@ -3,7 +3,6 @@ title: Keptn Metrics Operator
 linktitle: Metrics Operator
 description: Basic understanding of Keptn's Metrics Operator
 weight: 80
-cascade:
 ---
 
 The Keptn Metrics Operator collects, processes,

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -13,7 +13,7 @@ On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 
-If the Keptn helm chart value `schedulingGatesEnabled` is set to to `true`, and Keptn is running on a Kubernetes version greater than 1.26,
+If the Keptn helm chart value `schedulingGatesEnabled` is set to `true`, and Keptn is running on a Kubernetes version greater than 1.26,
 Keptn does not install a scheduler plugin.
 Instead, it uses
 the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -29,7 +29,7 @@ This spec tells the Kubernetes scheduling framework
 to wait for  the Keptn checks before assigning the pod to a node.
 
 For instance a pod gated by keptn looks like the following:
-{{<embed path="/docs/assets/scheduler-gates/gated.yaml">}}
+{{< embed path="/docs/assets/scheduler-gates/gated.yaml" >}}
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that
 need to be performed before the Pod can be scheduled.
@@ -41,7 +41,7 @@ When removing the gate, the WorkloadInstance controller also adds the following 
 if the spec is updated,
 the Pod is not gated again:
 
-{{<embed path="/docs/assets/scheduler-gates/gate-removed.yaml">}}
+{{< embed path="/docs/assets/scheduler-gates/gate-removed.yaml" >}}
 
 ## Keptn Scheduler for K8s 1.26 and earlier
 
@@ -68,7 +68,7 @@ If the annotations are present, the Webhook assigns the **Keptn Scheduler** to t
 This ensures that the Keptn Scheduler only gets Pods that have been annotated for it.
 A Pod `test-pod` modified by the Mutating Webhook looks as follows:
 
-{{<embed path="/docs/assets/scheduler-gates/scheduler.yaml">}}
+{{< embed path="/docs/assets/scheduler-gates/scheduler.yaml" >}}
 
 If the Pod is annotated with Keptn specific annotations, the Keptn Scheduler retrieves
 the WorkloadInstance CRD that is associated with the Pod.

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -14,7 +14,8 @@ The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 
 If you set Keptn helm chart value `schedulingGatesEnabled` to `true`, and you do have a K8s version greater than 1.26,
-Keptn will not install a scheduler plugin, but it will use
+Keptn does not install a scheduler plugin.
+Instead, it uses
 the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
 ## Keptn Scheduling Gates for K8s 1.27 and above

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -15,15 +15,17 @@ the deployment process.
 
 From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26,
 Keptn
-uses the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
+uses
+the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
 ## Keptn Scheduling Gates for K8s 1.27 and above
 
 When you apply a workload to a K8s cluster, the Mutating Webhook checks for annotations on Pods to
 see if it is annotated with
 [Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
-If the annotations are present, the Webhook adds a gate to the Pod called "keptn-prechecks-gate",
-this is a spec that tells the default scheduler to wait for Keptn's checks before assigning the pod to a node.
+If the annotations are present, the Webhook adds a gate to the Pod called `keptn-prechecks-gate`,
+this is a spec that tells the Kubernetes scheduling framework to wait for Keptn's checks before assigning the pod to a
+node.
 
 For instance a pod gated by keptn will look like the following:
 

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -13,11 +13,11 @@ On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 
-If the Keptn helm chart value `schedulingGatesEnabled` is set to `true`, and Keptn is running on a Kubernetes version greater than 1.26,
-Keptn does not install a scheduler plugin.
+If the Keptn helm chart value `schedulingGatesEnabled` is set to `true`, and Keptn is running on a Kubernetes version
+greater than 1.26, Keptn does not install a scheduler plugin.
 Instead, it uses
-the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
-
+the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness) 
+to gate Pods until the required deployment checks pass.
 ## Keptn Scheduling Gates for K8s 1.27 and above
 
 When you apply a workload to a K8s cluster, the Mutating Webhook checks for annotations on Pods to

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -19,11 +19,11 @@ uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduli
 
 ## Keptn Scheduling Gates for K8s 1.27.0 and above
 
-Firstly the Mutating Webhook checks for annotations on Pods to see if it is annotated with
+When you apply a workload to a K8s cluster, the Mutating Webhook checks for annotations on Pods to
+see if it is annotated with
 [Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
-If the annotations are present, the Webhook adds a gate to the Pod called "keptn-prechecks-gate", this is a spec that
-tells the
-default scheduler to wait.
+If the annotations are present, the Webhook adds a gate to the Pod called "keptn-prechecks-gate",
+this is a spec that tells the default scheduler to wait for Keptn's checks before assigning the pod to a node.
 
 For instance a pod gated by keptn will look like the following:
 
@@ -40,12 +40,11 @@ spec:
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that
 need to be performed before the Pod can be scheduled.
-When the Workload Instance controller finishes these
-pre-checks it will decide if the `pre-deployment` checks have finished successfully, to remove the gate from the Pod.
+If the `pre-deployment` checks have finished successfully, the WorkloadInstance Controller removes the gate from the Pod.
 The default scheduler can then allow the Pod to be scheduled to a node.
 If the `pre-deployment` checks have not yet finished, the gate will stay and the Pod will remain pending.
-When removing the gate, the WorkloadInstance controller alo adds the following annotation,
-to avoid gating again the pod in case of a later update:
+When removing the gate, the WorkloadInstance controller also adds the following annotation, so that if there is an update of the spec the 
+Pod will not be gated again:
 
 ```yaml
 apiVersion: v1
@@ -70,7 +69,7 @@ scheduler has (typically CPU and memory values).
 The Keptn Scheduler uses the Kubernetes
 [Scheduler Framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) and is based on the
 [Scheduler Plugins Repository](https://github.com/kubernetes-sigs/scheduler-plugins/tree/master).
-Additionally it registers itself as
+Additionally, it registers itself as
 a [Permit plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#permit).
 
 ### How does the Keptn Scheduler works
@@ -127,7 +126,7 @@ Also the Keptn Scheduler will not schedule Pods to nodes that have failed `pre-d
 checks in the past.
 This helps to prevent Pods from being scheduled to nodes that are not ready for them.
 
-# Integrating Keptn with your custom scheduler
+## Integrating Keptn with your custom scheduler
 
 Keptn scheduling logics are compatible with
 the [Scheduler Framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -13,9 +13,8 @@ On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 
-From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26,
-Keptn
-uses
+If you set Keptn helm chart value `schedulingGatesEnabled` to `true`, and you do have a K8s version greater than 1.26,
+Keptn will not install a scheduler plugin, but it will use
 the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
 ## Keptn Scheduling Gates for K8s 1.27 and above
@@ -28,17 +27,7 @@ this is a spec that tells the Kubernetes scheduling framework to wait for Keptn'
 node.
 
 For instance a pod gated by keptn will look like the following:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-pod
-spec:
-  schedulingGates:
-    - name: "keptn-prechecks-gate"
-  ...
-```
+{{<embed path="/docs/assets/scheduler-gates/gated.yaml">}}
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that
 need to be performed before the Pod can be scheduled.
@@ -49,14 +38,7 @@ If the `pre-deployment` checks have not yet finished, the gate will stay and the
 When removing the gate, the WorkloadInstance controller also adds the following annotation, so that if there is an
 update of the spec the Pod will not be gated again:
 
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-pod
-  annotations:
-    keptn.sh/scheduling-gate-removed: "true"
-```
+{{<embed path="/docs/assets/scheduler-gates/gate-removed.yaml">}}
 
 ## Keptn Scheduler for K8s 1.26 and lower
 
@@ -83,15 +65,7 @@ If the annotations are present, the Webhook assigns the **Keptn Scheduler** to t
 This ensures that the Keptn Scheduler only gets Pods that have been annotated for it.
 A Pod `test-pod` modified by the Mutating Webhook will look as follows:
 
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-pod
-spec:
-  schedulerName: default-scheduler
-  ...
-```
+{{<embed path="/docs/assets/scheduler-gates/scheduler.yaml">}}
 
 If the Pod is annotated with Keptn specific annotations, the Keptn Scheduler retrieves
 the WorkloadInstance CRD that is associated with the Pod.

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -9,7 +9,7 @@ cascade:
 Keptn needs to integrate with Kubernetes scheduling to block
 the deployment of applications that do not satisfy Keptn defined pre-deployment checks.
 
-On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block applications deployment.
+On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block application deployment.
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -22,7 +22,7 @@ the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/sched
 
 When you apply a workload to a K8s cluster, the Mutating Webhook checks for annotations on Pods to
 see if it is annotated with
-[Keptn specific annotations](../../implementing/integrate/#basic-annotations).
+[Keptn specific annotations](../../../implementing/integrate/#basic-annotations).
 If the annotations are present, the Webhook adds a gate to the Pod called `keptn-prechecks-gate`,
 this is a spec that tells the Kubernetes scheduling framework to wait for Keptn's checks before assigning the pod to a
 node.
@@ -61,7 +61,7 @@ a [Permit plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/schedu
 ### How does the Keptn Scheduler works
 
 Firstly the Mutating Webhook checks for annotations on Pods to see if it is annotated with
-[Keptn specific annotations](../../implementing/integrate/#basic-annotations).
+[Keptn specific annotations](../../../implementing/integrate/#basic-annotations).
 If the annotations are present, the Webhook assigns the **Keptn Scheduler** to the Pod.
 This ensures that the Keptn Scheduler only gets Pods that have been annotated for it.
 A Pod `test-pod` modified by the Mutating Webhook will look as follows:

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -8,9 +8,11 @@ cascade:
 
 Keptn needs to interfere on the Kuberetes scheduling to be able to block
 the deployment of applications that do not satisfy Keptn defined pre-deployment checks.
+
 On Kubernetes versions older and including 1.26.0, Keptn uses a Scheduler to block applications deployment.
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
+
 From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26.0, instead of a scheduler plugin,
 Keptn
 uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -13,7 +13,7 @@ On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 
-If you set Keptn helm chart value `schedulingGatesEnabled` to `true`, and you do have a K8s version greater than 1.26,
+If the Keptn helm chart value `schedulingGatesEnabled` is set to to `true`, and Keptn is running on a Kubernetes version greater than 1.26,
 Keptn does not install a scheduler plugin.
 Instead, it uses
 the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -1,23 +1,23 @@
 ---
-title: Keptn Lifecycle Scheduling
+title: Keptn integration with Scheduling
 linktitle: Scheduler and Scheduling Gates
-description: Basic understanding of the Keptn Scheduler
+description: Basic understanding of how Keptn integrates with Kubernetes Pod Scheduling
 weight: 80
 cascade:
 ---
 
-Keptn needs to interfere on the Kuberetes scheduling to be able to block
+Keptn needs to integrate with Kubernetes scheduling to block
 the deployment of applications that do not satisfy Keptn defined pre-deployment checks.
 
-On Kubernetes versions older and including 1.26.0, Keptn uses a Scheduler to block applications deployment.
+On Kubernetes versions older and including 1.26, Keptn uses a Scheduler to block applications deployment.
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
 
-From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26.0, instead of a scheduler plugin,
+From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26,
 Keptn
-uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
+uses the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
-## Keptn Scheduling Gates for K8s 1.27.0 and above
+## Keptn Scheduling Gates for K8s 1.27 and above
 
 When you apply a workload to a K8s cluster, the Mutating Webhook checks for annotations on Pods to
 see if it is annotated with
@@ -42,7 +42,7 @@ The **WorkloadInstance CRD** contains information about the `pre-deployment` che
 need to be performed before the Pod can be scheduled.
 If the `pre-deployment` checks have finished successfully, the WorkloadInstance Controller removes the gate from the
 Pod.
-The default scheduler can then allow the Pod to be scheduled to a node.
+The scheduler can then allow the Pod to be scheduled to a node.
 If the `pre-deployment` checks have not yet finished, the gate will stay and the Pod will remain pending.
 When removing the gate, the WorkloadInstance controller also adds the following annotation, so that if there is an
 update of the spec the Pod will not be gated again:
@@ -56,7 +56,7 @@ metadata:
     keptn.sh/scheduling-gate-removed: "true"
 ```
 
-## Keptn Scheduler for K8s 1.26.0 and lower
+## Keptn Scheduler for K8s 1.26 and lower
 
 The **Keptn Scheduler** works by registering itself as a Permit plugin within the Kubernetes
 scheduling cycle that ensures that Pods are scheduled to a node until and unless the

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -37,7 +37,8 @@ spec:
 ```
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that
-need to be performed before the Pod can be scheduled. When the Workload Instance controller finishes these
+need to be performed before the Pod can be scheduled.
+When the Workload Instance controller finishes these
 pre-checks it will decide if the `pre-deployment` checks have finished successfully, to remove the gate from the Pod.
 The default scheduler can then allow the Pod to be scheduled to a node.
 If the `pre-deployment` checks have not yet finished, the gate will stay and the Pod will remain pending.

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -15,7 +15,7 @@ From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26.0, inst
 Keptn
 uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
-## Keptn Scheduling Gates for K8s 1.27.0 and above
+# Keptn Scheduling Gates for K8s 1.27.0 and above
 
 Firstly the Mutating Webhook checks for annotations on Pods to see if it is annotated with
 [Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
@@ -54,7 +54,7 @@ metadata:
     keptn.sh/scheduling-gate-removed: "true"
 ```
 
-## Keptn Scheduler for K8s 1.26.0 and lower
+# Keptn Scheduler for K8s 1.26.0 and lower
 
 The **Keptn Scheduler** works by registering itself as a Permit plugin within the Kubernetes
 scheduling cycle that ensures that Pods are scheduled to a node until and unless the
@@ -125,7 +125,7 @@ Also the Keptn Scheduler will not schedule Pods to nodes that have failed `pre-d
 checks in the past.
 This helps to prevent Pods from being scheduled to nodes that are not ready for them.
 
-### Integrating Keptn with your custom scheduler
+# Integrating Keptn with your custom scheduler
 
 Keptn scheduling logics are compatible with
 the [Scheduler Framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -6,12 +6,14 @@ weight: 80
 cascade:
 ---
 
+Keptn needs to interfere on the Kuberetes scheduling to be able to block
+the deployment of applications that do not satisfy Keptn defined pre-deployment checks.
 On Kubernetes versions older and including 1.26.0, Keptn uses a Scheduler to block applications deployment.
-From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26.0, instead of a scheduler plugin,
-Keptn
-uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).  
 The **Keptn Scheduler** is an integral component of Keptn that orchestrates
 the deployment process.
+From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26.0, instead of a scheduler plugin,
+Keptn
+uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
 ## Keptn Scheduling Gates for K8s 1.27.0 and above
 
@@ -31,7 +33,7 @@ metadata:
 spec:
   schedulingGates:
     - name: "keptn-prechecks-gate"
-
+  ...
 ```
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that
@@ -74,6 +76,17 @@ Firstly the Mutating Webhook checks for annotations on Pods to see if it is anno
 [Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
 If the annotations are present, the Webhook assigns the **Keptn Scheduler** to the Pod.
 This ensures that the Keptn Scheduler only gets Pods that have been annotated for it.
+A Pod `test-pod` modified by the Mutating Webhook will look as follows:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  schedulerName: default-scheduler
+  ...
+```
 
 If the Pod is annotated with Keptn specific annotations, the Keptn Scheduler retrieves
 the WorkloadInstance CRD that is associated with the Pod.

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -40,11 +40,12 @@ spec:
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that
 need to be performed before the Pod can be scheduled.
-If the `pre-deployment` checks have finished successfully, the WorkloadInstance Controller removes the gate from the Pod.
+If the `pre-deployment` checks have finished successfully, the WorkloadInstance Controller removes the gate from the
+Pod.
 The default scheduler can then allow the Pod to be scheduled to a node.
 If the `pre-deployment` checks have not yet finished, the gate will stay and the Pod will remain pending.
-When removing the gate, the WorkloadInstance controller also adds the following annotation, so that if there is an update of the spec the 
-Pod will not be gated again:
+When removing the gate, the WorkloadInstance controller also adds the following annotation, so that if there is an
+update of the spec the Pod will not be gated again:
 
 ```yaml
 apiVersion: v1

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -124,3 +124,10 @@ been reached, the Keptn Scheduler tells Kubernetes to check again later.
 Also the Keptn Scheduler will not schedule Pods to nodes that have failed `pre-deployment`
 checks in the past.
 This helps to prevent Pods from being scheduled to nodes that are not ready for them.
+
+### Integrating Keptn with your custom scheduler
+
+Keptn scheduling logics are compatible with
+the [Scheduler Framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/).
+Keptn will not work with a custom scheduler unless it is implemented as
+a [scheduler plugins](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#plugin-configuration).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -17,6 +17,7 @@ greater than 1.26, Keptn does not install a scheduler plugin.
 Instead, it uses
 the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness) 
 to gate Pods until the required deployment checks pass.
+
 ## Keptn Scheduling Gates for K8s 1.27 and above
 
 When you apply a workload to a K8s cluster,

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -21,7 +21,7 @@ the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/sched
 
 When you apply a workload to a K8s cluster, the Mutating Webhook checks for annotations on Pods to
 see if it is annotated with
-[Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
+[Keptn specific annotations](../../implementing/integrate/#basic-annotations).
 If the annotations are present, the Webhook adds a gate to the Pod called `keptn-prechecks-gate`,
 this is a spec that tells the Kubernetes scheduling framework to wait for Keptn's checks before assigning the pod to a
 node.
@@ -60,7 +60,7 @@ a [Permit plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/schedu
 ### How does the Keptn Scheduler works
 
 Firstly the Mutating Webhook checks for annotations on Pods to see if it is annotated with
-[Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
+[Keptn specific annotations](../../implementing/integrate/#basic-annotations).
 If the annotations are present, the Webhook assigns the **Keptn Scheduler** to the Pod.
 This ensures that the Keptn Scheduler only gets Pods that have been annotated for it.
 A Pod `test-pod` modified by the Mutating Webhook will look as follows:

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -15,7 +15,7 @@ From Keptn v0.8.4 onward, if you do have a K8s version greater than 1.26.0, inst
 Keptn
 uses [K8s Pod Scheduling Readiness](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness).
 
-# Keptn Scheduling Gates for K8s 1.27.0 and above
+## Keptn Scheduling Gates for K8s 1.27.0 and above
 
 Firstly the Mutating Webhook checks for annotations on Pods to see if it is annotated with
 [Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).
@@ -54,7 +54,7 @@ metadata:
     keptn.sh/scheduling-gate-removed: "true"
 ```
 
-# Keptn Scheduler for K8s 1.26.0 and lower
+## Keptn Scheduler for K8s 1.26.0 and lower
 
 The **Keptn Scheduler** works by registering itself as a Permit plugin within the Kubernetes
 scheduling cycle that ensures that Pods are scheduled to a node until and unless the
@@ -71,7 +71,7 @@ The Keptn Scheduler uses the Kubernetes
 Additionally it registers itself as
 a [Permit plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/#permit).
 
-## How does the Keptn Scheduler works
+### How does the Keptn Scheduler works
 
 Firstly the Mutating Webhook checks for annotations on Pods to see if it is annotated with
 [Keptn specific annotations](https://main.lifecycle.keptn.sh/docs/implementing/integrate/#basic-annotations).

--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -3,7 +3,6 @@ title: Keptn integration with Scheduling
 linktitle: Scheduler and Scheduling Gates
 description: Basic understanding of how Keptn integrates with Kubernetes Pod Scheduling
 weight: 80
-cascade:
 ---
 
 Keptn needs to integrate with Kubernetes scheduling to block
@@ -29,6 +28,7 @@ This spec tells the Kubernetes scheduling framework
 to wait for  the Keptn checks before assigning the pod to a node.
 
 For instance a pod gated by keptn looks like the following:
+
 {{< embed path="/docs/assets/scheduler-gates/gated.yaml" >}}
 
 The **WorkloadInstance CRD** contains information about the `pre-deployment` checks that

--- a/docs/content/en/docs/architecture/keptn-apps/_index.md
+++ b/docs/content/en/docs/architecture/keptn-apps/_index.md
@@ -19,7 +19,7 @@ and run pre- and post-deployment tasks.
 In its state, it tracks the currently active `Workload Instances`,
 (`Pod`, `DaemonSet`, `StatefulSet`, and `ReplicaSet` resources),
 as well as the overall state of the Pre Deployment phase,
-which the scheduler can use to determine
+which Keptn can use to determine
 whether the pods belonging to a workload
 should be created and assigned to a node.
 When it detects that the referenced object has reached its desired state

--- a/docs/content/en/docs/architecture/keptn-apps/_index.md
+++ b/docs/content/en/docs/architecture/keptn-apps/_index.md
@@ -3,7 +3,6 @@ title: KeptnApp and KeptnWorkload resources
 linktitle: Keptn Applications and Keptn Workloads
 description: How Keptn applications work
 weight: 50
-cascade:
 ---
 
 ## Keptn Workloads

--- a/docs/content/en/docs/architecture/working/_index.md
+++ b/docs/content/en/docs/architecture/working/_index.md
@@ -3,7 +3,6 @@ title: How Keptn works
 linktitle: How Keptn works
 description: Understand How Keptn Works
 weight: 30
-cascade:
 ---
 
 ### How does Keptn Work?

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -173,7 +173,7 @@ kubectl edit configmap otel-collector-conf \
 ```
 
 When the `otel-collector` pod is up and running,
-restart the `keptn-scheduler` and `lifecycle-operator`
+restart the `keptn-scheduler` (if installed) and `lifecycle-operator`
 so they can pick up the new configuration:
 
 ```shell

--- a/docs/content/en/docs/migrate/strategy/_index.md
+++ b/docs/content/en/docs/migrate/strategy/_index.md
@@ -77,7 +77,7 @@ Some key points:
 * Keptn provides an operator
   that can observe and orchestrate application-aware workload life cycles.
   This operator leverages Kubernetes webhooks
-  and extends the Kubernetes scheduler
+  and the Kubernetes scheduler
   to support pre- and post-deployment hooks.
   When the operator detects a new version of a service
   (implemented as a Kubernetes

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "26") (not .Values.schedulingGatesEnabled) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -167,7 +167,7 @@ spec:
       tolerations: {{- include "tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
 {{- end }}
 
-{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "26") (not .Values.schedulingGatesEnabled) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -167,7 +167,7 @@ spec:
       tolerations: {{- include "tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
 {{- end }}
 
-{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.schedulingGatesEnabled }}
+{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -167,7 +167,7 @@ spec:
       tolerations: {{- include "tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
 {{- end }}
 
-{{- if not .Values.schedulingGatesEnabled }}
+{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/lifecycle-operator/chart/templates/extension-apiserver-authentication-reader-rbac.yaml
+++ b/lifecycle-operator/chart/templates/extension-apiserver-authentication-reader-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/lifecycle-operator/chart/templates/extension-apiserver-authentication-reader-rbac.yaml
+++ b/lifecycle-operator/chart/templates/extension-apiserver-authentication-reader-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "26") (not .Values.schedulingGatesEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/lifecycle-operator/chart/templates/extension-apiserver-authentication-reader-rbac.yaml
+++ b/lifecycle-operator/chart/templates/extension-apiserver-authentication-reader-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.schedulingGatesEnabled }}
+{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/lifecycle-operator/chart/templates/keptn-scheduler-rbac.yaml
+++ b/lifecycle-operator/chart/templates/keptn-scheduler-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "26") (not .Values.schedulingGatesEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/lifecycle-operator/chart/templates/keptn-scheduler-rbac.yaml
+++ b/lifecycle-operator/chart/templates/keptn-scheduler-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/lifecycle-operator/chart/templates/keptn-scheduler-rbac.yaml
+++ b/lifecycle-operator/chart/templates/keptn-scheduler-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.schedulingGatesEnabled }}
+{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/lifecycle-operator/chart/templates/scheduler-config.yaml
+++ b/lifecycle-operator/chart/templates/scheduler-config.yaml
@@ -1,4 +1,4 @@
-{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lifecycle-operator/chart/templates/scheduler-config.yaml
+++ b/lifecycle-operator/chart/templates/scheduler-config.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.schedulingGatesEnabled }}
+{{- if and (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/lifecycle-operator/chart/templates/scheduler-config.yaml
+++ b/lifecycle-operator/chart/templates/scheduler-config.yaml
@@ -1,4 +1,4 @@
-{{- if or (le .Capabilities.KubeVersion.Minor "16") (not .Values.schedulingGatesEnabled) }}
+{{- if or (le .Capabilities.KubeVersion.Minor "26") (not .Values.schedulingGatesEnabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
closes #1460 

1. The scheduling feature needs to be enabled and the k8s minor version needs to be more than 26 for the gates to be enabled
2. docs are updated to explain both gates and scheduler 