### PR TITLE
feat(lifecycle-operator): introduce option to enable lifecycle orchestration only for specific namespaces

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -105,7 +105,8 @@ runs:
 
         touch tmp-values.yaml
         if [ "${{ inputs.allowed-namespaces }}" == "true" ]; then
-          echo "allowedNamespaces: [allowed-ns-test]" > tmp-values.yaml
+          echo "lifecycleOperator:" >> tmp-values.yaml
+          echo "  allowedNamespaces: [allowed-ns-test]" >> tmp-values.yaml
         fi
 
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -110,6 +110,9 @@ runs:
         fi
 
         if [ "${{ inputs.scheduling-gates }}" == "gates_on" ]; then
+          if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_off" ]; then
+            echo "lifecycleOperator:" >> tmp-values.yaml
+          fi
           echo "  schedulingGatesEnabled: true" >> tmp-values.yaml
         fi
 

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -109,9 +109,14 @@ runs:
           echo "  allowedNamespaces: [allowed-ns-test]" >> tmp-values.yaml
         fi
 
+        scheduling-gates-enabled="false"
+        if [ "${{ inputs.scheduling-gates }}" == "gates_on" ]; then
+          scheduling-gates-enabled="true"
+        fi
+
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
           --values tmp-values.yaml \
-          --set lifecycleOperator.schedulingGatesEnabled=${{ inputs.scheduling-gates }} \
+          --set lifecycleOperator.schedulingGatesEnabled=${{ scheduling-gates_enabled }} \
           --set lifecycleOperator.scheduler.imagePullPolicy=Never \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.scheduler.image.repository="localhost:5000/keptn/scheduler" \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -21,15 +21,15 @@ inputs:
   helm-install:
     required: false
     description: "Install Keptn via helm instead of manifest if true"
-    default: "true"
+    default: "helm_on"
   scheduling-gates:
     required: false
     description: "Use scheduling gates instead of scheduler"
-    default: "false"
+    default: "gates_off"
   allowed-namespaces:
     required: false
     description: "Decides whether to allow only certain namespaces"
-    default: "false"
+    default: "allowed_ns_off"
 runs:
   using: "composite"
   steps:
@@ -65,7 +65,7 @@ runs:
         done
 
     - name: Install lifecycle-toolkit with manifests
-      if: inputs.helm-install == 'false' && inputs.scheduling-gates == 'false'
+      if: ${{  inputs.helm-install == 'helm_off' }}
       shell: bash
       run: |
         echo "Installing Keptn using manifests"
@@ -91,7 +91,7 @@ runs:
         kubectl rollout status deployment lifecycle-operator -n keptn-lifecycle-toolkit-system -w
 
     - name: Install lifecycle-toolkit with helm
-      if: inputs.helm-install == 'true'
+      if: ${{ inputs.helm-install == 'helm_on' }}
       env:
         RELEASE_REGISTRY: "localhost:5000/keptn"
       shell: bash
@@ -104,7 +104,7 @@ runs:
         helm dependency build
 
         touch tmp-values.yaml
-        if [ "${{ inputs.allowed-namespaces }}" == "true" ]; then
+        if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_on" ]; then
           echo "lifecycleOperator:" >> tmp-values.yaml
           echo "  allowedNamespaces: [allowed-ns-test]" >> tmp-values.yaml
         fi

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -109,14 +109,12 @@ runs:
           echo "  allowedNamespaces: [allowed-ns-test]" >> tmp-values.yaml
         fi
 
-        scheduling-gates-enabled="false"
         if [ "${{ inputs.scheduling-gates }}" == "gates_on" ]; then
-          scheduling-gates-enabled="true"
+          echo "  schedulingGatesEnabled: true" >> tmp-values.yaml
         fi
 
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
           --values tmp-values.yaml \
-          --set lifecycleOperator.schedulingGatesEnabled=$scheduling-gates_enabled \
           --set lifecycleOperator.scheduler.imagePullPolicy=Never \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.scheduler.image.repository="localhost:5000/keptn/scheduler" \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -116,7 +116,7 @@ runs:
 
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
           --values tmp-values.yaml \
-          --set lifecycleOperator.schedulingGatesEnabled=${{ scheduling-gates_enabled }} \
+          --set lifecycleOperator.schedulingGatesEnabled=$scheduling-gates_enabled \
           --set lifecycleOperator.scheduler.imagePullPolicy=Never \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.scheduler.image.repository="localhost:5000/keptn/scheduler" \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -26,6 +26,10 @@ inputs:
     required: false
     description: "Use scheduling gates instead of scheduler"
     default: "false"
+  allowed-namespaces:
+    required: false
+    description: "Decides whether to allow only certain namespaces"
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -99,7 +103,13 @@ runs:
         helm dependency update
         helm dependency build
 
+        touch tmp-values.yaml
+        if [ "${{ inputs.allowed-namespaces }}" == "true" ]; then
+          echo "allowedNamespaces: [allowed-ns-test]" > tmp-values.yaml
+        fi
+
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
+          --values tmp-values.yaml \
           --set lifecycleOperator.schedulingGatesEnabled=${{ inputs.scheduling-gates }} \
           --set lifecycleOperator.scheduler.imagePullPolicy=Never \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -8257,9 +8257,6 @@ webhooks:
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
-      - kube-system
-      - kube-public
-      - kube-node-lease
       - cert-manager
       - keptn-lifecycle-toolkit-system
       - observability
@@ -8268,6 +8265,9 @@ webhooks:
       operator: NotIn
       values:
       - 'helmtests'
+      - kube-system
+      - kube-public
+      - kube-node-lease
   rules:
   - apiGroups:
     - ""

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -6343,9 +6343,6 @@ webhooks:
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
-      - kube-system
-      - kube-public
-      - kube-node-lease
       - cert-manager
       - keptn-lifecycle-toolkit-system
       - observability
@@ -6354,6 +6351,9 @@ webhooks:
       operator: NotIn
       values:
       - 'helmtests'
+      - kube-system
+      - kube-public
+      - kube-node-lease
   rules:
   - apiGroups:
     - ""

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -6599,9 +6599,6 @@ webhooks:
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
-      - kube-system
-      - kube-public
-      - kube-node-lease
       - cert-manager
       - keptn-lifecycle-toolkit-system
       - observability
@@ -6610,6 +6607,9 @@ webhooks:
       operator: NotIn
       values:
       - 'helmtests'
+      - kube-system
+      - kube-public
+      - kube-node-lease
   rules:
   - apiGroups:
     - ""

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -219,6 +219,7 @@ jobs:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       helm-install: ${{ matrix.helm }}
       scheduling-gates: ${{ matrix.scheduling-gates }}
+      allowed-namespaces: ${{ matrix.allowed-namespaces }}
     uses: ./.github/workflows/integration-test.yml
 
   load-tests:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -204,10 +204,17 @@ jobs:
       matrix:
         helm: [true, false]
         scheduling-gates: [true, false]
-        # do not run the tests with manifests installation and scheduling gates
+        allowed-namespaces: [true, false]
         exclude:
           - helm: false
             scheduling-gates: true
+            allowed-namespaces: true
+          - helm: false
+            scheduling-gates: false
+            allowed-namespaces: true
+          - helm: false
+            scheduling-gates: true
+            allowed-namespaces: false
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       helm-install: ${{ matrix.helm }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -202,19 +202,19 @@ jobs:
       - build_image
     strategy:
       matrix:
-        helm: [true, false]
-        scheduling-gates: [true, false]
-        allowed-namespaces: [true, false]
+        helm: ["helm_on", "helm_off"]
+        scheduling-gates: ["gates_on", "gates_off"]
+        allowed-namespaces: ["allowed_ns_on", "allowed_ns_off"]
         exclude:
-          - helm: false
-            scheduling-gates: true
-            allowed-namespaces: true
-          - helm: false
-            scheduling-gates: false
-            allowed-namespaces: true
-          - helm: false
-            scheduling-gates: true
-            allowed-namespaces: false
+          - helm: "helm_off"
+            scheduling-gates: "gates_on"
+            allowed-namespaces: "allowed_ns_on"
+          - helm: "helm_off"
+            scheduling-gates: "gates_off"
+            allowed-namespaces: "allowed_ns_on"
+          - helm: "helm_off"
+            scheduling-gates: "gates_on"
+            allowed-namespaces: "allowed_ns_off"
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       helm-install: ${{ matrix.helm }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -202,19 +202,19 @@ jobs:
       - build_image
     strategy:
       matrix:
-        helm: ["helm_on", "helm_off"]
-        scheduling-gates: ["gates_on", "gates_off"]
-        allowed-namespaces: ["allowed_ns_on", "allowed_ns_off"]
+        helm: [helm_on, helm_off]
+        scheduling-gates: [gates_on, gates_off]
+        allowed-namespaces: [allowed_ns_on, allowed_ns_off]
         exclude:
-          - helm: "helm_off"
-            scheduling-gates: "gates_on"
-            allowed-namespaces: "allowed_ns_on"
-          - helm: "helm_off"
-            scheduling-gates: "gates_off"
-            allowed-namespaces: "allowed_ns_on"
-          - helm: "helm_off"
-            scheduling-gates: "gates_on"
-            allowed-namespaces: "allowed_ns_off"
+          - helm: helm_off
+            scheduling-gates: gates_on
+            allowed-namespaces: allowed_ns_on
+          - helm: helm_off
+            scheduling-gates: gates_off
+            allowed-namespaces: allowed_ns_on
+          - helm: helm_off
+            scheduling-gates: gates_on
+            allowed-namespaces: allowed_ns_off
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       helm-install: ${{ matrix.helm }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,15 +9,15 @@ on:
       helm-install:
         description: "Decides whether to install via helm"
         type: "string"
-        default: "helm_on"
+        default: helm_on
       scheduling-gates:
         description: "Decides whether to use scheduling gates"
         type: "string"
-        default: "gates_off"
+        default: gates_off
       allowed-namespaces:
         description: "Decides whether to allow only certain namespaces"
         type: "string"
-        default: "allowed_ns_off"
+        default: allowed_ns_off
 env:
   GO_VERSION: "~1.20"
   # renovate: datasource=github-tags depName=kudobuilder/kuttl

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,16 +8,16 @@ on:
         required: true
       helm-install:
         description: "Decides whether to install via helm"
-        type: "boolean"
-        default: true
+        type: "string"
+        default: "helm_on"
       scheduling-gates:
         description: "Decides whether to use scheduling gates"
-        type: "boolean"
-        default: false
+        type: "string"
+        default: "gates_off"
       allowed-namespaces:
         description: "Decides whether to allow only certain namespaces"
-        type: "boolean"
-        default: false
+        type: "string"
+        default: "allowed_ns_off"
 env:
   GO_VERSION: "~1.20"
   # renovate: datasource=github-tags depName=kudobuilder/kuttl
@@ -54,17 +54,17 @@ jobs:
           mv kubectl-kuttl /usr/local/bin
 
       - name: Run Scheduling Gates Integration Tests
-        if: inputs.scheduling-gates == true && inputs.allowed-namespaces == false
+        if: ${{ inputs.scheduling-gates == 'gates_on' }} && ${{ inputs.allowed-namespaces == 'allowed_ns_off' }}
         working-directory: .
         run: make integration-test-scheduling-gates
 
       - name: Run Allowed namespaces Integration Tests
-        if: inputs.allowed-namespaces == true
+        if: ${{ inputs.allowed-namespaces == 'allowed_ns_on' }}
         working-directory: .
         run: make integration-test-allowed-namespaces
 
       - name: Run Integration Tests
-        if: inputs.allowed-namespaces == false
+        if: ${{ inputs.allowed-namespaces == 'allowed_ns_off' }}
         working-directory: .
         run: make integration-test
 
@@ -77,5 +77,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: logs-integration-tests-helm_${{ inputs.helm-install }}-schedule_${{ inputs.scheduling-gates }}-allowed-ns_${{ inputs.allowed-namespaces }}
+          name: logs-integration-tests-${{ inputs.helm-install }}-${{ inputs.scheduling-gates }}-${{ inputs.allowed-namespaces }}
           path: .github/scripts/logs

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,11 +54,17 @@ jobs:
           mv kubectl-kuttl /usr/local/bin
 
       - name: Run Scheduling Gates Integration Tests
-        if: inputs.scheduling-gates == true
+        if: inputs.scheduling-gates == true && inputs.allowed-namespaces == false
         working-directory: .
         run: make integration-test-scheduling-gates
 
+      - name: Run Allowed namespaces Integration Tests
+        if: inputs.allowed-namespaces == true
+        working-directory: .
+        run: make integration-test-allowed-namespaces
+
       - name: Run Integration Tests
+        if: inputs.allowed-namespaces == false
         working-directory: .
         run: make integration-test
 
@@ -71,5 +77,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: logs-integration-tests-helm_${{ inputs.helm-install }}-schedule_${{ inputs.scheduling-gates }}
+          name: logs-integration-tests-helm_${{ inputs.helm-install }}-schedule_${{ inputs.scheduling-gates }}-allowed-ns_${{ inputs.allowed-namespaces }}
           path: .github/scripts/logs

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,11 @@ on:
         type: "boolean"
         default: true
       scheduling-gates:
-        description: "Decides whether to ue scheduling gates"
+        description: "Decides whether to use scheduling gates"
+        type: "boolean"
+        default: false
+      allowed-namespaces:
+        description: "Decides whether to allow only certain namespaces"
         type: "boolean"
         default: false
 env:
@@ -36,6 +40,7 @@ jobs:
           runtime_tag: ${{ inputs.runtime_tag }}
           helm-install: ${{ inputs.helm-install }}
           scheduling-gates: ${{ inputs.scheduling-gates }}
+          allowed-namespaces: ${{ inputs.allowed-namespaces }}
 
       - name: Install and expose Prometheus
         uses: ./.github/actions/deploy-prometheus-on-cluster

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -54,17 +54,17 @@ jobs:
           mv kubectl-kuttl /usr/local/bin
 
       - name: Run Scheduling Gates Integration Tests
-        if: ${{ inputs.scheduling-gates == 'gates_on' }} && ${{ inputs.allowed-namespaces == 'allowed_ns_off' }}
+        if: inputs.scheduling-gates == 'gates_on' && inputs.allowed-namespaces == 'allowed_ns_off'
         working-directory: .
         run: make integration-test-scheduling-gates
 
       - name: Run Allowed namespaces Integration Tests
-        if: ${{ inputs.allowed-namespaces == 'allowed_ns_on' }}
+        if: inputs.allowed-namespaces == 'allowed_ns_on'
         working-directory: .
         run: make integration-test-allowed-namespaces
 
       - name: Run Integration Tests
-        if: ${{ inputs.allowed-namespaces == 'allowed_ns_off' }}
+        if: inputs.allowed-namespaces == 'allowed_ns_off'
         working-directory: .
         run: make integration-test
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,14 @@ integration-test-scheduling-gates:	# to run a single test by name use --test eg.
 integration-test-scheduling-gates-local: install-prometheus
 	kubectl kuttl test --start-kind=false ./test/scheduling-gates/ --config=kuttl-test-local.yaml
 
+.PHONY: integration-test-allowed-namespaces #these tests should run on a real cluster!
+integration-test-allowed-namespaces:	# to run a single test by name use --test eg. --test=expose-keptn-metric
+	kubectl kuttl test --start-kind=false ./test/allowed-namespaces/ --config=kuttl-test.yaml
+
+.PHONY: integration-test-allowed-namespaces-local #these tests should run on a real cluster!
+integration-test-allowed-namespaces-local: install-prometheus
+	kubectl kuttl test --start-kind=false ./test/allowed-namespaces/ --config=kuttl-test-local.yaml
+
 .PHONY: load-test
 load-test:
 	kubectl apply -f ./test/load/assets/templates/namespace.yaml

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ helm repo update
 helm upgrade --install keptn klt/klt -n keptn-lifecycle-toolkit-system --create-namespace --wait
 ```
 
-### Instalation with only certain namespaces allowed
+### Installation with only certain namespaces allowed
 
 Keptn lifecycle orchestration is by default enabled for all namespaces except the following ones:
 
@@ -90,8 +90,8 @@ Keptn lifecycle orchestration is by default enabled for all namespaces except th
 - `observability`
 - `monitoring`
 
-To enable Keptn lifecycle orchestration only to specific namespaces, you need to specify
-those namespaces during instalation via helm values.
+To restrict Keptn lifecycle orchestration to specific namespaces, you must specify
+those namespaces during installation via helm values.
 First you need to create a `values.yaml`
 file
 
@@ -102,7 +102,7 @@ lifecycleOperator:
   - allowed-ns-2
 ```
 
-and add the values file to the helm instalation command:
+and add the values file to the helm installation command:
 
 ```shell
 helm repo add klt https://charts.lifecycle.keptn.sh
@@ -111,7 +111,7 @@ helm upgrade --install keptn klt/klt -n keptn-lifecycle-toolkit-system --values 
 ```
 
 > **Note**
-Please be aware that you still need to correctly annotate the namespaces, where
+Please be aware that you still need to correctly annotate the namespaces where
 Keptn lifecycle orchestration is allowed.
 > To annotate them, use:
 
@@ -120,9 +120,8 @@ kubectl annotate ns <your-allowed-namespace> keptn.sh/lifecycle-toolkit='enabled
 ```
 
 > **Note**
-Please be aware that if this option is set, adding any additional namespace will
-require the helm installation to be updated with the name of the new namespace
-being added to the list.
+Please be aware that,if this option is set, adding any additional namespace
+requires the helm installation to be updated by adding the name of the new namespace to the list.
 
 ### Installation without scheduler
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ kubectl annotate ns <your-allowed-namespace> keptn.sh/lifecycle-toolkit='enabled
 ```
 
 > **Note**
-Please be aware that,if this option is set, adding any additional namespace
+Please be aware that, if this option is set, adding any additional namespace
 requires the helm installation to be updated by adding the name of the new namespace to the list.
 
 ### Installation without scheduler

--- a/README.md
+++ b/README.md
@@ -78,6 +78,47 @@ helm repo update
 helm upgrade --install keptn klt/klt -n keptn-lifecycle-toolkit-system --create-namespace --wait
 ```
 
+### Instalation with only certain namespaces allowed
+
+Keptn lifecycle orchestration is by default enabled for all namespaces except the following ones:
+
+- `kube-system`
+- `kube-public`
+- `kube-node-lease`
+- `cert-manager`
+- `keptn-lifecycle-toolkit-system`
+- `observability`
+- `monitoring`
+
+To enable Keptn lifecycle orchestration only to specific namespaces, you need to specify
+those namespaces during instalation via helm values.
+First you need to create a `values.yaml`
+file
+
+```yaml
+lifecycleOperator:
+  allowedNamespaces:
+  - allowed-ns-1
+  - allowed-ns-2
+```
+
+and add the values file to the helm instalation command:
+
+```shell
+helm repo add klt https://charts.lifecycle.keptn.sh
+helm repo update
+helm upgrade --install keptn klt/klt -n keptn-lifecycle-toolkit-system --values values.yaml --create-namespace --wait
+```
+
+> **Note**
+Please be aware that you still need to correctly annotate the namespaces, where
+Keptn lifecycle orchestration is allowed.
+> To annotate them, use:
+
+```shell
+kubectl annotate ns <your-allowed-namespace> keptn.sh/lifecycle-toolkit='enabled'
+```
+
 ### Installation without scheduler
 
 Keptn installed on Kubernetes cluster running Kubernetes >= 1.26

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Keptn lifecycle orchestration is by default enabled for all namespaces except th
 - `keptn-lifecycle-toolkit-system`
 - `observability`
 - `monitoring`
-- <Keptn installation namespace>
+- `<Keptn installation namespace>`
 
 To restrict Keptn lifecycle orchestration to specific namespaces, you must specify
 those namespaces during installation via helm values.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Keptn lifecycle orchestration is by default enabled for all namespaces except th
 - `keptn-lifecycle-toolkit-system`
 - `observability`
 - `monitoring`
+- <Keptn installation namespace>
 
 To restrict Keptn lifecycle orchestration to specific namespaces, you must specify
 those namespaces during installation via helm values.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ Keptn lifecycle orchestration is allowed.
 kubectl annotate ns <your-allowed-namespace> keptn.sh/lifecycle-toolkit='enabled'
 ```
 
+> **Note**
+Please be aware that if this option is set, adding any additional namespace will
+require the helm installation to be updated with the name of the new namespace
+being added to the list.
+
 ### Installation without scheduler
 
 Keptn installed on Kubernetes cluster running Kubernetes >= 1.26

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -64,6 +64,7 @@ and application health checks
 | `kubernetesClusterDomain` | overrides domain.local                                                                                                                          | `cluster.local` |
 | `imagePullSecrets`        | global value for image registry secret                                                                                                          | `[]`            |
 | `schedulingGatesEnabled`  | enables the scheduling gates in lifecycle-operator. This feature is available in alpha version from K8s 1.27 or 1.26 enabling the alpha version | `false`         |
+| `allowedNamespaces`       | specifies the allowed namespaces for the lifecycle orchestration functionality                                                                  | `[]`            |
 
 ### Keptn Scheduler
 

--- a/lifecycle-operator/chart/doc.yaml
+++ b/lifecycle-operator/chart/doc.yaml
@@ -77,6 +77,7 @@
 ## @param  kubernetesClusterDomain overrides domain.local
 ## @param  imagePullSecrets global value for image registry secret
 ## @param  schedulingGatesEnabled enables the scheduling gates in lifecycle-operator. This feature is available in alpha version from K8s 1.27 or 1.26 enabling the alpha version
+## @param  allowedNamespaces specifies the allowed namespaces for the lifecycle orchestration functionality
 
 # yamllint disable rule:line-length
 ## @section Keptn Scheduler

--- a/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
+++ b/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
@@ -28,9 +28,6 @@ webhooks:
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
-      - kube-system
-      - kube-public
-      - kube-node-lease
       - cert-manager
       - keptn-lifecycle-toolkit-system
       - observability
@@ -39,17 +36,14 @@ webhooks:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{ .Values.allowedNamespaces | default list | toJson }}
-    - key: kubernetes.io/metadata.name
-      operator: NotIn
-      values:
-      - kube-system
-      - kube-public
-      - kube-node-lease
 {{- end }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - '{{ .Release.Namespace }}'
+      - kube-system
+      - kube-public
+      - kube-node-lease
   rules:
   - apiGroups:
     - ""

--- a/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
+++ b/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
@@ -39,6 +39,12 @@ webhooks:
     - key: kubernetes.io/metadata.name
       operator: In
       values: {{ .Values.allowedNamespaces | default list | toJson }}
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - kube-public
+      - kube-node-lease
 {{- end }}
     - key: kubernetes.io/metadata.name
       operator: NotIn

--- a/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
+++ b/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
@@ -24,6 +24,7 @@ webhooks:
       operator: NotIn
       values:
       - lifecycle-operator
+{{- if eq (len .Values.allowedNamespaces) 0 }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
@@ -34,6 +35,11 @@ webhooks:
       - keptn-lifecycle-toolkit-system
       - observability
       - monitoring
+{{- else }}
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values: {{ .Values.allowedNamespaces | default list | toJson }}
+{{- end }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -1,6 +1,7 @@
 imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 schedulingGatesEnabled: false
+allowedNamespaces: []
 lifecycleOperatorConfig:
   health:
     healthProbeBindAddress: :8081

--- a/test/allowed-namespaces/simple-deployment-allowed/00-assert.yaml
+++ b/test/allowed-namespaces/simple-deployment-allowed/00-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+  namespace: allowed-ns-test
+status:
+  readyReplicas: 2

--- a/test/allowed-namespaces/simple-deployment-allowed/00-install.yaml
+++ b/test/allowed-namespaces/simple-deployment-allowed/00-install.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnTaskDefinition
+metadata:
+  name: pre-deployment-hello
+  namespace: allowed-ns-test
+spec:
+  function:
+    inline:
+      code: |
+        console.log("Pre-Deployment Task has been executed");
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+  namespace: allowed-ns-test
+  annotations:
+    keptn.sh/workload: waiter
+    keptn.sh/version: "0.4"
+    keptn.sh/pre-deployment-tasks: pre-deployment-hello
+    keptn.sh/post-deployment-tasks: pre-deployment-hello
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - image: busybox
+          name: busybox
+          command: ['sh', '-c', 'echo The app is running! && sleep infinity']
+      initContainers:
+        - name: init-myservice
+          image: busybox:1.36.1
+          command: ['sh', '-c', 'sleep 10']

--- a/test/allowed-namespaces/simple-deployment-allowed/00-teststep.yaml
+++ b/test/allowed-namespaces/simple-deployment-allowed/00-teststep.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - script: kubectl create ns allowed-ns-test
+  - script: kubectl annotate ns allowed-ns-test keptn.sh/lifecycle-toolkit='enabled'

--- a/test/allowed-namespaces/simple-deployment-allowed/01-assert.yaml
+++ b/test/allowed-namespaces/simple-deployment-allowed/01-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnWorkload
+metadata:
+  name: waiter-waiter
+  namespace: allowed-ns-test
+---
+
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnWorkloadInstance
+metadata:
+  name: waiter-waiter-0.4
+  namespace: allowed-ns-test
+status:
+  currentPhase: Completed
+  deploymentStatus: Succeeded
+  postDeploymentEvaluationStatus: Succeeded
+  postDeploymentStatus: Succeeded
+  postDeploymentTaskStatus:
+    - status: Succeeded
+      definitionName: pre-deployment-hello
+  preDeploymentEvaluationStatus: Succeeded
+  preDeploymentStatus: Succeeded
+  preDeploymentTaskStatus:
+    - status: Succeeded
+      definitionName: pre-deployment-hello

--- a/test/allowed-namespaces/simple-deployment-not-allowed/00-assert.yaml
+++ b/test/allowed-namespaces/simple-deployment-not-allowed/00-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+  namespace: not-allowed-ns-test
+status:
+  readyReplicas: 2

--- a/test/allowed-namespaces/simple-deployment-not-allowed/00-install.yaml
+++ b/test/allowed-namespaces/simple-deployment-not-allowed/00-install.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnTaskDefinition
+metadata:
+  name: pre-deployment-hello
+  namespace: not-allowed-ns-test
+spec:
+  function:
+    inline:
+      code: |
+        console.log("Pre-Deployment Task has been executed");
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+  namespace: not-allowed-ns-test
+  annotations:
+    keptn.sh/workload: waiter
+    keptn.sh/version: "0.4"
+    keptn.sh/pre-deployment-tasks: pre-deployment-hello
+    keptn.sh/post-deployment-tasks: pre-deployment-hello
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+        - image: busybox
+          name: busybox
+          command: ['sh', '-c', 'echo The app is running! && sleep infinity']
+      initContainers:
+        - name: init-myservice
+          image: busybox:1.36.1
+          command: ['sh', '-c', 'sleep 10']

--- a/test/allowed-namespaces/simple-deployment-not-allowed/00-teststep.yaml
+++ b/test/allowed-namespaces/simple-deployment-not-allowed/00-teststep.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - script: kubectl create ns not-allowed-ns-test
+  - script: kubectl annotate ns not-allowed-ns-test keptn.sh/lifecycle-toolkit='enabled'

--- a/test/allowed-namespaces/simple-deployment-not-allowed/01-verify-tasks.yaml
+++ b/test/allowed-namespaces/simple-deployment-not-allowed/01-verify-tasks.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - script: ../../common-scripts/verify-number-of-resources.sh "keptntask" "0" "not-allowed-ns-test"

--- a/test/allowed-namespaces/simple-deployment-not-allowed/01-verify-tasks.yaml
+++ b/test/allowed-namespaces/simple-deployment-not-allowed/01-verify-tasks.yaml
@@ -1,4 +1,0 @@
-apiVersion: kuttl.dev/v1
-kind: TestStep
-commands:
-  - script: ../../common-scripts/verify-number-of-resources.sh "keptntask" "0" "not-allowed-ns-test"

--- a/test/allowed-namespaces/simple-deployment-not-allowed/01-verify.yaml
+++ b/test/allowed-namespaces/simple-deployment-not-allowed/01-verify.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - script: ../../common-scripts/verify-number-of-resources.sh "keptntask" "0" "not-allowed-ns-test"
+  - script: ../../common-scripts/verify-number-of-resources.sh "keptnworkload" "0" "not-allowed-ns-test"
+  - script: ../../common-scripts/verify-number-of-resources.sh "keptnapp" "0" "not-allowed-ns-test"

--- a/test/common-scripts/verify-number-of-resources.sh
+++ b/test/common-scripts/verify-number-of-resources.sh
@@ -4,9 +4,10 @@
  SLEEP_TIME=5
  RESOURCE_TYPE=$1
  EXPECTED_NUMBER=$2
+ NS=$3
 
  for i in $(seq 1 $RETRY_COUNT); do
-     NR_RESOURCES=$(kubectl get ${RESOURCE_TYPE} -n ${NAMESPACE} --no-headers | wc -l)
+     NR_RESOURCES=$(kubectl get ${RESOURCE_TYPE} -n ${NS} --no-headers | wc -l)
 
      if [[ ${NR_RESOURCES} -eq ${EXPECTED_NUMBER} ]]; then
        echo "Found expected number of ${RESOURCE_TYPE}: ${EXPECTED_NUMBER}"

--- a/test/integration/app-one-taskdefinition-not-found/01-teststep-verify-number-of-tasks.yaml
+++ b/test/integration/app-one-taskdefinition-not-found/01-teststep-verify-number-of-tasks.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
-  - script: ../common-scripts/verify-number-of-resources.sh "keptntask" "1"
+  - script: ../../common-scripts/verify-number-of-resources.sh "keptntask" "1" $NAMESPACE

--- a/test/integration/simple-task/01-teststep.yaml
+++ b/test/integration/simple-task/01-teststep.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
-  - script: ../common-scripts/verify-number-of-resources.sh "job" "1"
+  - script: ../../common-scripts/verify-number-of-resources.sh "job" "1" $NAMESPACE


### PR DESCRIPTION
## Changes
- adapt helm charts to allow mutating webhook only for certain namespaces
- adapt installation action to be able to test the feature
- introduce integration tests
- update docs
- document changes

Fixes: #2090 