### PR TITLE
chore: adapt helm chart pipeline to substitue local paths before syncing with charts repository

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -263,7 +263,7 @@ jobs:
         working-directory: ./${{ matrix.config.path }}
         run: |
           # substitute local charts path with official ones
-          sed -i 's|file://../.*/chart|https://charts.lifecycle.keptn.sh|' ./Chart.yaml
+          yq '.dependencies.[].repository = "https://charts.lifecycle.keptn.sh"' ./Chart.yaml > ./Chart.yaml
           helm dependency update
           helm dependency build
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -258,6 +258,15 @@ jobs:
           path: ./helm-charts-repository
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
+      - name: Substitue local paths with official chart URL
+        if: matrix.config.name == 'keptn'
+        working-directory: ./${{ matrix.config.path }}
+        run: |
+          # substitute local charts path with official ones
+          sed -i 's|file://../.*/chart|https://charts.lifecycle.keptn.sh|' ./Chart.yaml
+          helm dependency update
+          helm dependency build
+
       - name: Copy chart from klt to helm repo
         run: rsync -av --delete --exclude='charts/*.tgz' ./${{ matrix.config.path }}/ ./helm-charts-repository/charts/${{ matrix.config.name }}/
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -29,7 +29,6 @@ annotations:
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: "Full Lifecycle"
-
 kubeVersion: ">= 1.24.0-0"
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -40,18 +39,15 @@ kubeVersion: ">= 1.24.0-0"
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.3.0
-
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.9.0" # x-release-please-version
-
 dependencies:
   - name: keptn-cert-manager
     version: 0.2.0
@@ -68,4 +64,3 @@ dependencies:
     alias: metricsOperator
     condition: metricsOperator.enabled
     repository: file://../metrics-operator/chart
-# TODO: change repository links to released ones once the charts get their first release


### PR DESCRIPTION
## Changes

Adapt chart sync pipeline to substitute local paths with official charts url
