### PR TITLE
enable google custom search engine for production

### DIFF
--- a/docs/config/production/params.yaml
+++ b/docs/config/production/params.yaml
@@ -2,3 +2,7 @@ versions:
   - url: https://main.lifecycle.keptn.sh/docs
     version: development
 github_branch: page
+
+algolia_docsearch: false
+offlineSearch: false
+gcs_engine_id: '37a611225469c41ae' # needs to be replaced with a search engine ID from the keptn google account


### PR DESCRIPTION
### This PR
- exchanges the local site search for a google custom search
- the search only uses pages from the latest release, not the previous versions
- the custom search is currently owned by @mowies for testing. This needs to be updated in the future to a keptnproject owned engine

Part of #2319