### PR TITLE
docs: refine info about configuring Grafana/Jaeger

### DIFF
--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -120,7 +120,7 @@ you must have the following on your cluster:
 
   - Install
     [Grafana](https://grafana.com/grafana/dashboards/)
-    or the dashboard of your choice, following the instructions in
+    or the visualization tool of your choice, following the instructions in
     [Grafana Setup](https://grafana.com/docs/grafana/latest/setup-grafana/).
   - Install
     [Jaeger](https://grafana.com/grafana/dashboards/10001-jaeger/)

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -93,39 +93,47 @@ you must have the following on your cluster:
   See
   [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
   for more information.
-- Prometheus Operator.
+- A Prometheus Operator.
   See [Prometheus Operator Setup](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizing.md).
-- The Prometheus Operator must have the required permissions
-  to watch resources of the `keptn-lifecycle-toolkit-system` namespace (see
-  [Setup for Monitoring other Namespaces](https://prometheus-operator.dev/docs/kube/monitoring-other-namespaces/)).
 
-If you want a dashboard for reviewing metrics and traces,
-you need:
+  - The Prometheus Operator must have the required permissions
+    to watch resources of the `keptn-lifecycle-toolkit-system` namespace (see
+    [Setup for Monitoring other Namespaces](https://prometheus-operator.dev/docs/kube/monitoring-other-namespaces/)).
 
-- [Grafana](https://grafana.com/)
-  or the dashboard of your choice.
-   See
-  [Grafana Setup](https://grafana.com/docs/grafana/latest/setup-grafana/).
+  - To install Prometheus into the `monitoring` namespace
+    using the default configuration included with Keptn,
+    use the following command sequence.
+    Use similar commands if you define a different configuration:
 
-- [Jaeger](https://jaegertracing.io)
-  or a similar tool if you want traces.
-   See
-  [Jaeger Setup](https://github.com/jaegertracing/jaeger-operator#getting-started).
+    > **Note**
+    You must clone  the `lifecycle-toolkit` repository
+    and `cd` into the correct directory
+    (`examples/support/observability`) before running the following commands.
 
-To install Prometheus into the `monitoring` namespace,
-using the default configuration included with Keptn,
-use the following commands.
-Use similar commands if you define a different configuration::
+    ```shell
+    kubectl create namespace monitoring
+    kubectl apply --server-side -f config/prometheus/setup
+    kubectl apply -f config/prometheus/
+    ```
 
-> **Note**
-You must clone  the `lifecycle-toolkit` repository and `cd` into the correct directory
-(`examples/support/observability`) before running the following commands.
+- If you want a dashboard for reviewing metrics and traces:
 
-```shell
-kubectl create namespace monitoring
-kubectl apply --server-side -f config/prometheus/setup
-kubectl apply -f config/prometheus/
-```
+  - Install
+    [Grafana](https://grafana.com/grafana/dashboards/)
+    or the dashboard of your choice, following the instructions in
+    [Grafana Setup](https://grafana.com/docs/grafana/latest/setup-grafana/).
+  - Install
+    [Jaeger](https://grafana.com/grafana/dashboards/10001-jaeger/)
+    or a similar tool for traces following the instructions in
+    [Jaeger Setup](https://github.com/jaegertracing/jaeger-operator#getting-started).
+
+  - Follow the instructions in the Grafana
+    [README](https://github.com/keptn/lifecycle-toolkit/blob/main/dashboards/grafana/README.md)
+    file to configure the Grafana dashboard(s) for Keptn..
+
+    Metrics can also be retrieved without a dashboard.
+    See
+    [Accessing Metrics via the Kubernetes Custom Metrics API](evaluatemetrics/#accessing-metrics-via-the-kubernetes-custom-metrics-api)
 
 ### Integrate OpenTelemetry into Keptn
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -133,7 +133,7 @@ you must have the following on your cluster:
 
     Metrics can also be retrieved without a dashboard.
     See
-    [Accessing Metrics via the Kubernetes Custom Metrics API](evaluatemetrics/#accessing-metrics-via-the-kubernetes-custom-metrics-api)
+    [Accessing Metrics via the Kubernetes Custom Metrics API](evaluatemetrics.md/#accessing-metrics-via-the-kubernetes-custom-metrics-api)
 
 ### Integrate OpenTelemetry into Keptn
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -123,9 +123,9 @@ you must have the following on your cluster:
     or the visualization tool of your choice, following the instructions in
     [Grafana Setup](https://grafana.com/docs/grafana/latest/setup-grafana/).
   - Install
-    [Jaeger](https://grafana.com/grafana/dashboards/10001-jaeger/)
+    [Jaeger](https://www.jaegertracing.io/)
     or a similar tool for traces following the instructions in
-    [Jaeger Setup](https://github.com/jaegertracing/jaeger-operator#getting-started).
+    [Jaeger Setup](https://www.jaegertracing.io/docs/1.50/getting-started/).
 
   - Follow the instructions in the Grafana
     [README](https://github.com/keptn/lifecycle-toolkit/blob/main/dashboards/grafana/README.md)

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -112,7 +112,7 @@ you must have the following on your cluster:
 
     ```shell
     kubectl create namespace monitoring
-    kubectl apply --server-side -f config/prometheus/setup
+    kubectl apply --server-side -f config/prometheus/setup/
     kubectl apply -f config/prometheus/
     ```
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -101,7 +101,7 @@ you must have the following on your cluster:
     [Setup for Monitoring other Namespaces](https://prometheus-operator.dev/docs/kube/monitoring-other-namespaces/)).
 
   - To install Prometheus into the `monitoring` namespace
-    using the default configuration included with Keptn,
+    using the example configuration included with Keptn,
     use the following command sequence.
     Use similar commands if you define a different configuration:
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -106,7 +106,7 @@ you must have the following on your cluster:
     Use similar commands if you define a different configuration:
 
     > **Note**
-    You must clone  the `lifecycle-toolkit` repository
+    You must clone the `lifecycle-toolkit` repository
     and `cd` into the correct directory
     (`examples/support/observability`) before running the following commands.
 

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -119,7 +119,7 @@ you must have the following on your cluster:
 - If you want a dashboard for reviewing metrics and traces:
 
   - Install
-    [Grafana](https://grafana.com/grafana/dashboards/)
+    [Grafana](https://grafana.com/grafana/)
     or the visualization tool of your choice, following the instructions in
     [Grafana Setup](https://grafana.com/docs/grafana/latest/setup-grafana/).
   - Install

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -97,7 +97,7 @@ you must have the following on your cluster:
   See [Prometheus Operator Setup](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizing.md).
 
   - The Prometheus Operator must have the required permissions
-    to watch resources of the `keptn-lifecycle-toolkit-system` namespace (see
+    to watch resources of your Keptn namespace (default is `keptn-lifecycle-toolkit-system`) (see
     [Setup for Monitoring other Namespaces](https://prometheus-operator.dev/docs/kube/monitoring-other-namespaces/)).
 
   - To install Prometheus into the `monitoring` namespace

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -99,7 +99,7 @@ Your cluster should include the following:
   you must have an OpenTelemetry collector
   as well as a Prometheus operator installed on your cluster.
   For more information, see
-  [Requirements for Open Telemetry](../implementing/otel.md/#requirements-for-opentelemetry).
+  [Requirements for OpenTelemetry](../implementing/otel.md/#requirements-for-opentelemetry).
 
 * If you want a dashboard for reviewing metrics and traces,
   install the dashboard tools of your choice;

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -85,14 +85,14 @@ Your cluster should include the following:
   you can use multiple instances of different data providers.
   These provide:
 
-  - Metrics used for
+  * Metrics used for
     [Keptn Metrics](../implementing/evaluatemetrics.md/)
-  - Metrics used for
+  * Metrics used for
     [OpenTelemetry](implementing/otel.md/)
     observability
-  - SLIs for pre- and post-deployment
+  * SLIs for pre- and post-deployment
     [evaluations](../implementing/evaluations.md/)
-  - SLIs used for
+  * SLIs used for
     [analyses](../implementing/slo/)
 
 * If you want to use the standardized observability feature,

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -88,7 +88,7 @@ Your cluster should include the following:
   * Metrics used for
     [Keptn Metrics](../implementing/evaluatemetrics.md/)
   * Metrics used for
-    [OpenTelemetry](./implementing/otel.md/)
+    [OpenTelemetry](../implementing/otel.md/)
     observability
   * SLIs for pre- and post-deployment
     [evaluations](../implementing/evaluations.md/)

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -109,7 +109,7 @@ Your cluster should include the following:
 
 * Keptn includes a lightweight `cert-manager` that, by default,
   is installed as part of the Keptn software.
-  If you are using another certification manager in the cluster,
+  If you are using another certificate manager in the cluster,
   you can configure Keptn to instead use your cert-manager.
   See [Use Keptn with cert-manager.io](../operate/cert-manager.md)
   for detailed instructions.

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -103,7 +103,7 @@ Your cluster should include the following:
 
 * If you want a dashboard for reviewing metrics and traces,
   install the dashboard tools of your choice;
-  we primarily use Grafana and Jaeger.
+  we primarily use Grafana.
   For more information, see
   [Requirements for Open Telemetry](../implementing/otel.md/#requirements-for-opentelemetry).
 

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -76,7 +76,7 @@ Your cluster should include the following:
   such as
   [Argo CD](https://argo-cd.readthedocs.io/en/stable/) or
   [Flux](https://fluxcd.io/).
-  Alternatively, Keptn also works with just `kubctl apply` for deployment.
+  Alternatively, Keptn also works with just `kubectl apply` for deployment.
 
 * At least one observability data provider such as
   [Prometheus](https://prometheus.io/),

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -66,7 +66,7 @@ Your cluster should include the following:
 
 * The
   [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
-  command that is used to administer Kubernetes.
+  CLI that is used to interact with Kubernetes clusters.
 
 * The
   [Helm](https://helm.sh/docs/intro/install/)

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -70,7 +70,7 @@ Your cluster should include the following:
 
 * The
   [Helm](https://helm.sh/docs/intro/install/)
-  command that is used to install and configure Keptn.
+  CLI that is used to install and configure Keptn.
 
 * Deployment tools of your choice,
   such as

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -55,8 +55,7 @@ The basic steps are:
 ## Prepare your cluster for Keptn
 
 Keptn installs into an existing Kubernetes cluster.
-When setting up a local Kubernetes cluster
-to study or demonstrate Keptn,
+When setting up a local Kubernetes cluster to study or demonstrate Keptn,
 you need to provide these components.
 
 Your cluster should include the following:
@@ -65,16 +64,13 @@ Your cluster should include the following:
   See [Supported Kubernetes versions](reqs.md/#supported-kubernetes-versions)
   for details.
 
-* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+* The
+  [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+  command that is used to administer Kubernetes.
 
-* [Helm](https://helm.sh/docs/intro/install/)
-
-* Metric provider such as
-  [Prometheus](https://prometheus.io/),
-  [Dynatrace](https://www.dynatrace.com/),
-  or [Datadog](https://www.datadoghq.com/).
-  This is used for the metrics used for the observability features
-  as well as the pre- and post-deployment evaluations.
+* The
+  [Helm](https://helm.sh/docs/intro/install/)
+  command that is used to install and configure Keptn.
 
 * Deployment tools of your choice,
   such as
@@ -82,25 +78,41 @@ Your cluster should include the following:
   [Flux](https://fluxcd.io/).
   Alternatively, Keptn also works with just `kubctl apply` for deployment.
 
+* At least one observability data provider such as
+  [Prometheus](https://prometheus.io/),
+  [Dynatrace](https://www.dynatrace.com/),
+  or [Datadog](https://www.datadoghq.com/);
+  you can use multiple instances of different data providers.
+  These provide:
+
+  - Metrics used for
+    [Keptn Metrics](../implementing/evaluatemetrics.md/)
+  - Metrics used for
+    [OpenTelemetry](implementing/otel.md/)
+    observability
+  - SLIs for pre- and post-deployment
+    [evaluations](../implementing/evaluations.md/)
+  - SLIs used for
+    [analyses](../implementing/slo/)
+
 * If you want to use the standardized observability feature,
   you must have an OpenTelemetry collector
-  and a Prometheus operator installed on your cluster.
-
-  If you want a dashboard for reviewing metrics and traces,
-  install Grafana or the dashboard of your choice.
-
-  For traces, install Jaeger or a similar tool.
-
+  as well as a Prometheus operator installed on your cluster.
   For more information, see
   [Requirements for Open Telemetry](../implementing/otel.md/#requirements-for-opentelemetry).
 
-Also note that Keptn includes
-a light-weight cert-manager that, by default, is installed
-as part of the Keptn software.
-If you are using another cert-manager in the cluster,
-you can configure Keptn to instead use your cert-manager.
-See [Use Keptn with cert-manager.io](../operate/cert-manager.md)
-for detailed instructions.
+* If you want a dashboard for reviewing metrics and traces,
+  install the dashboard tools of your choice;
+  we primarily use Grafana and Jaeger.
+  For more information, see
+  [Requirements for Open Telemetry](../implementing/otel.md/#requirements-for-opentelemetry).
+
+* Keptn includes a lightweight `cert-manager` that, by default,
+  is installed as part of the Keptn software.
+  If you are using another certification manager in the cluster,
+  you can configure Keptn to instead use your cert-manager.
+  See [Use Keptn with cert-manager.io](../operate/cert-manager.md)
+  for detailed instructions.
 
 ## How many namespaces?
   
@@ -109,7 +121,7 @@ and how to set them up.
 See the Kubernetes
 [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
 documentation for some basic information.
-You can also search and find lots of "Best Practices for Namespaces"
+You can also search and find many "Best Practices for Namespaces"
 documents published on the web.
 
 Some considerations for Keptn:

--- a/docs/content/en/docs/install/k8s.md
+++ b/docs/content/en/docs/install/k8s.md
@@ -88,7 +88,7 @@ Your cluster should include the following:
   * Metrics used for
     [Keptn Metrics](../implementing/evaluatemetrics.md/)
   * Metrics used for
-    [OpenTelemetry](implementing/otel.md/)
+    [OpenTelemetry](./implementing/otel.md/)
     observability
   * SLIs for pre- and post-deployment
     [evaluations](../implementing/evaluations.md/)


### PR DESCRIPTION
This PR refines the (minimal) information about configuring Grafana and Jaeger for Keptn:

* install/k8s says that you must install and configure Grafana and Jaeger if you want. dashboard for metrics and tracing and links to the "Requirements" subsection of the OpenTelemetry page for more details
* The OpenTelemetry/Requirements section gives links to the vendor docs for Grafana and Jaeger and to the Keptn Grafana README file for info about configuring Grafana for Keptn