### PR TITLE
chore: remove manifests usage from security-scans

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -171,19 +171,21 @@ jobs:
           name: ${{ matrix.config.name }}-image.tar
           path: /tmp/${{ matrix.config.name }}-image.tar
 
+  image_tag:
+    name: Store tag of the built images
+    needs: prepare_ci_run
+    runs-on: ubuntu-22.04
+    env:
+      DATETIME: ${{ needs.prepare_ci_run.outputs.DATETIME }}
+    steps:
       - name: Create empty file to store image tag
-        if: matrix.config.name == 'lifecycle-operator'
-        working-directory: ./${{ matrix.config.folder }}
-        env:
-          CHART_APPVERSION: dev-${{ env.DATETIME }}
         run: echo "" > tag
 
-      - name: Upload release.yaml for tests
-        if: matrix.config.name == 'lifecycle-operator'
+      - name: Upload tag for tests
         uses: actions/upload-artifact@v3
         with:
           name: dev-${{ env.DATETIME }}
-          path: ${{ matrix.config.folder }}/tag
+          path: tag
 
   component_tests:
     name: Component Tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -171,24 +171,19 @@ jobs:
           name: ${{ matrix.config.name }}-image.tar
           path: /tmp/${{ matrix.config.name }}-image.tar
 
-      - name: Install controller-gen
-        if: matrix.config.name == 'lifecycle-operator' || matrix.config.name == 'metrics-operator'
-        working-directory: ./${{ matrix.config.folder }}
-        run: make controller-gen
-
-      - name: Generate test release manifest
-        if: matrix.config.name != 'deno-runtime' && matrix.config.name != 'python-runtime'
+      - name: Create empty file to store image tag
+        if: matrix.config.name == 'lifecycle-operator'
         working-directory: ./${{ matrix.config.folder }}
         env:
           CHART_APPVERSION: dev-${{ env.DATETIME }}
-        run: make release-manifests
+        run: echo "" > tag
 
       - name: Upload release.yaml for tests
-        if: matrix.config.name != 'deno-runtime' && matrix.config.name != 'python-runtime'
+        if: matrix.config.name == 'lifecycle-operator'
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.config.name }}-manifest-test
-          path: ${{ matrix.config.folder }}/config/rendered/release.yaml
+          name: dev-${{ env.DATETIME }}
+          path: ${{ matrix.config.folder }}/tag
 
   component_tests:
     name: Component Tests

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -49,7 +49,7 @@ jobs:
           echo "Run ID that will be used to download artifacts from: $RUN_ID"
           echo "RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
 
-      - name: Download all artifacts from last successful build of main branch
+      - name: Download all artifacts from last successful build of target branch
         uses: dawidd6/action-download-artifact@v2.28.0
         id: download_artifacts_push
         with:
@@ -60,21 +60,13 @@ jobs:
           # directory where to extract artifacts to
           path: ./dist
 
-      - name: Upload manifests main build
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name  == 'schedule' }}
-        with:
-          name: manifests
-          path: |
-            ./dist/*-manifest-test/
-
-      - name: Upload manifests user run
+      - name: Upload tag
         if: ${{ github.event_name  != 'schedule' }}
         uses: actions/upload-artifact@v3
         with:
-          name: manifests
+          name: tag
           path: |
-            ./dist/*-manifest-test/
+            ./dist/dev-*/
 
       - name: Upload images
         uses: actions/upload-artifact@v3
@@ -116,12 +108,52 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
-      - name: Download manifest files
+      - name: Download tag
         id: download_manifests
         uses: actions/download-artifact@v3
         with:
-          name: manifests
-          path: scans
+          name: tag
+          path: tag
+
+      - name: Setup helm charts
+        run: |
+          helm repo add keptn "https://charts.lifecycle.keptn.sh"
+          helm repo update
+
+          for chart_dir in ./lifecycle-operator/chart \
+                  ./metrics-operator/chart \
+                  ./klt-cert-manager/chart \
+                  ./chart; do
+              cd "$chart_dir"
+              echo "updating charts for" $chart_dir
+              helm dependency update
+              helm dependency build
+              cd -  # Return to the previous directory
+          done
+
+      - name: Generate manifests
+        run: |
+          # Fetch tag of the images
+          TAG=$(ls tag/)
+          echo "$TAG"
+          mkdir scans
+
+          helm template keptn-test --namespace helmtests -f ./chart/values.yaml ./chart \
+            --set lifecycleOperator.lifecycleOperator.image.tag=$TAG \
+            --set lifecycleOperator.lifecycleOperator.image.repository="localhost:5000/keptn/lifecycle-operator" \
+            --set lifecycleOperator.scheduler.imagePullPolicy=Never \
+            --set lifecycleOperator.scheduler.image.tag=$TAG \
+            --set lifecycleOperator.scheduler.image.repository="localhost:5000/keptn/scheduler" \
+            --set lifecycleOperator.lifecycleOperator.imagePullPolicy=Never \
+            --set lifecycleOperator.lifecycleOperator.env.functionRunnerImage=localhost:5000/keptn/deno-runtime:$TAG \
+            --set lifecycleOperator.lifecycleOperator.env.pythonRunnerImage=localhost:5000/keptn/python-runtime:$TAG \
+            --set certManager.imagePullPolicy=Never \
+            --set certManager.image.tag=$TAG \
+            --set certManager.image.repository="localhost:5000/keptn/certificate-operator" \
+            --set metricsOperator.imagePullPolicy=Never \
+            --set metricsOperator.env.enableKeptnAnalysis="true" \
+            --set metricsOperator.image.tag=$TAG \
+            --set metricsOperator.image.repository="localhost:5000/keptn/metrics-operator" > ./scans/result.yaml
 
       - name: KICS Scan
         if: matrix.tool == 'kics'

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -138,22 +138,13 @@ jobs:
           echo "$TAG"
           mkdir scans
 
-          helm template keptn-test --namespace helmtests -f ./chart/values.yaml ./chart \
+          helm template keptn-test --namespace helmtests -f .github/actions/deploy-klt-on-cluster/values.yaml ./chart \
             --set lifecycleOperator.lifecycleOperator.image.tag=$TAG \
-            --set lifecycleOperator.lifecycleOperator.image.repository="localhost:5000/keptn/lifecycle-operator" \
-            --set lifecycleOperator.scheduler.imagePullPolicy=Never \
             --set lifecycleOperator.scheduler.image.tag=$TAG \
-            --set lifecycleOperator.scheduler.image.repository="localhost:5000/keptn/scheduler" \
-            --set lifecycleOperator.lifecycleOperator.imagePullPolicy=Never \
             --set lifecycleOperator.lifecycleOperator.env.functionRunnerImage=localhost:5000/keptn/deno-runtime:$TAG \
             --set lifecycleOperator.lifecycleOperator.env.pythonRunnerImage=localhost:5000/keptn/python-runtime:$TAG \
-            --set certManager.imagePullPolicy=Never \
             --set certManager.image.tag=$TAG \
-            --set certManager.image.repository="localhost:5000/keptn/certificate-operator" \
-            --set metricsOperator.imagePullPolicy=Never \
-            --set metricsOperator.env.enableKeptnAnalysis="true" \
-            --set metricsOperator.image.tag=$TAG \
-            --set metricsOperator.image.repository="localhost:5000/keptn/metrics-operator" > ./scans/result.yaml
+            --set metricsOperator.image.tag=$TAG > ./scans/result.yaml
 
       - name: KICS Scan
         if: matrix.tool == 'kics'


### PR DESCRIPTION
Fixes: #1602 

## Changes
- remove storage/upload of manifests during CI
- remove manifests usage from security pipeline

Security scan run https://github.com/keptn/lifecycle-toolkit/actions/runs/6731161682