### PR TITLE
fix(lifecycle-operator): adopt KeptnApp name from either Keptn or k8s label

### DIFF
--- a/lifecycle-operator/webhooks/pod_mutator/handlers/appcreationrequest_handler.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/appcreationrequest_handler.go
@@ -72,7 +72,8 @@ func generateResource(ctx context.Context, pod *corev1.Pod, namespace string) *k
 		initEmptyAnnotations(&pod.ObjectMeta, 2)
 		// at this point if the pod does not have an app annotation it means we create the app
 		// and it will have a single workload
-		pod.ObjectMeta.Annotations[apicommon.AppAnnotation] = pod.ObjectMeta.Annotations[apicommon.WorkloadAnnotation]
+		appName, _ := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.WorkloadAnnotation, apicommon.K8sRecommendedWorkloadAnnotations)
+		pod.Annotations[apicommon.AppAnnotation] = appName
 		// so we can mark the app request as single service type
 		kacr.Annotations[apicommon.AppTypeAnnotation] = string(apicommon.AppTypeSingleService)
 	}

--- a/test/integration/simple-deployment-k8s-recommended-label/00-assert.yaml
+++ b/test/integration/simple-deployment-k8s-recommended-label/00-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+status:
+  readyReplicas: 1

--- a/test/integration/simple-deployment-k8s-recommended-label/00-install.yaml
+++ b/test/integration/simple-deployment-k8s-recommended-label/00-install.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: test
+      annotations:
+        app.kubernetes.io/name: "waiter"
+        keptn.sh/version: "0.4"
+    spec:
+      containers:
+        - image: busybox
+          name: busybox
+          command: ['sh', '-c', 'echo The app is running! && sleep infinity']
+      initContainers:
+        - name: init-myservice
+          image: busybox:1.36.1
+          command: ['sh', '-c', 'sleep 30']

--- a/test/integration/simple-deployment-k8s-recommended-label/00-teststep.yaml
+++ b/test/integration/simple-deployment-k8s-recommended-label/00-teststep.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - script: kubectl annotate ns $NAMESPACE keptn.sh/lifecycle-toolkit='enabled'

--- a/test/integration/simple-deployment-k8s-recommended-label/01-assert.yaml
+++ b/test/integration/simple-deployment-k8s-recommended-label/01-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnWorkload
+metadata:
+  name: waiter-waiter
+---
+apiVersion: lifecycle.keptn.sh/v1alpha4
+kind: KeptnWorkloadVersion
+metadata:
+  name: waiter-waiter-0.4
+status:
+  currentPhase: Completed
+  deploymentStatus: Succeeded
+  postDeploymentEvaluationStatus: Succeeded
+  postDeploymentStatus: Succeeded
+  preDeploymentEvaluationStatus: Succeeded
+  preDeploymentStatus: Succeeded
+---
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnApp
+metadata:
+  name: waiter
+---
+apiVersion: lifecycle.keptn.sh/v1alpha3
+kind: KeptnAppVersion
+metadata:
+  name: waiter-0.4-6b86b273


### PR DESCRIPTION
When no app name is set explicitly in the labels/annotations of a pod, the mutating webhook was using the name of the workload for the name of the related, autogenerated app. Afterwards it adds the name of the app as an annotation to the pod, however it did that without considering the `app.kubernetes.io/name` label, but only based on what is in `keptn.sh/workload`. This prevented pods not using the `keptn.sh/workload` label from spinning up as the scheduler, which is using these annotations as information for constructing the name of the related workload version, could not find a matching WorkloadVersion.