### PR TITLE
chore: remove test images from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,8 @@
         "docker.io\\/bacherfl\\/.*",
         "docker.io\\/mowies\\/.*",
         "docker.io\\/odubajdt\\/.*",
-        "docker.io\\/thisthatdc\\/.*"
+        "docker.io\\/thisthatdc\\/.*",
+        "testreg\\/.*"
       ]
     },
     {


### PR DESCRIPTION
### This PR
- removes occurrences of `testreg` from renovate since this name is only used to test helm values in the helm test setup