### PR TITLE
docs: add required labels to required CRD fields (KeptnTask, KeptnMetric, KeptnMetricsProvider, KeptnTaskDefintion)

### DIFF
--- a/docs/content/en/docs/yaml-crd-ref/metric.md
+++ b/docs/content/en/docs/yaml-crd-ref/metric.md
@@ -40,7 +40,7 @@ spec:
 
 * **apiVersion** (required) -- API version being used.
 
-* **kind** -- Resource type.
+* **kind** (required) -- Resource type.
    Must be set to `KeptnMetric`.
 
 * **metadata**

--- a/docs/content/en/docs/yaml-crd-ref/metric.md
+++ b/docs/content/en/docs/yaml-crd-ref/metric.md
@@ -38,9 +38,9 @@ spec:
 
 ## Fields
 
-* **apiVersion** (required) -- API version being used.
+* **apiVersion** -- API version being used.
 
-* **kind** (required) -- Resource type.
+* **kind** -- Resource type.
    Must be set to `KeptnMetric`.
 
 * **metadata**
@@ -51,7 +51,7 @@ spec:
   * **namespace** -- Namespace of the application using this metric.
 
 * **spec**
-  * **provider.name** --
+  * **provider.name** (required) --
     Name of this instance of the data source
     from which the metric is collected.
     This value must match the value of the `metadata.name` field
@@ -64,9 +64,9 @@ spec:
     as the name of the Prometheus server that monitors the dev deployment
     and `prod-prometheus` as the name of the Prometheus server
     that monitors the production deployment.
-  * **query** -- String in the provider-specific query language,
+  * **query** (required) -- String in the provider-specific query language,
     used to obtain a metric.
-  * **fetchIntervalSeconds** -- Number of seconds between updates of the metric.
+  * **fetchIntervalSeconds** (required) -- Number of seconds between updates of the metric.
   * **range**
     * **interval** -- Timeframe for which the metric would be queried.
     Defaults to 5m.

--- a/docs/content/en/docs/yaml-crd-ref/metric.md
+++ b/docs/content/en/docs/yaml-crd-ref/metric.md
@@ -38,8 +38,8 @@ spec:
 
 ## Fields
 
-* **apiVersion** -- API version being used.
-`
+* **apiVersion** (required) -- API version being used.
+
 * **kind** -- Resource type.
    Must be set to `KeptnMetric`.
 

--- a/docs/content/en/docs/yaml-crd-ref/metricsprovider.md
+++ b/docs/content/en/docs/yaml-crd-ref/metricsprovider.md
@@ -60,8 +60,8 @@ spec:
 
 * **spec**
 
-  * **type** -- The type of data provider for this instance
-  * **targetServer** -- URL of the data provider, enclosed in double quotes
+  * **type** (required) -- The type of data provider for this instance
+  * **targetServer** (required) -- URL of the data provider, enclosed in double quotes
   * **secretKeyRef**
     * **name:** -- Name of the token for this data provider
     * **key:** -- Key for this data provider

--- a/docs/content/en/docs/yaml-crd-ref/task.md
+++ b/docs/content/en/docs/yaml-crd-ref/task.md
@@ -50,17 +50,17 @@ spec:
     [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
     specification.
 * **spec** - Defines the speficication of this `KeptnTask` resource
-  * **taskDefinition** - Name of the corresponding `KeptnTaskDefinition` resource.
+  * **taskDefinition** (required) -- Name of the corresponding `KeptnTaskDefinition` resource.
     This `KeptnTaskDefinition` can be located in the same namespace
     or in the Keptn installation namespace.
-  * **context** - Contextual information about the task execution
-    * **appName** - Name of the
+  * **context** (required) -- Contextual information about the task execution
+    * **appName** (required) -- Name of the
       [KeptnApp](../yaml-crd-ref/app.md) resource
       for which the `KeptnTask` is being executed.
-    * **appVersion** - Version of the `KeptnApp` resource
+    * **appVersion** (required) -- Version of the `KeptnApp` resource
       for which the `KeptnTask` is being executed.
 
-    * **objectType** - Indicates whether this `KeptnTask`
+    * **objectType** (required) -- Indicates whether this `KeptnTask`
       is being executed for a `KeptnApp` or a `KeptnWorkload` resource.
       When populating this resource manually
       to run a task for a non-Kubernetes deployment,
@@ -68,7 +68,7 @@ spec:
       Keptn populates this field based on annotations
       to the `KeptnWorkload` and `KeptnApp` resources.
 
-    * **taskType** Indicates whether this `KeptnTask`
+    * **taskType** (required) -- Indicates whether this `KeptnTask`
       is part of the pre- or post-deployment phase.
       When populating this resource manually
       to run a task for a non-Kubernetes deployment,
@@ -76,13 +76,13 @@ spec:
       Keptn populates this field based on annotations
       to the `KeptnWorkload` and `KeptnApp` resources.
 
-    * **workloadName** - Name of the `KeptnWorkload`
+    * **workloadName** (required) -- Name of the `KeptnWorkload`
       for which the `KeptnTask` is being executed.
-    * **workloadVersion** - Version of the `KeptnWorkload`
+    * **workloadVersion** (required) -- Version of the `KeptnWorkload`
       for which the `KeptnTask` is being executed.
-  * **parameters** (optional) -- Parameters that are passed to the job
+  * **parameters** -- Parameters that are passed to the job
     that executes the `KeptnTask`.
-  * **secureParameters** (optional) -- Secure parameters that are passed
+  * **secureParameters** -- Secure parameters that are passed
     to the job that executes the `KeptnTask`.
     These are stored and accessed as Kubernetes `Secrets` in the cluster.
     See [Working with secrets](../implementing/tasks/#working-with-secrets)
@@ -90,10 +90,10 @@ spec:
   * **checkType** -- Defines whether task is part of pre- or post-deployment phase.
     Keptn populates this field based on annotations
     to the `KeptnWorkload` and `KeptnApp` resources.
-  * **retries** (optional) -- If errors occur,
+  * **retries** -- If errors occur,
     this defines the number of attempts made
     before the `KeptnTask` is considered to be failed.
-  * **timeout** (optional) -- Specifies the time, in seconds,
+  * **timeout** -- Specifies the time, in seconds,
     to wait for the `KeptnTask` to complete successfully.
     If the `KeptnTask` does not complete successfully in this timeframe,
     it is considered to be failed.

--- a/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
+++ b/docs/content/en/docs/yaml-crd-ref/taskdefinition.md
@@ -87,7 +87,7 @@ spec:
     [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
     specification.
 * **spec**
-  * **deno | python | container** -- Define the container type
+  * **deno | python | container** (required) -- Define the container type
   to use for this task.
   Each task can use one type of runner,
   identified by this field:
@@ -107,10 +107,10 @@ spec:
       and code the functionality to match the container you define.
       See
       [Synopsis for container-runtime container](#synopsis-for-container-runtime).
-  * **retries** (optional) -- specifies the number of times
+  * **retries** -- specifies the number of times
     a job executing the `KeptnTaskDefinition`
     should be restarted if an attempt is unsuccessful.
-  * **timeout** (optional) -- specifies the maximum time
+  * **timeout** -- specifies the maximum time
     to wait for the task to be completed successfully.
     The value supplied should specify the unit of measurement;
     for example, `5s` indicates 5 seconds and `5m` indicates 5 minutes.


### PR DESCRIPTION
### This PR
- adds required labels for required fields in the CRD reference pages for the following types:
  - KeptnTask
  - KeptnMetric
  - KeptnMetricsProvider
  - KeptnTaskDefintion


Part-of: https://github.com/keptn/lifecycle-toolkit/issues/2324