### PR TITLE
fix: helm charts image registry, image pull policy and install action

### DIFF
--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -81,12 +81,12 @@ runs:
             helm dependency build
             cd -  # Return to the previous directory
         done
-
-        cd ./chart
-
+        
+        cd .github/actions/deploy-klt-on-cluster
+        
         if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_on" ]; then
           echo "lifecycleOperator:" >> values.yaml
-          echo "  allowedNamespaces: [allowed-ns-test]" >> tmp-values.yaml
+          echo "  allowedNamespaces: [allowed-ns-test]" >> values.yaml
         fi
 
         if [ "${{ inputs.scheduling-gates }}" == "gates_on" ]; then
@@ -97,7 +97,9 @@ runs:
         fi
         echo "installing with values.yaml file:"
         cat values.yaml
-        
+
+        cd ../../../chart
+
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
           --values values.yaml \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -84,34 +84,24 @@ runs:
 
         cd ./chart
 
-        touch tmp-values.yaml
         if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_on" ]; then
-          echo "lifecycleOperator:" >> tmp-values.yaml
+          echo "lifecycleOperator:" >> values.yaml
           echo "  allowedNamespaces: [allowed-ns-test]" >> tmp-values.yaml
         fi
 
         if [ "${{ inputs.scheduling-gates }}" == "gates_on" ]; then
           if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_off" ]; then
-            echo "lifecycleOperator:" >> tmp-values.yaml
+            echo "lifecycleOperator:" >> values.yaml
           fi
-          echo "  schedulingGatesEnabled: true" >> tmp-values.yaml
+          echo "  schedulingGatesEnabled: true" >> values.yaml
         fi
 
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
-          --values tmp-values.yaml \
-          --set lifecycleOperator.scheduler.imagePullPolicy=Never \
+          --values values.yaml \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \
-          --set lifecycleOperator.scheduler.image.repository="localhost:5000/keptn/scheduler" \
-          --set lifecycleOperator.lifecycleOperator.imagePullPolicy=Never \
           --set lifecycleOperator.lifecycleOperator.image.tag=${{ inputs.runtime_tag }} \
-          --set lifecycleOperator.lifecycleOperator.image.repository="localhost:5000/keptn/lifecycle-operator" \
           --set lifecycleOperator.lifecycleOperator.env.functionRunnerImage=localhost:5000/keptn/deno-runtime:${{ inputs.runtime_tag }} \
           --set lifecycleOperator.lifecycleOperator.env.pythonRunnerImage=localhost:5000/keptn/python-runtime:${{ inputs.runtime_tag }} \
-          --set certManager.imagePullPolicy=Never \
           --set certManager.image.tag=${{ inputs.runtime_tag }} \
-          --set certManager.image.repository="localhost:5000/keptn/certificate-operator" \
-          --set metricsOperator.imagePullPolicy=Never \
-          --set metricsOperator.env.enableKeptnAnalysis="true" \
           --set metricsOperator.image.tag=${{ inputs.runtime_tag }} \
-          --set metricsOperator.image.repository="localhost:5000/keptn/metrics-operator" \
           --debug --wait --timeout 1m

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -81,9 +81,9 @@ runs:
             helm dependency build
             cd -  # Return to the previous directory
         done
-        
+
         cd .github/actions/deploy-klt-on-cluster
-        
+
         if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_on" ]; then
           echo "lifecycleOperator:" >> values.yaml
           echo "  allowedNamespaces: [allowed-ns-test]" >> values.yaml
@@ -101,7 +101,7 @@ runs:
         cd ../../../chart
 
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
-          --values values.yaml \
+          --values ../.github/actions/deploy-klt-on-cluster/values.yaml \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.lifecycleOperator.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.lifecycleOperator.env.functionRunnerImage=localhost:5000/keptn/deno-runtime:${{ inputs.runtime_tag }} \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -95,7 +95,9 @@ runs:
           fi
           echo "  schedulingGatesEnabled: true" >> values.yaml
         fi
-
+        echo "installing with values.yaml file:"
+        cat values.yaml
+        
         helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
           --values values.yaml \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -94,10 +94,8 @@ runs:
         echo "installing with values.yaml file:"
         cat values.yaml
 
-        cd ../../../chart
-
-        helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ./ \
-          --values ../.github/actions/deploy-klt-on-cluster/values.yaml \
+        helm install -n keptn-lifecycle-toolkit-system --create-namespace keptn ../../../chart \
+          --values ./values.yaml \
           --set lifecycleOperator.scheduler.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.lifecycleOperator.image.tag=${{ inputs.runtime_tag }} \
           --set lifecycleOperator.lifecycleOperator.env.functionRunnerImage=localhost:5000/keptn/deno-runtime:${{ inputs.runtime_tag }} \

--- a/.github/actions/deploy-klt-on-cluster/action.yml
+++ b/.github/actions/deploy-klt-on-cluster/action.yml
@@ -85,14 +85,10 @@ runs:
         cd .github/actions/deploy-klt-on-cluster
 
         if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_on" ]; then
-          echo "lifecycleOperator:" >> values.yaml
           echo "  allowedNamespaces: [allowed-ns-test]" >> values.yaml
         fi
 
         if [ "${{ inputs.scheduling-gates }}" == "gates_on" ]; then
-          if [ "${{ inputs.allowed-namespaces }}" == "allowed_ns_off" ]; then
-            echo "lifecycleOperator:" >> values.yaml
-          fi
           echo "  schedulingGatesEnabled: true" >> values.yaml
         fi
         echo "installing with values.yaml file:"

--- a/.github/actions/deploy-klt-on-cluster/values.yaml
+++ b/.github/actions/deploy-klt-on-cluster/values.yaml
@@ -1,0 +1,16 @@
+global:
+  imageRegistry: "localhost:5000"
+
+certManager:
+  imagePullPolicy: Never
+
+metricsOperator:
+  imagePullPolicy: Never
+  env:
+    enableKeptnAnalysis: "true"
+
+lifecycleOperator:
+    lifecycleOperator:
+      imagePullPolicy: Never
+    scheduler:
+      imagePullPolicy: Never

--- a/.github/actions/deploy-klt-on-cluster/values.yaml
+++ b/.github/actions/deploy-klt-on-cluster/values.yaml
@@ -10,7 +10,8 @@ metricsOperator:
     enableKeptnAnalysis: "true"
 
 lifecycleOperator:
-    lifecycleOperator:
-      imagePullPolicy: Never
-    scheduler:
-      imagePullPolicy: Never
+  lifecycleOperator:
+    imagePullPolicy: Never
+  scheduler:
+    imagePullPolicy: Never
+    

--- a/.github/actions/deploy-klt-on-cluster/values.yaml
+++ b/.github/actions/deploy-klt-on-cluster/values.yaml
@@ -14,4 +14,3 @@ lifecycleOperator:
     imagePullPolicy: Never
   scheduler:
     imagePullPolicy: Never
-    

--- a/.github/scripts/.helm-tests/certificates-only/result.yaml
+++ b/.github/scripts/.helm-tests/certificates-only/result.yaml
@@ -234,7 +234,7 @@ spec:
               value: "true"
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
-          image: testreg/keptn/certificate-operator:v1.1.0
+          image: testreg/keptn/certificate-operator:v1.2.0
           imagePullPolicy: Always
           name: certificate-operator
           resources:

--- a/.github/scripts/.helm-tests/certificates-only/result.yaml
+++ b/.github/scripts/.helm-tests/certificates-only/result.yaml
@@ -234,7 +234,7 @@ spec:
               value: "true"
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
-          image: testreg/ghcr.io/keptn/certificate-operator:v1.2.0
+          image: testreg/keptn/certificate-operator:v1.1.0
           imagePullPolicy: Always
           name: certificate-operator
           resources:

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -8472,7 +8472,7 @@ spec:
           value: "0"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: ghcr.io/keptn/metrics-operator:v0.8.2
+        image: keptn/metrics-operator:v0.8.2
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -8473,7 +8473,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: ghcr.io/keptn/metrics-operator:v0.8.2
-        imagePullPolicy: 
+        imagePullPolicy: Always
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -8472,7 +8472,8 @@ spec:
           value: "0"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: keptn/metrics-operator:v0.8.2
+        image: ghcr.io/keptn/metrics-operator:v0.8.2
+        imagePullPolicy: 
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -6617,7 +6617,7 @@ spec:
           value: "otel-collector:4317"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: testreg/ghcr.io/keptn/scheduler:v0.8.2
+        image: testreg/keptn/scheduler:v0.8.2
         imagePullPolicy: Always
         name: scheduler
         resources:

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -6782,7 +6782,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: ghcr.io/keptn/lifecycle-operator:v0.8.2
-        imagePullPolicy: Always
+        imagePullPolicy: Never
         name: lifecycle-operator
         ports:
         - containerPort: 9443
@@ -6874,7 +6874,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: ghcr.io/keptn/scheduler:v0.8.2
-        imagePullPolicy: Always
+        imagePullPolicy: Never
         name: scheduler
         resources:
           limits:

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/values.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/values.yaml
@@ -2,5 +2,9 @@ certManager:
   enabled: true
 lifecycleOperator:
   enabled: true
+  lifecycleOperator:
+    imagePullPolicy: Never
+  scheduler:
+    imagePullPolicy: Never
 metricsOperator:
   enabled: false

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -1555,7 +1555,7 @@ spec:
           value: "0"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: ghcr.io/keptn/metrics-operator:v0.8.2
+        image: keptn/metrics-operator:v0.8.2
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -1556,7 +1556,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: ghcr.io/keptn/metrics-operator:v0.8.2
-        imagePullPolicy: 
+        imagePullPolicy: Always
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -1555,7 +1555,8 @@ spec:
           value: "0"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: keptn/metrics-operator:v0.8.2
+        image: ghcr.io/keptn/metrics-operator:v0.8.2
+        imagePullPolicy: 
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -1811,7 +1811,7 @@ spec:
           value: "0"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: ghcr.io/keptn/metrics-operator:v0.8.2
+        image: keptn/metrics-operator:v0.8.2
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -1713,7 +1713,7 @@ spec:
               value: "true"
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
-          image: ghcr.io/keptn/certificate-operator:v1.2.0
+          image: testreg/keptn/certificate-operator:v1.2.0
           imagePullPolicy: Always
           name: certificate-operator
           resources:
@@ -1811,7 +1811,8 @@ spec:
           value: "0"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: keptn/metrics-operator:v0.8.2
+        image: testreg/keptn/metrics-operator:v0.8.2
+        imagePullPolicy: Never
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/.github/scripts/.helm-tests/metrics-with-certs/values.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/values.yaml
@@ -4,3 +4,7 @@ lifecycleOperator:
   enabled: false
 metricsOperator:
   enabled: true
+  imagePullPolicy: Never
+
+global:
+  imageRegistry: "testreg"

--- a/klt-cert-manager/chart/README.md
+++ b/klt-cert-manager/chart/README.md
@@ -29,14 +29,15 @@ resource.
 
 ### Keptn Certificate Operator controller
 
-| Name                       | Description                                                               | Value                                |
-| -------------------------- | ------------------------------------------------------------------------- | ------------------------------------ |
-| `containerSecurityContext` | Sets security context for the cert manager                                |                                      |
-| `env.labelSelectorKey`     | specify the label selector to find resources to generate certificates for | `keptn.sh/inject-cert`               |
-| `env.labelSelectorValue`   | specify the value for the label selector                                  | `true`                               |
-| `image.repository`         | specify repo for manager image                                            | `ghcr.io/keptn/certificate-operator` |
-| `image.tag`                | select tag for manager container                                          | `v1.2.0`                             |
-| `imagePullPolicy`          | select image pull policy for manager container                            | `Always`                             |
-| `livenessProbe`            | custom RBAC proxy liveness probe                                          |                                      |
-| `readinessProbe`           | custom manager readiness probe                                            |                                      |
-| `resources`                | custom limits and requests for manager container                          |                                      |
+| Name                       | Description                                                               | Value                        |
+| -------------------------- | ------------------------------------------------------------------------- | ---------------------------- |
+| `containerSecurityContext` | Sets security context for the cert manager                                |                              |
+| `env.labelSelectorKey`     | specify the label selector to find resources to generate certificates for | `keptn.sh/inject-cert`       |
+| `env.labelSelectorValue`   | specify the value for the label selector                                  | `true`                       |
+| `image.registry`           | specify repo for manager image                                            | `ghcr.io`                    |
+| `image.repository`         | specify repo for manager image                                            | `keptn/certificate-operator` |
+| `image.tag`                | select tag for manager container                                          | `v1.2.0`                     |
+| `imagePullPolicy`          | select image pull policy for manager container                            | `Always`                     |
+| `livenessProbe`            | custom RBAC proxy liveness probe                                          |                              |
+| `readinessProbe`           | custom manager readiness probe                                            |                              |
+| `resources`                | custom limits and requests for manager container                          |                              |

--- a/klt-cert-manager/chart/README.md
+++ b/klt-cert-manager/chart/README.md
@@ -34,7 +34,7 @@ resource.
 | `containerSecurityContext` | Sets security context for the cert manager                                |                              |
 | `env.labelSelectorKey`     | specify the label selector to find resources to generate certificates for | `keptn.sh/inject-cert`       |
 | `env.labelSelectorValue`   | specify the value for the label selector                                  | `true`                       |
-| `image.registry`           | specify repo for manager image                                            | `ghcr.io`                    |
+| `image.registry`           | specify the container registry for the certificate-operator image         | `ghcr.io`                    |
 | `image.repository`         | specify repo for manager image                                            | `keptn/certificate-operator` |
 | `image.tag`                | select tag for manager container                                          | `v1.2.0`                     |
 | `imagePullPolicy`          | select image pull policy for manager container                            | `Always`                     |

--- a/klt-cert-manager/chart/values.yaml
+++ b/klt-cert-manager/chart/values.yaml
@@ -61,7 +61,7 @@ env:
 ## @param     env.labelSelectorValue specify the value for the label selector
   labelSelectorValue: "true"
 image:
-## @param     image.registry specify repo for manager image
+## @param     image.registry specify the container registry for the certificate-operator image
   registry: ghcr.io
 ## @param     image.repository specify repo for manager image
   repository: keptn/certificate-operator

--- a/klt-cert-manager/chart/values.yaml
+++ b/klt-cert-manager/chart/values.yaml
@@ -61,8 +61,10 @@ env:
 ## @param     env.labelSelectorValue specify the value for the label selector
   labelSelectorValue: "true"
 image:
+## @param     image.registry specify repo for manager image
+  registry: ghcr.io
 ## @param     image.repository specify repo for manager image
-  repository: ghcr.io/keptn/certificate-operator
+  repository: keptn/certificate-operator
 ## @param     image.tag select tag for manager container
   tag: v1.2.0 # x-release-please-version
 ## @param     imagePullPolicy select image pull policy for manager container

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -53,7 +53,7 @@ and application health checks
 | `lifecycleOperator.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                                                                         | `0`                                   |
 | `lifecycleOperator.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                                                                          | `otel-collector:4317`                 |
 | `lifecycleOperator.env.pythonRunnerImage`                             | specify image for python task runtime                                                                                  | `ghcr.io/keptn/python-runtime:v1.0.0` |
-| `lifecycleOperator.image.registry`                                    | specify repo for manager image                                                                                         | `ghcr.io`                             |
+| `lifecycleOperator.image.registry`                                    | specify the container registry for the lifecycle-operator image                                                        | `ghcr.io`                             |
 | `lifecycleOperator.image.repository`                                  | specify registry for manager image                                                                                     | `keptn/lifecycle-operator`            |
 | `lifecycleOperator.image.tag`                                         | select tag for manager image                                                                                           | `v0.8.2`                              |
 | `lifecycleOperator.imagePullPolicy`                                   | specify pull policy for manager image                                                                                  | `Always`                              |
@@ -84,7 +84,7 @@ and application health checks
 | `scheduler.replicas`                                         | modifies replicas                                              | `1`                   |
 | `scheduler.containerSecurityContext`                         | Sets security context                                          |                       |
 | `scheduler.env.otelCollectorUrl`                             | sets url for open telemetry collector                          | `otel-collector:4317` |
-| `scheduler.image.registry`                                   | specify repo for manager image                                 | `ghcr.io`             |
+| `scheduler.image.registry`                                   | specify the container registry for the scheduler image         | `ghcr.io`             |
 | `scheduler.image.repository`                                 | set image repository for scheduler                             | `keptn/scheduler`     |
 | `scheduler.image.tag`                                        | set image tag for scheduler                                    | `v0.8.2`              |
 | `scheduler.imagePullPolicy`                                  | set image pull policy for scheduler                            | `Always`              |

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -53,7 +53,8 @@ and application health checks
 | `lifecycleOperator.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                                                                         | `0`                                   |
 | `lifecycleOperator.env.otelCollectorUrl`                              | Sets the URL for the open telemetry collector                                                                          | `otel-collector:4317`                 |
 | `lifecycleOperator.env.pythonRunnerImage`                             | specify image for python task runtime                                                                                  | `ghcr.io/keptn/python-runtime:v1.0.0` |
-| `lifecycleOperator.image.repository`                                  | specify registry for manager image                                                                                     | `ghcr.io/keptn/lifecycle-operator`    |
+| `lifecycleOperator.image.registry`                                    | specify repo for manager image                                                                                         | `ghcr.io`                             |
+| `lifecycleOperator.image.repository`                                  | specify registry for manager image                                                                                     | `keptn/lifecycle-operator`            |
 | `lifecycleOperator.image.tag`                                         | select tag for manager image                                                                                           | `v0.8.2`                              |
 | `lifecycleOperator.imagePullPolicy`                                   | specify pull policy for manager image                                                                                  | `Always`                              |
 | `lifecycleOperator.livenessProbe`                                     | custom livenessprobe for manager container                                                                             |                                       |
@@ -77,20 +78,21 @@ and application health checks
 
 ### Keptn Scheduler
 
-| Name                                                         | Description                                                    | Value                     |
-| ------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------- |
-| `scheduler.nodeSelector`                                     | adds node selectors for scheduler                              | `{}`                      |
-| `scheduler.replicas`                                         | modifies replicas                                              | `1`                       |
-| `scheduler.containerSecurityContext`                         | Sets security context                                          |                           |
-| `scheduler.env.otelCollectorUrl`                             | sets url for open telemetry collector                          | `otel-collector:4317`     |
-| `scheduler.image.repository`                                 | set image repository for scheduler                             | `ghcr.io/keptn/scheduler` |
-| `scheduler.image.tag`                                        | set image tag for scheduler                                    | `v0.8.2`                  |
-| `scheduler.imagePullPolicy`                                  | set image pull policy for scheduler                            | `Always`                  |
-| `scheduler.livenessProbe`                                    | customizable liveness probe for the scheduler                  |                           |
-| `scheduler.readinessProbe`                                   | customizable readiness probe for the scheduler                 |                           |
-| `scheduler.resources`                                        | sets cpu and memory resurces/limits for scheduler              |                           |
-| `scheduler.topologySpreadConstraints`                        | add topology constraints for scheduler                         | `[]`                      |
-| `schedulerConfig.profiles[0].schedulerName`                  | changes scheduler name                                         | `keptn-scheduler`         |
-| `schedulerConfig.leaderElection.leaderElect`                 | enables leader election for multiple replicas of the scheduler | `false`                   |
-| `schedulerConfig.profiles[0].plugins.permit.enabled[0].name` | enables permit plugin                                          | `KLCPermit`               |
-| `scheduler.tolerations`                                      | adds tolerations for scheduler                                 | `[]`                      |
+| Name                                                         | Description                                                    | Value                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------- | --------------------- |
+| `scheduler.nodeSelector`                                     | adds node selectors for scheduler                              | `{}`                  |
+| `scheduler.replicas`                                         | modifies replicas                                              | `1`                   |
+| `scheduler.containerSecurityContext`                         | Sets security context                                          |                       |
+| `scheduler.env.otelCollectorUrl`                             | sets url for open telemetry collector                          | `otel-collector:4317` |
+| `scheduler.image.registry`                                   | specify repo for manager image                                 | `ghcr.io`             |
+| `scheduler.image.repository`                                 | set image repository for scheduler                             | `keptn/scheduler`     |
+| `scheduler.image.tag`                                        | set image tag for scheduler                                    | `v0.8.2`              |
+| `scheduler.imagePullPolicy`                                  | set image pull policy for scheduler                            | `Always`              |
+| `scheduler.livenessProbe`                                    | customizable liveness probe for the scheduler                  |                       |
+| `scheduler.readinessProbe`                                   | customizable readiness probe for the scheduler                 |                       |
+| `scheduler.resources`                                        | sets cpu and memory resurces/limits for scheduler              |                       |
+| `scheduler.topologySpreadConstraints`                        | add topology constraints for scheduler                         | `[]`                  |
+| `schedulerConfig.profiles[0].schedulerName`                  | changes scheduler name                                         | `keptn-scheduler`     |
+| `schedulerConfig.leaderElection.leaderElect`                 | enables leader election for multiple replicas of the scheduler | `false`               |
+| `schedulerConfig.profiles[0].plugins.permit.enabled[0].name` | enables permit plugin                                          | `KLCPermit`           |
+| `scheduler.tolerations`                                      | adds tolerations for scheduler                                 | `[]`                  |

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -98,7 +98,7 @@ lifecycleOperator:
 ## @param   lifecycleOperator.env.pythonRunnerImage specify image for python task runtime
     pythonRunnerImage: ghcr.io/keptn/python-runtime:v1.0.0
   image:
-## @param    lifecycleOperator.image.registry specify repo for manager image
+## @param    lifecycleOperator.image.registry specify the container registry for the lifecycle-operator image
     registry: ghcr.io
 ## @param   lifecycleOperator.image.repository specify registry for manager image
     repository: keptn/lifecycle-operator
@@ -205,7 +205,7 @@ scheduler:
 ## @param scheduler.env.otelCollectorUrl sets url for open telemetry collector
     otelCollectorUrl: otel-collector:4317
   image:
-## @param     scheduler.image.registry specify repo for manager image
+## @param     scheduler.image.registry specify the container registry for the scheduler image
     registry: ghcr.io
 ## @param scheduler.image.repository set image repository for scheduler
     repository: keptn/scheduler

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -98,8 +98,10 @@ lifecycleOperator:
 ## @param   lifecycleOperator.env.pythonRunnerImage specify image for python task runtime
     pythonRunnerImage: ghcr.io/keptn/python-runtime:v1.0.0
   image:
+## @param     image.registry specify repo for manager image
+    registry: ghcr.io
 ## @param   lifecycleOperator.image.repository specify registry for manager image
-    repository: ghcr.io/keptn/lifecycle-operator
+    repository: keptn/lifecycle-operator
 ## @param   lifecycleOperator.image.tag  select tag for manager image
     tag: v0.8.2 # x-release-please-version
 ## @param   lifecycleOperator.imagePullPolicy specify pull policy for manager image
@@ -203,8 +205,10 @@ scheduler:
 ## @param scheduler.env.otelCollectorUrl sets url for open telemetry collector
     otelCollectorUrl: otel-collector:4317
   image:
+## @param     image.registry specify repo for manager image
+    registry: ghcr.io
 ## @param scheduler.image.repository set image repository for scheduler
-    repository: ghcr.io/keptn/scheduler
+    repository: keptn/scheduler
 ## @param scheduler.image.tag set image tag for scheduler
     tag: v0.8.2 # x-release-please-version
 ## @param scheduler.imagePullPolicy set image pull policy for scheduler

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -98,7 +98,7 @@ lifecycleOperator:
 ## @param   lifecycleOperator.env.pythonRunnerImage specify image for python task runtime
     pythonRunnerImage: ghcr.io/keptn/python-runtime:v1.0.0
   image:
-## @param     image.registry specify repo for manager image
+## @param    lifecycleOperator.image.registry specify repo for manager image
     registry: ghcr.io
 ## @param   lifecycleOperator.image.repository specify registry for manager image
     repository: keptn/lifecycle-operator
@@ -205,7 +205,7 @@ scheduler:
 ## @param scheduler.env.otelCollectorUrl sets url for open telemetry collector
     otelCollectorUrl: otel-collector:4317
   image:
-## @param     image.registry specify repo for manager image
+## @param     scheduler.image.registry specify repo for manager image
     registry: ghcr.io
 ## @param scheduler.image.repository set image repository for scheduler
     repository: keptn/scheduler

--- a/metrics-operator/chart/README.md
+++ b/metrics-operator/chart/README.md
@@ -76,6 +76,7 @@ Prometheus, Dynatrace, DataDog and K8s metric server...
 | `image.registry`                                    | specify the container registry for the metrics-operator image | `ghcr.io`                |
 | `image.repository`                                  | specify registry for manager image                            | `keptn/metrics-operator` |
 | `image.tag`                                         | select tag for manager image                                  | `v0.8.2`                 |
+| `imagePullPolicy`                                   | specify pull policy for manager image                         | `Always`                 |
 | `livenessProbe`                                     | custom livenessprobe for manager container                    |                          |
 | `readinessProbe`                                    | custom readinessprobe for manager container                   |                          |
 | `resources`                                         | specify limits and requests for manager container             |                          |

--- a/metrics-operator/chart/README.md
+++ b/metrics-operator/chart/README.md
@@ -59,22 +59,23 @@ Prometheus, Dynatrace, DataDog and K8s metric server...
 
 ### Keptn Metrics Operator controller
 
-| Name                                                | Description                                       | Value                            |
-| --------------------------------------------------- | ------------------------------------------------- | -------------------------------- |
-| `containerSecurityContext`                          | Sets security context privileges                  |                                  |
-| `containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                          |
-| `containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                        |
-| `containerSecurityContext.privileged`               |                                                   | `false`                          |
-| `containerSecurityContext.runAsGroup`               |                                                   | `65532`                          |
-| `containerSecurityContext.runAsNonRoot`             |                                                   | `true`                           |
-| `containerSecurityContext.runAsUser`                |                                                   | `65532`                          |
-| `containerSecurityContext.seccompProfile.type`      |                                                   | `RuntimeDefault`                 |
-| `env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                           |
-| `env.enableKeptnAnalysis`                           | enables/disables the analysis feature             | `false`                          |
-| `env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                              |
-| `env.analysisControllerLogLevel`                    | sets the log level of Analysis Controller         | `0`                              |
-| `image.repository`                                  | specify registry for manager image                | `ghcr.io/keptn/metrics-operator` |
-| `image.tag`                                         | select tag for manager image                      | `v0.8.2`                         |
-| `livenessProbe`                                     | custom livenessprobe for manager container        |                                  |
-| `readinessProbe`                                    | custom readinessprobe for manager container       |                                  |
-| `resources`                                         | specify limits and requests for manager container |                                  |
+| Name                                                | Description                                       | Value                    |
+| --------------------------------------------------- | ------------------------------------------------- | ------------------------ |
+| `containerSecurityContext`                          | Sets security context privileges                  |                          |
+| `containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                  |
+| `containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                |
+| `containerSecurityContext.privileged`               |                                                   | `false`                  |
+| `containerSecurityContext.runAsGroup`               |                                                   | `65532`                  |
+| `containerSecurityContext.runAsNonRoot`             |                                                   | `true`                   |
+| `containerSecurityContext.runAsUser`                |                                                   | `65532`                  |
+| `containerSecurityContext.seccompProfile.type`      |                                                   | `RuntimeDefault`         |
+| `env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                   |
+| `env.enableKeptnAnalysis`                           | enables/disables the analysis feature             | `false`                  |
+| `env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                      |
+| `env.analysisControllerLogLevel`                    | sets the log level of Analysis Controller         | `0`                      |
+| `image.registry`                                    | specify repo for manager image                    | `ghcr.io`                |
+| `image.repository`                                  | specify registry for manager image                | `keptn/metrics-operator` |
+| `image.tag`                                         | select tag for manager image                      | `v0.8.2`                 |
+| `livenessProbe`                                     | custom livenessprobe for manager container        |                          |
+| `readinessProbe`                                    | custom readinessprobe for manager container       |                          |
+| `resources`                                         | specify limits and requests for manager container |                          |

--- a/metrics-operator/chart/README.md
+++ b/metrics-operator/chart/README.md
@@ -59,23 +59,23 @@ Prometheus, Dynatrace, DataDog and K8s metric server...
 
 ### Keptn Metrics Operator controller
 
-| Name                                                | Description                                       | Value                    |
-| --------------------------------------------------- | ------------------------------------------------- | ------------------------ |
-| `containerSecurityContext`                          | Sets security context privileges                  |                          |
-| `containerSecurityContext.allowPrivilegeEscalation` |                                                   | `false`                  |
-| `containerSecurityContext.capabilities.drop`        |                                                   | `["ALL"]`                |
-| `containerSecurityContext.privileged`               |                                                   | `false`                  |
-| `containerSecurityContext.runAsGroup`               |                                                   | `65532`                  |
-| `containerSecurityContext.runAsNonRoot`             |                                                   | `true`                   |
-| `containerSecurityContext.runAsUser`                |                                                   | `65532`                  |
-| `containerSecurityContext.seccompProfile.type`      |                                                   | `RuntimeDefault`         |
-| `env.exposeKeptnMetrics`                            | enable metrics exporter                           | `true`                   |
-| `env.enableKeptnAnalysis`                           | enables/disables the analysis feature             | `false`                  |
-| `env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller          | `0`                      |
-| `env.analysisControllerLogLevel`                    | sets the log level of Analysis Controller         | `0`                      |
-| `image.registry`                                    | specify repo for manager image                    | `ghcr.io`                |
-| `image.repository`                                  | specify registry for manager image                | `keptn/metrics-operator` |
-| `image.tag`                                         | select tag for manager image                      | `v0.8.2`                 |
-| `livenessProbe`                                     | custom livenessprobe for manager container        |                          |
-| `readinessProbe`                                    | custom readinessprobe for manager container       |                          |
-| `resources`                                         | specify limits and requests for manager container |                          |
+| Name                                                | Description                                                   | Value                    |
+| --------------------------------------------------- | ------------------------------------------------------------- | ------------------------ |
+| `containerSecurityContext`                          | Sets security context privileges                              |                          |
+| `containerSecurityContext.allowPrivilegeEscalation` |                                                               | `false`                  |
+| `containerSecurityContext.capabilities.drop`        |                                                               | `["ALL"]`                |
+| `containerSecurityContext.privileged`               |                                                               | `false`                  |
+| `containerSecurityContext.runAsGroup`               |                                                               | `65532`                  |
+| `containerSecurityContext.runAsNonRoot`             |                                                               | `true`                   |
+| `containerSecurityContext.runAsUser`                |                                                               | `65532`                  |
+| `containerSecurityContext.seccompProfile.type`      |                                                               | `RuntimeDefault`         |
+| `env.exposeKeptnMetrics`                            | enable metrics exporter                                       | `true`                   |
+| `env.enableKeptnAnalysis`                           | enables/disables the analysis feature                         | `false`                  |
+| `env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller                      | `0`                      |
+| `env.analysisControllerLogLevel`                    | sets the log level of Analysis Controller                     | `0`                      |
+| `image.registry`                                    | specify the container registry for the metrics-operator image | `ghcr.io`                |
+| `image.repository`                                  | specify registry for manager image                            | `keptn/metrics-operator` |
+| `image.tag`                                         | select tag for manager image                                  | `v0.8.2`                 |
+| `livenessProbe`                                     | custom livenessprobe for manager container                    |                          |
+| `readinessProbe`                                    | custom readinessprobe for manager container                   |                          |
+| `resources`                                         | specify limits and requests for manager container             |                          |

--- a/metrics-operator/chart/templates/deployment.yaml
+++ b/metrics-operator/chart/templates/deployment.yaml
@@ -57,8 +57,8 @@ spec:
             }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag
-          | default .Chart.AppVersion }}
+        image: {{- include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global ) | indent 1}}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: metrics-operator
         ports:
         - containerPort: 9443

--- a/metrics-operator/chart/values.yaml
+++ b/metrics-operator/chart/values.yaml
@@ -130,6 +130,8 @@ image:
   repository: keptn/metrics-operator
 ## @param   image.tag select tag for manager image
   tag: v0.8.2 # x-release-please-version
+## @param   imagePullPolicy specify pull policy for manager image
+  imagePullPolicy: Always
 ## @extra  livenessProbe custom livenessprobe for manager container
 ## @skip   livenessProbe.httpGet.path
 ## @skip   livenessProbe.httpGet.port

--- a/metrics-operator/chart/values.yaml
+++ b/metrics-operator/chart/values.yaml
@@ -131,7 +131,7 @@ image:
 ## @param   image.tag select tag for manager image
   tag: v0.8.2 # x-release-please-version
 ## @param   imagePullPolicy specify pull policy for manager image
-  imagePullPolicy: Always
+imagePullPolicy: Always
 ## @extra  livenessProbe custom livenessprobe for manager container
 ## @skip   livenessProbe.httpGet.path
 ## @skip   livenessProbe.httpGet.port

--- a/metrics-operator/chart/values.yaml
+++ b/metrics-operator/chart/values.yaml
@@ -124,7 +124,7 @@ env:
 ## @param   env.analysisControllerLogLevel  sets the log level of Analysis Controller
   analysisControllerLogLevel: "0"
 image:
-## @param     image.registry specify repo for manager image
+## @param     image.registry specify the container registry for the metrics-operator image
   registry: ghcr.io
 ## @param   image.repository specify registry for manager image
   repository: keptn/metrics-operator

--- a/metrics-operator/chart/values.yaml
+++ b/metrics-operator/chart/values.yaml
@@ -124,8 +124,10 @@ env:
 ## @param   env.analysisControllerLogLevel  sets the log level of Analysis Controller
   analysisControllerLogLevel: "0"
 image:
+## @param     image.registry specify repo for manager image
+  registry: ghcr.io
 ## @param   image.repository specify registry for manager image
-  repository: ghcr.io/keptn/metrics-operator
+  repository: keptn/metrics-operator
 ## @param   image.tag select tag for manager image
   tag: v0.8.2 # x-release-please-version
 ## @extra  livenessProbe custom livenessprobe for manager container


### PR DESCRIPTION
fixes #2360

also adds missing image function and imagePullPolicy from the metrics operator templates
to check that it works I added tests in the helm test folder and used a value file for our install action