### PR TITLE
docs: ref pages for Analysis CRDs

### DIFF
--- a/docs/content/en/docs/yaml-crd-ref/analysis.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysis.md
@@ -68,7 +68,7 @@ status:
   * **status** -- results of this Analysis run,
     added to the resource by Keptn.
     * **pass** -- Whether the analysis passed or failed.
-    * **warning** -- Whether the analysis returned a warning.
+    > **Warning** -- Whether the analysis returned a warning.
     * **raw** --  String-encoded JSON object that reaports the results
       of evaluating one or more objectives or metrics.
       See
@@ -226,23 +226,23 @@ each representing the results of a specific objective or performance metric.
       (value: 0).
   * **`score`** -- Indicates the score assigned to this objective (score: 1).
 
-- The second item in the array:
-  - **`result`** -- Similar to the first objective,
+* The second item in the array:
+  * **`result`** -- Similar to the first objective,
     it checks whether a value is greater than 0 and has not been fulfilled
     (`fulfilled: false`).
     There are no warning conditions in this case.
-  - **`objective`** -- Describes the objective related to error rate analysis.
-    - **`analysisValueTemplateRef`** -- Refers to the template
+  * **`objective`** -- Describes the objective related to error rate analysis.
+    * **`analysisValueTemplateRef`** -- Refers to the template
       used for analysis (`error-rate`).
-    - **`target`** -- Sets the target value for failure
+    * **`target`** -- Sets the target value for failure
       (failure occurs if the value is greater than 0).
-    - **`weight`** -- Specifies the weight assigned to this objective
+    * **`weight`** -- Specifies the weight assigned to this objective
       (weight: 1).
-    - **`keyObjective`** -- Indicates that this is a key objective (true).
+    * **`keyObjective`** -- Indicates that this is a key objective (true).
 
-  - **`value`** -- Indicates the actual value measured for this objective
+  * **`value`** -- Indicates the actual value measured for this objective
       (value: 0).
-  - **`score`** -- Indicates the score assigned to this objective (score: 1).
+  * **`score`** -- Indicates the score assigned to this objective (score: 1).
 
 **`totalScore`** -- Represents the total score achieved
 based on the objectives evaluated (totalScore: 2).
@@ -334,4 +334,3 @@ in the `metrics-operator` deployment.
 * [AnalysisDefinition](analysisdefinition.md)
 * [AnalysisValueTemplate](analysisvaluetemplate.md)
 * [Analysis](../implementing/slo) guide
-

--- a/docs/content/en/docs/yaml-crd-ref/analysis.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysis.md
@@ -3,3 +3,335 @@ title: Analysis
 description: Define specific configurations and the Analysis to report
 weight: 4
 ---
+
+An `Analysis` resource customizes the templates
+that are defined in an
+[AnalysisDefinition](analysisdefinition.md) resource
+by identifying the time for which the analysis should be done
+and the appropriate values to use for variables
+that are used in the `AnalysisDefinition` query.
+
+## Synopsis
+
+```yaml
+apiVersion: metrics.keptn.sh/v1alpha3
+kind: Analysis
+metadata:
+  name: analysis-sample
+spec:
+  timeframe: from: <start-time> to: <end-time> | `recent <timespan>`
+  args:
+    <variable1>: <value1>
+    <variable2>: <value2>
+    ...
+  analysisDefinition:
+    name: <name of associated `analysisDefinition` resource
+    namespace: <namespace of associated `analysisDefinition` resource
+status:
+  pass: true | false
+  warning: true | false
+  raw: <JSON object>
+  state: Completed | Progressing
+```
+
+## Fields
+
+* **apiVersion** -- API version being used
+* **kind** -- Resource type.
+   Must be set to `Analysis`
+* **metadata**
+  * **name** -- Unique name of this analysis.
+    Names must comply with the
+    [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+    specification.
+* **spec**
+  * **timeframe** -- Specifies the range  for the corresponding query
+    in the AnalysisValueTemplate.
+    This can be populated as one of the following:
+
+    * A combination of ‘from’ and ’to’
+      to specify the start and stop times for the analysis.
+      These fields follow the
+      [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt)
+      timestamp format.
+    * Set the ‘recent’ property to a time span.
+      This causes the Analysis to use data going back that amount of time.
+      For example, if `recent: 10m` is set,
+      the Analysis studies data from the last ten minutes.
+    If neither is set, the Analysis can not be added to the cluster.
+  * **args** -- Map of key/value pairs that can be used
+    to substitute variables in the `AnalysisValueTemplate` query.
+  * **analysisDefinition** -- Identify the `AnalysisDefinition` resource
+    that stores the `AnalysisValuesTemplate` associated with this `Analysis`
+    * **name** -- Name of the `AnalysisDefinition` resource
+    * **namespace** -- Namespace of the `AnalysisDefinition` resource.
+  * **status** -- results of this Analysis run,
+    added to the resource by Keptn.
+    * **pass** -- Whether the analysis passed or failed.
+    * **warning** -- Whether the analysis returned a warning.
+    * **raw** --  String-encoded JSON object that reaports the results
+      of evaluating one or more objectives or metrics.
+      See
+      [Interpreting Analysis results](#interpreting-analysis-results)
+      for details.
+    * **state** -- Set to `Completed` or `Progressing` as appropriate.
+
+## Interpreting Analysis results
+
+The `status.raw` field is a string encoded JSON object object that represents the
+results of evaluating one or more performance objectives or metrics.
+It shows whether these objectives have passed or failed, their actual values, and the associated scores.
+In this example, the objectives include response time and error rate analysis,
+each with its own criteria for passing or failing.
+The overall evaluation has passed, and no warnings have been issued.
+
+```json
+{
+    "objectiveResults": [
+        {
+            "result": {
+                "failResult": {
+                    "operator": {
+                        "greaterThan": {
+                            "fixedValue": "500m"
+                        }
+                    },
+                    "fulfilled": false
+                },
+                "warnResult": {
+                    "operator": {
+                        "greaterThan": {
+                            "fixedValue": "300m"
+                        }
+                    },
+                    "fulfilled": false
+                },
+                "warning": false,
+                "pass": true
+            },
+            "objective": {
+                "analysisValueTemplateRef": {
+                    "name": "response-time-p95"
+                },
+                "target": {
+                    "failure": {
+                        "greaterThan": {
+                            "fixedValue": "500m"
+                        }
+                    },
+                    "warning": {
+                        "greaterThan": {
+                            "fixedValue": "300m"
+                        }
+                    }
+                },
+                "weight": 1
+            },
+            "value": 0.00475,
+            "score": 1
+        },
+        {
+            "result": {
+                "failResult": {
+                    "operator": {
+                        "greaterThan": {
+                            "fixedValue": "0"
+                        }
+                    },
+                    "fulfilled": false
+                },
+                "warnResult": {
+                    "operator": {
+
+                    },
+                    "fulfilled": false
+                },
+                "warning": false,
+                "pass": true
+            },
+            "objective": {
+                "analysisValueTemplateRef": {
+                    "name": "error-rate"
+                },
+                "target": {
+                    "failure": {
+                        "greaterThan": {
+                            "fixedValue": "0"
+                        }
+                    }
+                },
+                "weight": 1,
+                "keyObjective": true
+            },
+            "value": 0,
+            "score": 1
+        }
+    ],
+    "totalScore": 2,
+    "maximumScore": 2,
+    "pass": true,
+    "warning": false
+}
+```
+
+The meaning of each of these properties is as follows:
+
+**`objectiveResults`**: This is an array containing one or more objects,
+each representing the results of a specific objective or performance metric.
+
+* The first item in the array:
+  * **`result`** -- This object contains information
+    about whether the objective has passed or failed.
+    It has two sub-objects:
+    * **`failResult`** -- Indicates whether the objective has failed.
+      In this case, it checks if a value is greater than 500 milliseconds
+      and it has not been fulfilled (`fulfilled: false`).
+    * **`warnResult`** -- Indicates whether the objective has issued a warning.
+      It checks if a value is greater than 300 milliseconds
+      and it has not been fulfilled (`fulfilled: false`).
+    <!-- markdownlint-disable-next-line -->
+    - **`warning`** -- Indicates whether a warning has been issued
+      (false in this case).
+    * **`pass`** -- Indicates whether the objective has passed
+      (true in this case).
+  * **`objective`** -- Describes the objective being evaluated.
+    It includes:
+    * **`analysisValueTemplateRef`** -- Refers to the template
+      used for analysis (`response-time-p95`).
+    * **`target`** -- Sets the target values for failure and warning conditions.
+      In this case, failure occurs
+      if the value is greater than 500 milliseconds
+      and warning occurs if it's greater than 300 milliseconds.
+    * **`weight`** -- Specifies the weight assigned to this objective
+      (weight: 1).
+  * **`value`** -- Indicates the actual value measured for this objective
+    (value: 0.00475).
+  * **`score`** -- Indicates the score assigned to this objective (score: 1).
+
+* The second item in the array:
+  * **`result`** -- Similar to the first objective,
+    it checks whether a value is greater than 0 and has not been fulfilled
+    (`fulfilled: false`).
+    There are no warning conditions in this case.
+  * **`objective`** -- Describes the objective related to error rate analysis.
+    * **`analysisValueTemplateRef`** -- Refers to the template
+      used for analysis (`error-rate`).
+    * **`target`** -- Sets the target value for failure
+      (failure occurs if the value is greater than 0).
+    * **`weight`** -- Specifies the weight assigned to this objective
+      (weight: 1).
+    * **`keyObjective`** -- Indicates that this is a key objective (true).
+
+  * **`value`** -- Indicates the actual value measured for this objective
+      (value: 0).
+  * **`score`** -- Indicates the score assigned to this objective (score: 1).
+
+- The second item in the array:
+  - **`result`** -- Similar to the first objective,
+    it checks whether a value is greater than 0 and has not been fulfilled
+    (`fulfilled: false`).
+    There are no warning conditions in this case.
+  - **`objective`** -- Describes the objective related to error rate analysis.
+    - **`analysisValueTemplateRef`** -- Refers to the template
+      used for analysis (`error-rate`).
+    - **`target`** -- Sets the target value for failure
+      (failure occurs if the value is greater than 0).
+    - **`weight`** -- Specifies the weight assigned to this objective
+      (weight: 1).
+    - **`keyObjective`** -- Indicates that this is a key objective (true).
+
+  - **`value`** -- Indicates the actual value measured for this objective
+      (value: 0).
+  - **`score`** -- Indicates the score assigned to this objective (score: 1).
+
+**`totalScore`** -- Represents the total score achieved
+based on the objectives evaluated (totalScore: 2).
+
+**`maximumScore`** -- Indicates the maximum possible score (maximumScore: 2).
+
+**`pass`** -- Indicates whether the overall evaluation has passed
+(true in this case).
+<!-- markdownlint-disable-next-line -->
+**`warning`** -- Indicates whether any warnings have been issued
+during the evaluation (false in this case).
+
+## Usage
+
+An `Analysis` resource specifies a single Analysis run.
+It specifies the `AnalysisTemplateValue` resource
+that defines the calculations to use,
+the timeframe for which to report information,
+and values to use for variables for this run.
+
+The result of this analysis stays in the cluster
+until the `Analysis` is deleted.
+That also means that, if another analysis should be performed,
+the new analysis must be given a new, unique name within the namespace.
+
+To perform an Analysis (or "trigger an evaluation" in Keptn v1 jargon),
+apply the `analysis-instance.yaml` file:
+
+```shell
+kubectl apply -f analysis-instance.yaml -n keptn-lifecycle-poc
+```
+
+Retrieve the current status of the Analysis with the following command:
+
+```shell
+kubectl get analysis - n keptn-lifecycle-poc
+```
+
+This yields an output that looks like the following:
+
+```shell
+NAME                ANALYSISDEFINITION      WARNING   PASS
+analysis-sample-1   my-project-ad                     true
+```
+
+This shows that the analysis passed successfully.
+
+To get the detailed result of the evaluation,
+use the `-oyaml` argument to inspect the full state of the analysis:
+
+This displays the `Analysis` resource
+with the definition of the analysis
+as well as the `status` (results) of the analysis; for example:
+
+```shell
+kubectl get analysis - n keptn-lifecycle-poc -oyaml
+```
+
+## Examples
+
+{{< embed path="/metrics-operator/config/samples/metrics_v1alpha3_analysis.yaml" >}}
+
+This `Analysis` resource:
+
+* Defines the `timeframe` for which the analysis is done
+  as between 5 am and 10 am on the 5th of May 2023
+* Adds a few specific key-value pairs that will be substituted in the query.
+  For instance, the query could contain the `{{.nodename}}` variable.
+  The value of the `args.nodename` field (`test`)
+  will be substituted for this string.
+
+For a full example of how to implement the Keptn Analysis feature, see the
+[Analysis](../implementing/slo)
+guide page.
+
+## Files
+
+API reference: [Analysis](../crd-ref/metrics/v1alpha3/#analysis)
+
+## Differences between versions
+
+Keptn v.0.8.3 includes a preliminary release of the Keptn Analysis feature
+but is hidden behind a feature flag.
+To preview these features, set the environment `ENABLE_ANALYSIS` to `true`
+in the `metrics-operator` deployment.
+
+## See also
+
+* [AnalysisDefinition](analysisdefinition.md)
+* [AnalysisValueTemplate](analysisvaluetemplate.md)
+* [Analysis](../implementing/slo) guide
+

--- a/docs/content/en/docs/yaml-crd-ref/analysis.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysis.md
@@ -68,7 +68,7 @@ status:
   * **status** -- results of this Analysis run,
     added to the resource by Keptn.
     * **pass** -- Whether the analysis passed or failed.
-    > **Warning** -- Whether the analysis returned a warning.
+    * **Warning** -- Whether the analysis returned a warning.
     * **raw** --  String-encoded JSON object that reaports the results
       of evaluating one or more objectives or metrics.
       See

--- a/docs/content/en/docs/yaml-crd-ref/analysis.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysis.md
@@ -68,7 +68,8 @@ status:
   * **status** -- results of this Analysis run,
     added to the resource by Keptn.
     * **pass** -- Whether the analysis passed or failed.
-    * **Warning** -- Whether the analysis returned a warning.
+    <!-- markdownlint-disable -->
+    * **warning** -- Whether the analysis returned a warning.
     * **raw** --  String-encoded JSON object that reaports the results
       of evaluating one or more objectives or metrics.
       See

--- a/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
@@ -52,7 +52,8 @@ spec:
         * **failure**
           * **lessThan**
             * **fixedValue** 600
-        * **Warning**
+        <!-- markdownlint-disable -->
+        * **warning**
           * **inRange**
             * **lowBound** 300
             * **highBound** 500
@@ -60,7 +61,8 @@ spec:
       * **keyObjective** false
   * **totalScore**
     * **passPercentage** 90
-    * **WarningPercentage**
+    <!-- markdownlint-disable -->
+    * **warningPercentage**
 
 ## Usage
 

--- a/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
@@ -52,7 +52,7 @@ spec:
         * **failure**
           * **lessThan**
             * **fixedValue** 600
-        * **Warning**
+        > **Warning**
         * **inRange**
           * **lowBound** 300
           * **highBound** 500
@@ -60,7 +60,7 @@ spec:
       * **keyObjective** false
   * **totalScore**
     * **passPercentage** 90
-    * **Warning**Percentage
+    > **Warning**Percentage
 
 ## Usage
 

--- a/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
@@ -3,3 +3,124 @@ title: AnalysisDefinition
 description: Define SLOs for an Analysis
 weight: 6
 ---
+
+An `AnalysisDefinition` resource defines the
+list of Service Level Objectives (SLOs) for an `Analysis`.
+
+## Synopsis
+
+```yaml
+apiVersion: metrics.keptn.sh/v1alpha3
+kind: AnalysisDefinition
+metadata:
+  name: ed-my-proj-dev-svc1
+  namespace: keptn-lifecycle-toolkit-system
+spec:
+  objectives:
+    - analysisValueTemplateRef:
+        name: response-time-p95
+        namespace: keptn-lifecycle-toolkit-system
+      target:
+        failure:
+          lessThan:
+            fixedValue: 600
+        warning:
+          inRange:
+            lowBound: 300
+            highBound: 500
+      weight: 1
+      keyObjective: false
+  totalScore:
+    passPercentage: 90
+    warningPercentage: 75
+```
+
+## Fields
+
+* **apiVersion** -- API version being used
+* **kind** -- Resource type.
+   Must be set to AnalysisDefinition.
+* **metadata**
+  * **name** ed-my-proj-dev-svc1
+  * **namespace** keptn-lifecycle-toolkit-system
+* **spec**
+  * **objectives**
+    * **analysisValueTemplateRef**
+      * **name** response-time-p95
+      * **namespace** keptn-lifecycle-toolkit-system
+      * **target**
+        * **failure**
+          * **lessThan**
+            * **fixedValue** 600
+        * **Warning**
+        * **inRange**
+          * **lowBound** 300
+          * **highBound** 500
+      * **weight** 1
+      * **keyObjective** false
+  * **totalScore**
+    * **passPercentage** 90
+    * **Warning**Percentage
+
+## Usage
+
+An `AnalysisDefinition` resource contains a list of objectives to satisfy.
+Each of these objectives must specify:
+
+* Failure or warning target criteria
+* Whether the objective is a key objective
+  meaning that its failure fails the Analysis
+* Weight of the objective on the overall Analysis
+* The `AnalysisValueTemplate` resource that contains the SLIs,
+  defining the data provider from which to gather the data
+  and how to compute the Analysis
+
+## Examples
+
+```yaml
+apiVersion: metrics.keptn.sh/v1alpha3
+kind: AnalysisDefinition
+metadata:
+  name: ed-my-proj-dev-svc1
+  namespace: keptn-lifecycle-toolkit-system
+spec:
+  objectives:
+    - analysisValueTemplateRef:
+        name: response-time-p95
+        namespace: keptn-lifecycle-toolkit-system
+      target:
+        failure:
+          lessThan:
+            fixedValue: 600
+        warning:
+          inRange:
+            lowBound: 300
+            highBound: 500
+      weight: 1
+      keyObjective: false
+  totalScore:
+    passPercentage: 90
+    warningPercentage: 75
+```
+
+For an example of how to implement the Keptn Analysis feature, see the
+[Analysis](../implementing/slo)
+guide page.
+
+## Files
+
+API reference:
+[AnalysisDefinition](../crd-ref/metrics/v1alpha3/#analysisdefinition)
+
+## Differences between versions
+
+A preliminary release of the Keptn Analysis feature
+is included in Keptn v.0.8.3 but is hidden behind a feature flag.
+To preview these features, set the environment `ENABLE_ANALYSIS` to `true`
+in the `metrics-operator` deployment.
+
+## See also
+
+* [Analysis](analysis.md)
+* [AnalysisValueTemplate](analysisvaluetemplate.md)
+* [Analysis](../implementing/slo) guide

--- a/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysisdefinition.md
@@ -52,15 +52,15 @@ spec:
         * **failure**
           * **lessThan**
             * **fixedValue** 600
-        > **Warning**
-        * **inRange**
-          * **lowBound** 300
-          * **highBound** 500
+        * **Warning**
+          * **inRange**
+            * **lowBound** 300
+            * **highBound** 500
       * **weight** 1
       * **keyObjective** false
   * **totalScore**
     * **passPercentage** 90
-    > **Warning**Percentage
+    * **WarningPercentage**
 
 ## Usage
 
@@ -75,7 +75,7 @@ Each of these objectives must specify:
   defining the data provider from which to gather the data
   and how to compute the Analysis
 
-## Examples
+## Example
 
 ```yaml
 apiVersion: metrics.keptn.sh/v1alpha3

--- a/docs/content/en/docs/yaml-crd-ref/analysisvaluetemplate.md
+++ b/docs/content/en/docs/yaml-crd-ref/analysisvaluetemplate.md
@@ -3,3 +3,105 @@ title: AnalysisValueTemplate
 description: Define the data source and query for each SLI
 weight: 8
 ---
+
+An `AnalysisValueTemplate` resource
+defines a Service Level Indicator (SLI),
+which identifies the data to be analyzed
+by data source to use and the query to issue.
+One Analysis can use data from multiple instances
+of multiple types of data provider.
+
+## Synopsis
+
+```yaml
+apiVersion: metrics.keptn.sh/v1alpha3
+kind: AnalysisValueTemplate
+metadata:
+  name: response-time-p95
+  namespace: keptn-lifecycle-toolkit-system
+spec:
+  provider:
+    name: prometheus | dynatrace | dql | datadog
+  query: <query>
+```
+
+## Fields
+
+* **apiVersion** -- API version being used
+* **kind** -- Resource type.
+  Must be set to `AnalysisValueTemplate`
+* **metadata**
+  * **labels** -- The Analysis feature uses the
+    `name` and `part-of` labels that are discussed in
+    [Basic annotations](../implementing/integrate/#basic-annotations)
+    plus the following:
+    * **app.kubernetes.io/instance** analysis-sample
+    * **app.kuberentes.io/managed-by** -- Tool used to manage
+      the operation of the application.
+      Valid values are `helm` and `kustomize`.
+    * **app.kubernetes.io/created-by** metrics-operator
+
+      TODO: Need to clarify how to use these annotations
+  * **name** -- Unique name of this template.
+    Names must comply with the
+    [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+    specification.
+  * **namespace** -- Namespace where this template lives
+* **spec**
+  * **provider**
+    * **name** -- The `spec.name` value of the
+      [KeptnMetricsProvider](metricsprovider.md) resource to use.
+      Note that each `AnalysisValueTemplate` resource
+      can use only one data source.
+      However, an `Analysis` resource
+      can use multiple `AnalysisValueTemplate` resources,
+      each of which uses a different data source.
+  * **query** -- query to be made.
+    This is done in the data provider's query language.
+    It can include variables that use the go templating syntax
+    to insert a placeholder in the query.
+    For example, the query might include `{{.nodename}}'}`;
+    the value to substitute for that variable for this Analysis
+    is defined in the `spec.args` section of the `AnalysisTemplate` resource,
+    which might be set to `nodename: test`.
+
+## Usage
+
+You must define a
+[KeptnMetricsProvider](metricsprovider.md)
+for each instance of each data provider you are using.
+The `AnalysisValueTemplate` refers to that provider and queries it.
+
+One `Analysis` can use data from multiple instances
+of multiple types of data provider;
+you must define a
+[KeptnMetricsProvider](metricsprovider.md)
+resource for each instance of each data provider you are using.
+The template refers to that provider and queries it.
+
+## Example
+
+{{< embed path="/metrics-operator/config/samples/metrics_v1alpha3_analysisvaluetemplate.yaml" >}}
+
+For a full example of how the `AnalysisValueTemplate` is used
+to implement the Keptn Analysis feature, see the
+[Analysis](../implementing/slo)
+guide page.
+
+## Files
+
+API reference:
+[AnalysisValueTemplate](../crd-ref/metrics/v1alpha3/#analysisvaluetemplate)
+
+## Differences between versions
+
+Keptn v0.8.3 includes a preliminary release of the Keptn Analysis feature
+but is hidden behind a feature flag.
+To preview these features, set the environment `ENABLE_ANALYSIS` to `true`
+in the `metrics-operator` deployment.
+
+## See also
+
+* [Analysis](analysis.md)
+* [AnalysisDefinition](analysisdefinition.md)
+* [Analysis](../implementing/slo) guide

--- a/docs/content/en/docs/yaml-crd-ref/crd-template.md
+++ b/docs/content/en/docs/yaml-crd-ref/crd-template.md
@@ -1,20 +1,17 @@
 ---
-title: <crd-name>
 description: <one-line description of CRD>
 weight: <assign weight to create alphabetical order>
-hide: true
 ---
 
 Copy this template to create a new CRD reference page.
 
 1. Replace the variable text in metadata with information for this page
-1. Delete the `hidden: true` line
 1. Delete these instructions from your file
 1. Populate the page with appropriate content
 
 ## Synopsis
 
-## Parameters
+## Fields
 
 <!-- Detailed description of each field/parameter -->
 
@@ -30,3 +27,5 @@ Copy this template to create a new CRD reference page.
 ## Differences between versions
 
 ## See also
+
+

--- a/docs/content/en/docs/yaml-crd-ref/crd-template.md
+++ b/docs/content/en/docs/yaml-crd-ref/crd-template.md
@@ -1,4 +1,5 @@
 ---
+title: template for new files in this directory
 description: <one-line description of CRD>
 weight: <assign weight to create alphabetical order>
 ---

--- a/docs/content/en/docs/yaml-crd-ref/crd-template.md
+++ b/docs/content/en/docs/yaml-crd-ref/crd-template.md
@@ -27,5 +27,3 @@ Copy this template to create a new CRD reference page.
 ## Differences between versions
 
 ## See also
-
-


### PR DESCRIPTION
Replaces https://github.com/keptn/lifecycle-toolkit/pull/2219/

Draft of CRD reference pages for the analysis feature:
* Analysis
* AnalysisDefinition
* AnalysisValueTemplate

Also updates:
* crd-template.md, which is just the template to start a new page in this section