### PR TITLE
docs: add solid background color override to navbar

### DIFF
--- a/docs/assets/scss/_variables_project.scss
+++ b/docs/assets/scss/_variables_project.scss
@@ -6,6 +6,11 @@ $primary: #006bb8;
 $secondary: #469bdd;
 $light: #d8e6f4;
 
+.td-navbar-cover {
+  background: $primary !important;
+  opacity: inherit;
+}
+
 #td-cover-block-0 {
   background-size: 100% auto;
   background-position-y: bottom;

--- a/docs/assets/scss/_variables_project.scss
+++ b/docs/assets/scss/_variables_project.scss
@@ -6,7 +6,7 @@ $primary: #006bb8;
 $secondary: #469bdd;
 $light: #d8e6f4;
 
-.td-navbar-cover {
+nav.td-navbar-cover {
   background: $primary !important;
   opacity: inherit;
 }


### PR DESCRIPTION
Fixes #1525

Please check the page preview. The navbar now always has solid background color and doesn't change during scrolling.