### PR TITLE
ci: drop manifests support in CI pipelines

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -18,10 +18,6 @@ inputs:
     required: false
     description: "Name of the kind cluster"
     default: "test-cluster"
-  helm-install:
-    required: false
-    description: "Install Keptn via helm instead of manifest if true"
-    default: "helm_on"
   scheduling-gates:
     required: false
     description: "Use scheduling gates instead of scheduler"
@@ -64,34 +60,7 @@ runs:
           kind load image-archive $image/$image -n ${{ inputs.cluster-name }}
         done
 
-    - name: Install lifecycle-toolkit with manifests
-      if: ${{  inputs.helm-install == 'helm_off' }}
-      shell: bash
-      run: |
-        echo "Installing Keptn using manifests"
-        sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/lifecycle-operator-manifest-test/release.yaml
-        sed -i 's/ghcr.io\/keptn\/deno-runtime:.*/localhost:5000\/keptn\/deno-runtime:${{ inputs.runtime_tag }}/g' \
-          ~/download/artifacts/lifecycle-operator-manifest-test/release.yaml
-        sed -i 's/ghcr.io\/keptn\/python-runtime:.*/localhost:5000\/keptn\/python-runtime:${{ inputs.runtime_tag }}/g' \
-          ~/download/artifacts/lifecycle-operator-manifest-test/release.yaml
-        kubectl create namespace keptn-lifecycle-toolkit-system
-        kubectl apply -f ~/download/artifacts/lifecycle-operator-manifest-test
-
-        sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/certificate-operator-manifest-test/release.yaml
-        kubectl apply -f ~/download/artifacts/certificate-operator-manifest-test
-        kubectl rollout status deployment certificate-operator -n keptn-lifecycle-toolkit-system -w
-
-        sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/metrics-operator-manifest-test/release.yaml
-        kubectl apply -f ~/download/artifacts/metrics-operator-manifest-test
-        kubectl rollout status deployment metrics-operator -n keptn-lifecycle-toolkit-system -w
-
-        sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ~/download/artifacts/scheduler-manifest-test/release.yaml
-        kubectl apply -f ~/download/artifacts/scheduler-manifest-test
-        kubectl rollout status deployment scheduler -n keptn-lifecycle-toolkit-system -w
-        kubectl rollout status deployment lifecycle-operator -n keptn-lifecycle-toolkit-system -w
-
     - name: Install lifecycle-toolkit with helm
-      if: ${{ inputs.helm-install == 'helm_on' }}
       env:
         RELEASE_REGISTRY: "localhost:5000/keptn"
       shell: bash

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -202,22 +202,10 @@ jobs:
       - build_image
     strategy:
       matrix:
-        helm: [helm_on, helm_off]
         scheduling-gates: [gates_on, gates_off]
         allowed-namespaces: [allowed_ns_on, allowed_ns_off]
-        exclude:
-          - helm: helm_off
-            scheduling-gates: gates_on
-            allowed-namespaces: allowed_ns_on
-          - helm: helm_off
-            scheduling-gates: gates_off
-            allowed-namespaces: allowed_ns_on
-          - helm: helm_off
-            scheduling-gates: gates_on
-            allowed-namespaces: allowed_ns_off
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
-      helm-install: ${{ matrix.helm }}
       scheduling-gates: ${{ matrix.scheduling-gates }}
       allowed-namespaces: ${{ matrix.allowed-namespaces }}
     uses: ./.github/workflows/integration-test.yml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,10 +6,6 @@ on:
         description: "Tag for the deno and python runner images"
         type: "string"
         required: true
-      helm-install:
-        description: "Decides whether to install via helm"
-        type: "string"
-        default: helm_on
       scheduling-gates:
         description: "Decides whether to use scheduling gates"
         type: "string"
@@ -38,7 +34,6 @@ jobs:
         uses: ./.github/actions/deploy-klt-on-cluster
         with:
           runtime_tag: ${{ inputs.runtime_tag }}
-          helm-install: ${{ inputs.helm-install }}
           scheduling-gates: ${{ inputs.scheduling-gates }}
           allowed-namespaces: ${{ inputs.allowed-namespaces }}
 
@@ -77,5 +72,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: logs-integration-tests-${{ inputs.helm-install }}-${{ inputs.scheduling-gates }}-${{ inputs.allowed-namespaces }}
+          name: logs-integration-tests-${{ inputs.scheduling-gates }}-${{ inputs.allowed-namespaces }}
           path: .github/scripts/logs


### PR DESCRIPTION
Part-of: #1602 

## Changes
- drop manifests installation support in CI, integration tests and installation action

## Follow-up
-  drop support os manifests in security checks