### PR TITLE
docs: tweaks to intro material for Keptn landing page

### DIFF
--- a/docs/content/en/docs/architecture/components/scheduler/_index.md
+++ b/docs/content/en/docs/architecture/components/scheduler/_index.md
@@ -15,7 +15,7 @@ and orchestrate the deployment process.
 If the Keptn helm chart value `schedulingGatesEnabled` is set to `true`, and Keptn is running on a Kubernetes version
 greater than 1.26, Keptn does not install a scheduler plugin.
 Instead, it uses
-the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness) 
+the [Pod Scheduling Readiness K8s API](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness)
 to gate Pods until the required deployment checks pass.
 
 ## Keptn Scheduling Gates for K8s 1.27 and above

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -1,10 +1,13 @@
 ---
-title: Getting started with Keptn
-description: Get started with Keptn
+title: Getting started with Keptn Observability
+description: Get started with Keptn Observability
 weight: 20
 ---
 
-Keptn works whether or not you use a GitOps strategy.
+Keptn provides sophisticated observability features
+that enhance your existing cloud-native deployment environment.
+These features are useful whether or not you use a GitOps strategy.
+
 The following is an imperative walkthrough.
 
 ## Prerequisites

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -89,7 +89,7 @@ To learn more, see:
 
 * [Getting started with Keptn Observability](../getting-started)
 * [Standardize observability](usecase-observability/)
-* [Dora metrics](../implementing/dora) guide
+* [DORA metrics](../implementing/dora) guide
 * [OpenTelemetry observability](../implementing/otel) guide
 
 ## Release lifecycle management

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -48,7 +48,7 @@ simplifying configuration and integration into a single set of metrics.
 To learn more, see:
 
 * [Custom Keptn metrics](usecase_metrics.md)
-* [Keptn Metrics](../implementing/evaluatemetrics.md)
+* [Keptn Metrics](../implementing/evaluatemetrics.md) guide
 
 ## Observability
 

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -8,7 +8,8 @@ Keptn integrates seamlessly with cloud-native deployment tools
 such as ArgoCD, Flux, and Gitlab
 to bring application awareness to your Kubernetes cluster.
 Keptn supplements the standard deployment tools
-with facilities to ensure that your deployment is usable.
+with features to help you ensure that your deployments are in
+a healthy state.
 
 For information about the history of the Keptn project,
 see the

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -13,7 +13,7 @@ a healthy state.
 
 For information about the history of the Keptn project,
 see the
-[Keptn Lifecycle Toolkit is now Keptn!](https://medium.com/keptn/keptn-lifecycle-toolkit-is-now-keptn-e0812217bf46).
+[Keptn Lifecycle Toolkit is now Keptn!](https://medium.com/keptn/keptn-lifecycle-toolkit-is-now-keptn-e0812217bf46)
 blog.
 
 Keptn includes multiple features

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -48,8 +48,8 @@ simplifying configuration and integration into a single set of metrics.
 
 To learn more, see:
 
-* [Custom Keptn metrics](usecase_metrics)
-* [Keptn Metrics](../implementing/evaluatemetrics)
+* [Custom Keptn metrics](usecase_metrics.md)
+* [Keptn Metrics](../implementing/evaluatemetrics.md)
 
 ## Observability
 
@@ -88,9 +88,9 @@ to ensure that your deployments are observable.
 To learn more, see:
 
 * [Getting started with Keptn Observability](../getting-started)
-* [Standardize observability](usecase-observability/)
+* [Standardize observability](usecase-observability.md/)
 * [DORA metrics](../implementing/dora) guide
-* [OpenTelemetry observability](../implementing/otel) guide
+* [OpenTelemetry observability](../implementing/otel.md) guide
 
 ## Release lifecycle management
 

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -134,7 +134,7 @@ or a
 [KeptnApp](https://lifecycle.keptn.sh/docs/yaml-crd-ref/app/) resource,
 which is a single, cohesive unit that groups multiple workloads.
 
-To learn more:
+To learn more, see:
 
 * [Getting started with release lifecycle management](../tutorials/tasks/)
 * [Manage release lifecycle](usecase-orchestrate)

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -88,7 +88,7 @@ to ensure that your deployments are observable.
 To learn more, see:
 
 * [Getting started with Keptn Observability](../getting-started)
-* [Standardize observability](../intro/usecase-observability/)
+* [Standardize observability](usecase-observability/)
 * [Dora metrics](../implementing/dora) guide
 * [OpenTelemetry observability](../implementing/otel) guide
 

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -4,27 +4,25 @@ description: An introduction to Keptn and the usecases.
 weight: 10
 ---
 
-Keptn implements observability for deployments.
-It seamlessly integrates with deployment tools
+Keptn integrates seamlessly with cloud-native deployment tools
 such as ArgoCD, Flux, and Gitlab
 to bring application awareness to your Kubernetes cluster.
+Keptn supplements the standard deployment tools
+with facilities to ensure that your deployment is usable.
 
-These standard deployment tools
-do an excellent job at deploying applications
-but do not handle all issues
-that are required to ensure that your deployment is usable.
-Keptn "wraps" a standard Kubernetes deployment
-with the capability to automatically handle issues
-before and after the actual deployment.
+For information about the history of the Keptn project,
+see the
+[Keptn Lifecycle Toolkit is now Keptn!](https://medium.com/keptn/keptn-lifecycle-toolkit-is-now-keptn-e0812217bf46).
+blog.
 
 Keptn includes multiple features
 that can be implemented independently or together.
 It targets three main use cases:
-Custom metrics, Observability, and Release lifecycle management.
+Metrics, Observability, and Release lifecycle management.
 
-## Custom metrics
+## Metrics
 
-The Custom Keptn metrics feature extends the functionality of
+The Keptn metrics feature extends the functionality of
 [Kubernetes metrics](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/):
 
 * Allows you to define metrics
@@ -39,9 +37,18 @@ The Custom Keptn metrics feature extends the functionality of
   as well as data that comes directly from your cloud provider
   such as AWS, Google, or Azure.
 
+* Enhances the Kubernetes
+  [Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+  facility.
+
 The Keptn metrics server unifies and standardizes
 access to data from various sources,
 simplifying configuration and integration into a single set of metrics.
+
+To learn more:
+
+* [Custom Keptn metrics](usecase_metrics)
+* [Keptn Metrics](../implementing/evaluatemetrics)
 
 ## Observability
 
@@ -77,11 +84,21 @@ Keptn emits signals at every stage
 OpenTelemetry metrics and traces)
 to ensure that your deployments are observable.
 
+To learn more, see:
+
+* [Getting started with Keptn Observability](../getting-started)
+* [Standardize observability](../intro/usecase-observability/)
+* [Dora metrics](../implementing/dora) guide
+* [OpenTelemetry observability](../implementing/otel) guide
+
 ## Release lifecycle management
 
 The Release lifecycle management tools run in conjunction
 with the standard Kubernetes deployment tools
 to make deployments more robust.
+Keptn "wraps" a standard Kubernetes deployment
+with the capability to automatically handle issues
+before and after the actual deployment.
 
 These tools run checks and tasks before or after deployment initiation.
 
@@ -116,12 +133,9 @@ or a
 [KeptnApp](https://lifecycle.keptn.sh/docs/yaml-crd-ref/app/) resource,
 which is a single, cohesive unit that groups multiple workloads.
 
-To familiarize yourself with how Keptn works, refer to the
-[Getting started with Keptn](../getting-started/)
-and the
-[Getting Started Exercises](https://lifecycle.keptn.sh/docs/getting-started/).
+To learn more:
 
-For information about the history of the Keptn project,
-see the
-[Keptn Lifecycle Toolkit is now Keptn!](https://medium.com/keptn/keptn-lifecycle-toolkit-is-now-keptn-e0812217bf46).
-blog.
+* [Getting started with release lifecycle management](../tutorials/tasks/)
+* [Manage release lifecycle](usecase-orchestrate)
+* [Deployment tasks](../implementing/tasks)
+* [Evaluations](../implementing/evaluations)

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -11,8 +11,7 @@ Keptn supplements the standard deployment tools
 with features to help you ensure that your deployments are in
 a healthy state.
 
-For information about the history of the Keptn project,
-see the
+For information about the history of the Keptn project, see the
 [Keptn Lifecycle Toolkit is now Keptn!](https://medium.com/keptn/keptn-lifecycle-toolkit-is-now-keptn-e0812217bf46)
 blog.
 

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -46,7 +46,7 @@ The Keptn metrics server unifies and standardizes
 access to data from various sources,
 simplifying configuration and integration into a single set of metrics.
 
-To learn more:
+To learn more, see:
 
 * [Custom Keptn metrics](usecase_metrics)
 * [Keptn Metrics](../implementing/evaluatemetrics)

--- a/docs/content/en/docs/intro/_index.md
+++ b/docs/content/en/docs/intro/_index.md
@@ -136,6 +136,6 @@ which is a single, cohesive unit that groups multiple workloads.
 To learn more, see:
 
 * [Getting started with release lifecycle management](../tutorials/tasks/)
-* [Manage release lifecycle](usecase-orchestrate)
+* [Manage release lifecycle](usecase-orchestrate.md)
 * [Deployment tasks](../implementing/tasks)
-* [Evaluations](../implementing/evaluations)
+* [Evaluations](../implementing/evaluations.md)

--- a/docs/content/en/docs/tutorials/tasks/_index.md
+++ b/docs/content/en/docs/tutorials/tasks/_index.md
@@ -1,11 +1,19 @@
 ---
-title: Add Deployment Tasks
+title: Getting started with Release Lifecycle Management
 description: Add KeptnTasks to deployments
-weight: 10
+weight: 25
 hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.html
 ---
 
-> This tutorial assumes you have already completed the [getting started guide](../../getting-started/).
+The Release Lifecycle Management tools run
+pre- and post-deployment tasks and checks
+for your existing cloud-native deployments
+to make deployments more robust.
+This tutorial introduces these tools.
+
+> This tutorial assumes you have already completed the
+[Getting started with Keptn Observability](../../getting-started/)
+exercise.
 > Please ensure you've finished that before attempting this guide.
 
 ## Keptn Pre and Post Deployment Tasks

--- a/docs/content/en/docs/tutorials/tasks/_index.md
+++ b/docs/content/en/docs/tutorials/tasks/_index.md
@@ -8,7 +8,7 @@ hidechildren: false # this flag hides all sub-pages in the sidebar-multicard.htm
 The Release Lifecycle Management tools run
 pre- and post-deployment tasks and checks
 for your existing cloud-native deployments
-to make deployments more robust.
+to make them more robust.
 This tutorial introduces these tools.
 
 > This tutorial assumes you have already completed the


### PR DESCRIPTION
Relates to https://github.com/keptn/lifecycle-toolkit/issues/2216

* I am proposing that the "get started" links on the landing page take the user to the short blurbs about the use-cases that are in the "Introduction to Keptn" page.
* This PR then adds "To learn more" lists at the end of each section
   * First link(s) go to whatever relevant getting started material we have
   * Other links go to relevant user guide pages
* Also tweaked the titles of the getting started exercises to be specific to the use case
* Add a sentence or two about the specific use-case to the beginning of each of the new tutorials