### PR TITLE
docs: fix weights for contrib/docs files

### DIFF
--- a/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
+++ b/docs/content/en/contribute/docs/contrib-guidelines-docs/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Contribution guidelines for documentation
 description: Guidelines for contributing towards Keptn Lifecycle Toolkit
-weight: 300
+weight: 100
 ---
 
 The [Contribution Guidelines](../../general/contrib-guidelines-gen) page

--- a/docs/content/en/contribute/docs/linter-requirements/_index.md
+++ b/docs/content/en/contribute/docs/linter-requirements/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Linter Requirements
 description: To maintain optimal code quality, this project employs linters which require a specific IDE configuration for effective utilization.
-weight: 400
+weight: 320
 ---
 
 ## Linter Requirements

--- a/docs/content/en/contribute/docs/local-building/_index.md
+++ b/docs/content/en/contribute/docs/local-building/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Build Documentation Locally
 description: This guide explains how to create a local version of the documentation
-weight: 400
+weight: 200
 ---
 
 ## Building the documentation locally


### PR DESCRIPTION
# Summary

This PR fixes the weights for files in contribute/docs section

# Checks

- [n/a] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [n/a] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
