### PR TITLE
chore: update renovate file to allow more makefile regex patterns, pin markdownlint version

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -45,8 +45,7 @@ lint: lint-fix
 # - .markdownlintignore holds the configuration for files to be ignored
 # - .markdownlint.yaml contains the rules for markdownfiles
 # renovate: datasource=docker depName=davidanson/markdownlint-cli2-rules
-MDL_DOCKER_VERSION := v0.6.0 # TODO: remove next line on version increase from v0.6.0
-MDL_DOCKER_VERSION := next
+MDL_DOCKER_VERSION := v0.10.0
 MDL_CMD := docker run -v $(ROOT_DIR)../:/workdir --rm 
 
 .PHONY: markdownlint markdownlint-fix

--- a/renovate.json
+++ b/renovate.json
@@ -73,7 +73,7 @@
         "(^|\\/).*\\.sh$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*?_VERSION ?(\\??=|\\: ?) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
+        "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*?_VERSION ?(=|\\?=|:=|\\+=) ?\\\"?(?<currentValue>.+?)?\\\"?\\s"
       ]
     }
   ],


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

- This PR pins the markdownlint version to 0.10.0. Before, `next` was used, which is not a fixed tag. That caused unforseen error from now and then. Also now, this is the issue behind some markdownlint errors on files that nobody touched.
- This PR also updates the renovate config to be able to capture more deps updates in makefiles.
