### PR TITLE
chore(lifecycle-operator): remove spans created by webhook

### DIFF
--- a/lifecycle-operator/main.go
+++ b/lifecycle-operator/main.go
@@ -49,7 +49,6 @@ import (
 	controlleroptions "github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/options"
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/webhooks/pod_mutator"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.opentelemetry.io/otel"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
 	metricsapi "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -384,11 +383,14 @@ func main() {
 			"/mutate-v1-pod": {
 				Handler: pod_mutator.NewPodMutator(
 					mgr.GetClient(),
-					otel.Tracer("keptn/webhook"),
 					admission.NewDecoder(mgr.GetScheme()),
-					controllercommon.NewEventMultiplexer(webhookLogger, webhookRecorder, ceClient),
+					controllercommon.NewEventMultiplexer(
+						webhookLogger,
+						webhookRecorder,
+						ceClient),
 					webhookLogger,
-					env.SchedulingGatesEnabled),
+					env.SchedulingGatesEnabled,
+				),
 			},
 		})
 		setupLog.Info("starting webhook")

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/appcreationrequest_handler.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/appcreationrequest_handler.go
@@ -9,9 +9,7 @@ import (
 	apicommon "github.com/keptn/lifecycle-toolkit/lifecycle-operator/apis/lifecycle/v1alpha3/common"
 	controllercommon "github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,43 +20,34 @@ import (
 type AppCreationRequestHandler struct {
 	Client      client.Client
 	Log         logr.Logger
-	Tracer      trace.Tracer
 	EventSender controllercommon.IEvent
 }
 
 func (a *AppCreationRequestHandler) Handle(ctx context.Context, pod *corev1.Pod, namespace string) error {
-
-	ctx, span := a.Tracer.Start(ctx, "create_appCreationRequest", trace.WithSpanKind(trace.SpanKindProducer))
-	defer span.End()
-
 	newAppCreationRequest := generateResource(ctx, pod, namespace)
-	newAppCreationRequest.SetSpanAttributes(span)
 
 	a.Log.Info("Searching for AppCreationRequest", "appCreationRequest", newAppCreationRequest.Name, "namespace", newAppCreationRequest.Namespace)
 
 	appCreationRequest := &klcv1alpha3.KeptnAppCreationRequest{}
 	err := a.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: newAppCreationRequest.Name}, appCreationRequest)
 	if errors.IsNotFound(err) {
-		return a.createResource(ctx, newAppCreationRequest, span)
+		return a.createResource(ctx, newAppCreationRequest)
 	}
 
 	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-
 		return fmt.Errorf("could not fetch AppCreationRequest %w", err)
 	}
 	a.Log.Info("Found AppCreationRequest", "appCreationRequest", newAppCreationRequest.Name, "namespace", newAppCreationRequest.Namespace)
 	return nil
 }
 
-func (a *AppCreationRequestHandler) createResource(ctx context.Context, newAppCreationRequest *klcv1alpha3.KeptnAppCreationRequest, span trace.Span) error {
+func (a *AppCreationRequestHandler) createResource(ctx context.Context, newAppCreationRequest *klcv1alpha3.KeptnAppCreationRequest) error {
 	a.Log.Info("Creating app creation request", "appCreationRequest", newAppCreationRequest.Name, "namespace", newAppCreationRequest.Namespace)
 
 	err := a.Client.Create(ctx, newAppCreationRequest)
 	if err != nil {
 		a.Log.Error(err, "Could not create AppCreationRequest")
 		a.EventSender.Emit(apicommon.PhaseCreateAppCreationRequest, "Warning", newAppCreationRequest, apicommon.PhaseStateFailed, "could not create KeptnAppCreationRequest", newAppCreationRequest.Spec.AppName)
-		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/appcreationrequest_handler_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/appcreationrequest_handler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common"
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common/fake"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,9 +31,6 @@ func TestAppHandlerHandle(t *testing.T) {
 
 	mockEventSender := common.NewK8sSender(record.NewFakeRecorder(100))
 	log := testr.New(t)
-	tr := &fake.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -135,7 +131,6 @@ func TestAppHandlerHandle(t *testing.T) {
 				Client:      tt.client,
 				Log:         log,
 				EventSender: mockEventSender,
-				Tracer:      tr,
 			}
 			err := appHandler.Handle(context.TODO(), tt.pod, namespace)
 
@@ -161,13 +156,10 @@ func TestAppHandlerCreateAppSucceeds(t *testing.T) {
 	fakeClient := fake.NewClient()
 	logger := logr.Discard()
 	eventSender := common.NewK8sSender(record.NewFakeRecorder(100))
-	tracer := &fake.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
+
 	appHandler := &AppCreationRequestHandler{
 		Client:      fakeClient,
 		Log:         logger,
-		Tracer:      tracer,
 		EventSender: eventSender,
 	}
 
@@ -176,7 +168,7 @@ func TestAppHandlerCreateAppSucceeds(t *testing.T) {
 	newAppCreationRequest := &klcv1alpha3.KeptnAppCreationRequest{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}
-	err := appHandler.createResource(ctx, newAppCreationRequest, trace.SpanFromContext(ctx))
+	err := appHandler.createResource(ctx, newAppCreationRequest)
 
 	require.Nil(t, err)
 	creationReq := &klcv1alpha3.KeptnAppCreationRequest{}
@@ -189,13 +181,10 @@ func TestAppHandlerCreateAppFails(t *testing.T) {
 	fakeClient := fake.NewClient()
 	logger := logr.Discard()
 	eventSender := common.NewK8sSender(record.NewFakeRecorder(100))
-	tracer := &fake.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
+
 	appHandler := &AppCreationRequestHandler{
 		Client:      fakeClient,
 		Log:         logger,
-		Tracer:      tracer,
 		EventSender: eventSender,
 	}
 
@@ -203,7 +192,7 @@ func TestAppHandlerCreateAppFails(t *testing.T) {
 	newAppCreationRequest := &klcv1alpha3.KeptnAppCreationRequest{
 		ObjectMeta: metav1.ObjectMeta{},
 	}
-	err := appHandler.createResource(ctx, newAppCreationRequest, trace.SpanFromContext(ctx))
+	err := appHandler.createResource(ctx, newAppCreationRequest)
 	require.Error(t, err)
 
 }

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/workload_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/workload_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common/fake"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,9 +30,7 @@ func TestHandle(t *testing.T) {
 
 	mockEventSender := controllercommon.NewK8sSender(record.NewFakeRecorder(100))
 	log := testr.New(t)
-	tr := &fake.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
+
 	workload := &klcv1alpha3.KeptnWorkload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-workload-my-workload",
@@ -124,7 +121,6 @@ func TestHandle(t *testing.T) {
 				Client:      tt.client,
 				Log:         log,
 				EventSender: mockEventSender,
-				Tracer:      tr,
 			}
 			err := workloadHandler.Handle(context.TODO(), tt.pod, "test-namespace")
 
@@ -149,9 +145,6 @@ func TestHandle(t *testing.T) {
 func TestUpdateWorkloadNoSpecChanges(t *testing.T) {
 	mockEventSender := controllercommon.NewK8sSender(record.NewFakeRecorder(100))
 	log := testr.New(t)
-	tr := &fake.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
 
 	workload := &klcv1alpha3.KeptnWorkload{
 		ObjectMeta: metav1.ObjectMeta{
@@ -162,10 +155,9 @@ func TestUpdateWorkloadNoSpecChanges(t *testing.T) {
 	a := &WorkloadHandler{
 		Client:      nil,
 		Log:         log,
-		Tracer:      tr,
 		EventSender: mockEventSender,
 	}
-	err := a.updateWorkload(context.TODO(), workload, workload, nil)
+	err := a.updateWorkload(context.TODO(), workload, workload)
 	require.Nil(t, err)
 
 }

--- a/lifecycle-operator/webhooks/pod_mutator/pod_mutating_webhook_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/pod_mutating_webhook_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/webhooks/pod_mutator/handlers"
 	fakehandler "github.com/keptn/lifecycle-toolkit/lifecycle-operator/webhooks/pod_mutator/handlers/fake"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace"
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,15 +42,10 @@ func TestPodMutatingWebhookHandleDisabledNamespace(t *testing.T) {
 		},
 	})
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
-
 	decoder := admission.NewDecoder(runtime.NewScheme())
 
 	wh := &PodMutatingWebhook{
 		Client:      fakeClient,
-		Tracer:      tr,
 		Decoder:     decoder,
 		EventSender: controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
 		Log:         testr.New(t),
@@ -92,15 +86,10 @@ func TestPodMutatingWebhookHandleUnsupportedOwner(t *testing.T) {
 		},
 	})
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
-
 	decoder := admission.NewDecoder(runtime.NewScheme())
 
 	wh := &PodMutatingWebhook{
 		Client:      fakeClient,
-		Tracer:      tr,
 		Decoder:     decoder,
 		EventSender: controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
 		Log:         testr.New(t),
@@ -174,18 +163,10 @@ func TestPodMutatingWebhookHandleSingleService(t *testing.T) {
 		},
 	})
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
-
 	decoder := admission.NewDecoder(runtime.NewScheme())
 	log := testr.New(t)
 
-	wh := NewPodMutator(fakeClient,
-		tr,
-		decoder,
-		controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
-		log, false)
+	wh := NewPodMutator(fakeClient, decoder, controllercommon.NewK8sSender(record.NewFakeRecorder(100)), log, false)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -293,16 +274,11 @@ func TestPodMutatingWebhookHandleSchedulingGatesGateRemoved(t *testing.T) {
 	}
 	fakeClient := fakeclient.NewClient(ns, pod)
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
-
 	decoder := admission.NewDecoder(runtime.NewScheme())
 
 	wh := &PodMutatingWebhook{
 		SchedulingGatesEnabled: true,
 		Client:                 fakeClient,
-		Tracer:                 tr,
 		Decoder:                decoder,
 		EventSender:            controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
 		Log:                    testr.New(t),
@@ -358,21 +334,10 @@ func TestPodMutatingWebhookHandleSchedulingGates(t *testing.T) {
 	}
 	fakeClient := fakeclient.NewClient(ns, pod)
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
-
 	decoder := admission.NewDecoder(runtime.NewScheme())
 
 	wh :=
-		NewPodMutator(
-			fakeClient,
-			tr,
-			decoder,
-			controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
-			testr.New(t),
-			true,
-		)
+		NewPodMutator(fakeClient, decoder, controllercommon.NewK8sSender(record.NewFakeRecorder(100)), testr.New(t), true)
 
 	request := generateRequest(pod, t)
 
@@ -448,19 +413,9 @@ func TestPodMutatingWebhookHandleSingleServiceAppCreationRequestAlreadyPresent(t
 		},
 	})
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
-
 	decoder := admission.NewDecoder(runtime.NewScheme())
 
-	wh := NewPodMutator(fakeClient,
-		tr,
-		decoder,
-		controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
-		testr.New(t),
-		false,
-	)
+	wh := NewPodMutator(fakeClient, decoder, controllercommon.NewK8sSender(record.NewFakeRecorder(100)), testr.New(t), false)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -542,16 +497,9 @@ func TestPodMutatingWebhookHandleMultiService(t *testing.T) {
 		},
 	})
 
-	pod, _, _, tr, decoder := setupTestData()
+	pod, _, _, decoder := setupTestData()
 
-	wh := NewPodMutator(
-		fakeClient,
-		tr,
-		decoder,
-		controllercommon.NewK8sSender(record.NewFakeRecorder(100)),
-		testr.New(t),
-		false,
-	)
+	wh := NewPodMutator(fakeClient, decoder, controllercommon.NewK8sSender(record.NewFakeRecorder(100)), testr.New(t), false)
 
 	request := generateRequest(pod, t)
 
@@ -597,7 +545,7 @@ func TestPodMutatingWebhookHandleMultiService(t *testing.T) {
 
 func TestPodMutatingWebhookHandleErrorPaths(t *testing.T) {
 
-	pod, dp, ns, tr, decoder := setupTestData()
+	pod, dp, ns, decoder := setupTestData()
 
 	tests := []struct {
 		name            string
@@ -666,7 +614,6 @@ func TestPodMutatingWebhookHandleErrorPaths(t *testing.T) {
 
 			wh := PodMutatingWebhook{
 				Decoder:  tt.decoder,
-				Tracer:   tr,
 				Log:      testr.New(t),
 				Client:   tt.client,
 				Workload: tt.workloadHandler,
@@ -705,7 +652,7 @@ func generateRequest(pod *corev1.Pod, t *testing.T) admissionv1.AdmissionRequest
 	}
 }
 
-func setupTestData() (*corev1.Pod, *v1.Deployment, *corev1.Namespace, *fakeclient.ITracerMock, *admission.Decoder) {
+func setupTestData() (*corev1.Pod, *v1.Deployment, *corev1.Namespace, *admission.Decoder) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testPod,
@@ -744,9 +691,6 @@ func setupTestData() (*corev1.Pod, *v1.Deployment, *corev1.Namespace, *fakeclien
 		},
 	}
 
-	tr := &fakeclient.ITracerMock{StartFunc: func(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-		return ctx, trace.SpanFromContext(ctx)
-	}}
 	decoder := admission.NewDecoder(runtime.NewScheme())
-	return pod, dp, ns, tr, decoder
+	return pod, dp, ns, decoder
 }


### PR DESCRIPTION
Part of #2290

This PR removes the spans created by the webhook, as they did not prove to be useful