### PR TITLE
feat: add annotation to select container for version extraction

### DIFF
--- a/lifecycle-operator/apis/lifecycle/v1alpha3/common/common.go
+++ b/lifecycle-operator/apis/lifecycle/v1alpha3/common/common.go
@@ -32,6 +32,7 @@ const CreateAppEvalSpanName = "create_%s_app_evaluation"
 const CreateWorkloadEvalSpanName = "create_%s_deployment_evaluation"
 const AppTypeAnnotation = "keptn.sh/app-type"
 const KeptnGate = "keptn-prechecks-gate"
+const ContainerNameAnnotation = "keptn.sh/container"
 
 const MinKeptnNameLen = 80
 const MaxK8sObjectLength = 253

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta.go
@@ -99,16 +99,21 @@ func initEmptyAnnotations(meta *metav1.ObjectMeta, size int) {
 	}
 }
 
+func getImageVersion(image string) (string, error) {
+	splitImage := strings.Split(image, ":")
+	lenImg := len(splitImage) - 1
+	if lenImg >= 1 && splitImage[lenImg] != "" && splitImage[lenImg] != "latest" {
+		return splitImage[lenImg], nil
+	}
+	return "", fmt.Errorf("Invalid image version")
+}
+
 func calculateVersion(pod *corev1.Pod, containerName string) (string, error) {
 	if len(pod.Spec.Containers) == 1 {
 		if containerName != "" && pod.Spec.Containers[0].Name != containerName {
 			return "", fmt.Errorf("The container name '%s' specified in %s does not match the name of the container in the pod", containerName, apicommon.ContainerNameAnnotation)
 		}
-		image := strings.Split(pod.Spec.Containers[0].Image, ":")
-		lenImg := len(image) - 1
-		if lenImg >= 1 && image[lenImg] != "" && image[lenImg] != "latest" {
-			return image[lenImg], nil
-		}
+		return getImageVersion(pod.Spec.Containers[0].Image)
 	}
 
 	name := ""
@@ -116,10 +121,9 @@ func calculateVersion(pod *corev1.Pod, containerName string) (string, error) {
 	for _, item := range pod.Spec.Containers {
 		if item.Name == containerName {
 			containerFound = true
-			image := strings.Split(item.Image, ":")
-			lenImg := len(image) - 1
-			if lenImg >= 1 && image[lenImg] != "" && image[lenImg] != "latest" {
-				return image[lenImg], nil
+			version, err := getImageVersion(item.Image)
+			if err == nil {
+				return version, nil
 			}
 		}
 		name = name + item.Name + item.Image

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta.go
@@ -74,11 +74,6 @@ func GetOwnerReference(resource *metav1.ObjectMeta) metav1.OwnerReference {
 	return reference
 }
 
-func getContainerName(meta *metav1.ObjectMeta) string {
-	containerName, _ := GetLabelOrAnnotation(meta, apicommon.ContainerNameAnnotation, apicommon.ContainerNameAnnotation)
-	return containerName
-}
-
 func setMapKey(myMap map[string]string, key, value string) {
 	if myMap == nil {
 		return

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta_test.go
@@ -187,6 +187,52 @@ func TestGetLabelOrAnnotation(t *testing.T) {
 	}
 }
 
+func TestGetImageVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Return image version when version is present",
+			image:   "my-image:1.0.0",
+			want:    "1.0.0",
+			wantErr: false,
+		},
+		{
+			name:    "Return error when image version is not present",
+			image:   "my-image",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Return error when image version is empty",
+			image:   "my-image:",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Return error when image version is latest",
+			image:   "my-image:latest",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getImageVersion(tt.image)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getImageVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getImageVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_calculateVersion(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta_test.go
@@ -265,6 +265,25 @@ func Test_calculateVersion(t *testing.T) {
 			wantErr:       false,
 		},
 		{
+			name: "single container with annotation mismatch",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-name",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-name",
+							Image: "image:tag1",
+						},
+					},
+				},
+			},
+			containerName: "not-container-name",
+			want:          "",
+			wantErr:       true,
+		},
+		{
 			name: "multiple containers",
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/objectmeta_test.go
@@ -187,12 +187,13 @@ func TestGetLabelOrAnnotation(t *testing.T) {
 	}
 }
 
-func TestCalculateVersion(t *testing.T) {
-
+func Test_calculateVersion(t *testing.T) {
 	tests := []struct {
-		name string
-		pod  *corev1.Pod
-		want string
+		name          string
+		pod           *corev1.Pod
+		containerName string
+		want          string
+		wantErr       bool
 	}{
 		{
 			name: "simple tag",
@@ -202,7 +203,9 @@ func TestCalculateVersion(t *testing.T) {
 						{Image: "ciao:1.0.0"},
 					},
 				}},
-			want: "1.0.0",
+			containerName: "",
+			want:          "1.0.0",
+			wantErr:       false,
 		}, {
 			name: "local registry",
 			pod: &corev1.Pod{
@@ -211,7 +214,9 @@ func TestCalculateVersion(t *testing.T) {
 						{Image: "localhost:5000/node-web-app:1.0.0"},
 					},
 				}},
-			want: "1.0.0",
+			containerName: "",
+			want:          "1.0.0",
+			wantErr:       false,
 		},
 		{
 			name: "multiple containers",
@@ -230,12 +235,66 @@ func TestCalculateVersion(t *testing.T) {
 							}},
 					},
 				}},
-			want: "1253120182", //the hash of ciaopeppetest12
+			containerName: "",
+			want:          "1253120182", //the hash of ciaopeppetest12
+			wantErr:       false,
+		},
+		{
+			name: "multiple containers with annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-name",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-name",
+							Image: "image:tag1",
+						},
+						{
+							Name:  "container-name2",
+							Image: "image:tag2",
+						},
+					},
+				},
+			},
+			containerName: "container-name2",
+			want:          "tag2",
+			wantErr:       false,
+		},
+		{
+			name: "multiple containers with annotation mismatch",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-name",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-name",
+							Image: "image:tag1",
+						},
+						{
+							Name:  "container-name2",
+							Image: "image:tag2",
+						},
+					},
+				},
+			},
+			containerName: "not-container-name",
+			want:          "",
+			wantErr:       true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := calculateVersion(tt.pod); got != tt.want {
+			got, err := calculateVersion(tt.pod, tt.containerName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("calculateVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
 				t.Errorf("calculateVersion() = %v, want %v", got, tt.want)
 			}
 		})

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/pod_annotation.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/pod_annotation.go
@@ -126,14 +126,15 @@ func isPodAnnotated(pod *corev1.Pod) bool {
 	containerName, _ := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.ContainerNameAnnotation, "")
 	_, gotWorkloadAnnotation := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.WorkloadAnnotation, apicommon.K8sRecommendedWorkloadAnnotations)
 	_, gotVersionAnnotation := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.VersionAnnotation, apicommon.K8sRecommendedVersionAnnotations)
-	var err error
 
 	if gotWorkloadAnnotation {
 		if !gotVersionAnnotation {
 			initEmptyAnnotations(&pod.ObjectMeta, 1)
-			pod.Annotations[apicommon.VersionAnnotation], err = calculateVersion(pod, containerName)
+			version, err := calculateVersion(pod, containerName)
 			if err != nil {
 				log.Println(err)
+			} else {
+				pod.Annotations[apicommon.VersionAnnotation] = version
 			}
 		}
 		return true

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/pod_annotation.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/pod_annotation.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"log"
 
 	argov1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/go-logr/logr"
@@ -94,12 +95,18 @@ func copyResourceLabelsIfPresent(sourceResource *metav1.ObjectMeta, targetPod *c
 	postDeploymentChecks, _ = GetLabelOrAnnotation(sourceResource, apicommon.PostDeploymentTaskAnnotation, "")
 	preEvaluationChecks, _ = GetLabelOrAnnotation(sourceResource, apicommon.PreDeploymentEvaluationAnnotation, "")
 	postEvaluationChecks, _ = GetLabelOrAnnotation(sourceResource, apicommon.PostDeploymentEvaluationAnnotation, "")
+	containerName, _ := GetLabelOrAnnotation(sourceResource, apicommon.ContainerNameAnnotation, "")
 
 	if gotWorkloadName {
 		setMapKey(targetPod.Annotations, apicommon.WorkloadAnnotation, workloadName)
 
 		if !gotVersion {
-			setMapKey(targetPod.Annotations, apicommon.VersionAnnotation, calculateVersion(targetPod))
+			version, err := calculateVersion(targetPod, containerName)
+			if err != nil {
+				log.Println(err)
+				return false
+			}
+			setMapKey(targetPod.Annotations, apicommon.VersionAnnotation, version)
 		} else {
 			setMapKey(targetPod.Annotations, apicommon.VersionAnnotation, version)
 		}
@@ -116,13 +123,18 @@ func copyResourceLabelsIfPresent(sourceResource *metav1.ObjectMeta, targetPod *c
 }
 
 func isPodAnnotated(pod *corev1.Pod) bool {
+	containerName, _ := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.ContainerNameAnnotation, "")
 	_, gotWorkloadAnnotation := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.WorkloadAnnotation, apicommon.K8sRecommendedWorkloadAnnotations)
 	_, gotVersionAnnotation := GetLabelOrAnnotation(&pod.ObjectMeta, apicommon.VersionAnnotation, apicommon.K8sRecommendedVersionAnnotations)
+	var err error
 
 	if gotWorkloadAnnotation {
 		if !gotVersionAnnotation {
 			initEmptyAnnotations(&pod.ObjectMeta, 1)
-			pod.Annotations[apicommon.VersionAnnotation] = calculateVersion(pod)
+			pod.Annotations[apicommon.VersionAnnotation], err = calculateVersion(pod, containerName)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 		return true
 	}

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/pod_annotation_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/pod_annotation_test.go
@@ -636,6 +636,49 @@ func TestIsPodAnnotated(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "Test return false when container annotation does not match container name",
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-name",
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apicommon.ContainerNameAnnotation: "not-container-name",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Test return false when container annotation does not match any container name",
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "container-name",
+							},
+							{
+								Name: "container-name2",
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apicommon.ContainerNameAnnotation: "not-container-name",
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/scheduler/pkg/klcpermit/workflow_manager_test.go
+++ b/scheduler/pkg/klcpermit/workflow_manager_test.go
@@ -435,8 +435,8 @@ func Test_calculateVersion(t *testing.T) {
 				},
 			},
 			containerName: "",
-			want:          "2894867514",
-			wantErr:       false,
+			want:          "",
+			wantErr:       true,
 		},
 		{
 			name: "single container annotation mismatch",

--- a/scheduler/pkg/klcpermit/workflow_manager_test.go
+++ b/scheduler/pkg/klcpermit/workflow_manager_test.go
@@ -374,6 +374,52 @@ func Test_getSpan_unbindSpan(t *testing.T) {
 
 }
 
+func TestGetImageVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Return image version when version is present",
+			image:   "my-image:1.0.0",
+			want:    "1.0.0",
+			wantErr: false,
+		},
+		{
+			name:    "Return error when image version is not present",
+			image:   "my-image",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Return error when image version is empty",
+			image:   "my-image:",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Return error when image version is latest",
+			image:   "my-image:latest",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getImageVersion(tt.image)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getImageVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getImageVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_calculateVersion(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

If a pod contains multiple containers the user can select which container the version should be extracted from by setting the keptn.sh/container annotation. If the annotation is set, but no container matches its name we assume something is wrong an throw an error.


Part-of #2464 

# How to test

The tests `Test_calculateVersion` were expanded to cover the added functionality

# Checklist

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [x] New and existing unit and integration tests pass locally with my changes
