### PR TITLE
ci: run report creation and upload only in case of failure

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -69,12 +69,12 @@ jobs:
         run: make integration-test
 
       - name: Create reports
-        if: ${{ failure() }}
+        if: failure()
         working-directory: ./.github/scripts
         run: ./create-reports-full.sh
 
       - name: Upload cluster logs
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: logs-integration-tests-${{ inputs.helm-install }}-${{ inputs.scheduling-gates }}-${{ inputs.allowed-namespaces }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -69,12 +69,12 @@ jobs:
         run: make integration-test
 
       - name: Create reports
-        if: always()
+        if: ${{ failure() }}
         working-directory: ./.github/scripts
         run: ./create-reports-full.sh
 
       - name: Upload cluster logs
-        if: always()
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: logs-integration-tests-${{ inputs.helm-install }}-${{ inputs.scheduling-gates }}-${{ inputs.allowed-namespaces }}

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -59,12 +59,12 @@ jobs:
           path: ./collected-metrics
 
       - name: Create reports
-        if: always()
+        if: ${{ failure() }}
         working-directory: ./.github/scripts
         run: ./create-reports-toolkit.sh
 
       - name: Upload cluster logs
-        if: always()
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: logs-load-tests

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -59,12 +59,12 @@ jobs:
           path: ./collected-metrics
 
       - name: Create reports
-        if: ${{ failure() }}
+        if: failure()
         working-directory: ./.github/scripts
         run: ./create-reports-toolkit.sh
 
       - name: Upload cluster logs
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: logs-load-tests

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -31,12 +31,12 @@ jobs:
           make performance-test
 
       - name: Create reports
-        if: ${{ failure() }}
+        if: failure()
         working-directory: ./.github/scripts
         run: ./create-reports-toolkit.sh
 
       - name: Upload cluster logs
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: logs-performance-tests

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -31,12 +31,12 @@ jobs:
           make performance-test
 
       - name: Create reports
-        if: always()
+        if: ${{ failure() }}
         working-directory: ./.github/scripts
         run: ./create-reports-toolkit.sh
 
       - name: Upload cluster logs
-        if: always()
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: logs-performance-tests


### PR DESCRIPTION
This PR changes the integration tests to collect and upload logs only in case of failure. 
Inspecting the logs for successful runs is not common and these two steps could take as much as running the test itself
 
![image](https://github.com/keptn/lifecycle-toolkit/assets/992621/d7cb1ea7-6af0-472e-8701-490c2631aed7)
