### PR TITLE
docs: remove duplicated DORA section from otel.md

### DIFF
--- a/docs/content/en/docs/implementing/dora.md
+++ b/docs/content/en/docs/implementing/dora.md
@@ -23,7 +23,7 @@ Keptn starts collecting these metrics
 as soon as you apply
 [basic annotations](./integrate.md#basic-annotations)
 to the
-[Workload](https://kubernetes.io/docs/concepts/workloads/)
+[workload](https://kubernetes.io/docs/concepts/workloads/)
 resources
 ([Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
 [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
@@ -39,21 +39,23 @@ To view DORA metrics, run the following two commands:
 
 - Retrieve the service name with:
 
-```shell
-kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
-```
+  ```shell
+  kubectl -n keptn-lifecycle-toolkit-system get service \
+    -l control-plane=lifecycle-operator
+  ```
 
 - Then port-forward to the name of your service:
 
-```shell
-kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
-```
+  ```shell
+  kubectl -n keptn-lifecycle-toolkit-system port-forward \
+    service/<YOURNAME> 2222
+  ```
 
 Then view the metrics at:
 
-```shell
-http://localhost:2222/metrics
-```
+  ```shell
+  http://localhost:2222/metrics
+  ```
 
 DORA metrics are also displayed on Grafana
 or whatever dashboard application you choose.

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -23,7 +23,7 @@ This means that:
 The observability data is an amalgamation of the following:
 
 - [DORA metrics](dora.md)
-  are collected out of the box when Keptn is enabled.
+  are collected out of the box when Keptn is enabled
 - [OpenTelemetry](https://opentelemetry.io/)
   runs traces that show everything that happens in the Kubernetes cluster
 - Custom

--- a/docs/content/en/docs/implementing/otel.md
+++ b/docs/content/en/docs/implementing/otel.md
@@ -22,69 +22,23 @@ This means that:
 
 The observability data is an amalgamation of the following:
 
-- DORA metrics are collected out of the box
-  when Keptn is enabled
-- OpenTelemetry runs traces that show
-  everything that happens in the Kubernetes cluster
-- Custom Keptn metrics that you can use to monitor
-  information from all the data providers configured in your cluster
+- [DORA metrics](dora.md)
+  are collected out of the box when Keptn is enabled.
+- [OpenTelemetry](https://opentelemetry.io/)
+  runs traces that show everything that happens in the Kubernetes cluster
+- Custom
+  [Keptn metrics](evaluatemetrics.md)
+  that you can use to monitor information
+  from all the data providers configured in your cluster
 
 All this information can be displayed with dashboard tools
 such as Grafana.
 
 For an introduction to using OpenTelemetry with Keptn metrics, see the
-[Standardize observability](../intro/usecase-observability.md)
+[Keptn Observability](../getting-started/observability.md)
 getting started guide.
 
-## DORA metrics
-
-DORA metrics are an industry-standard set of measurements;
-see the following for a description:
-
-- [What are DORA Metrics and Why Do They Matter?](https://codeclimate.com/blog/dora-metrics)
-- [Are you an Elite DevOps Performer?
-   Find out with the Four Keys Project](https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance)
-
-DORA metrics provide information such as:
-
-- How many deployments happened in the last six hours?
-- Time between deployments
-- Deployment time between versions
-- Average time between versions.
-
-Keptn starts collecting these metrics
-as soon as you apply
-[basic annotations](./integrate.md#basic-annotations)
-to the [workload](https://kubernetes.io/docs/concepts/workloads/).
-Metrics are collected only for the resources
-that are annotated.
-
-To view DORA metrics, run the following two commands:
-
-- Retrieve the service name with:
-
-```shell
-kubectl -n keptn-lifecycle-toolkit-system get service -l control-plane=lifecycle-operator
-```
-
-- Then port-forward to the name of your service:
-
-```shell
-kubectl -n keptn-lifecycle-toolkit-system port-forward service/<YOURNAME> 2222
-```
-
-Then view the metrics at:
-
-```shell
-http://localhost:2222/metrics
-```
-
-DORA metrics can be displayed on Grafana
-or whatever dashboard application you choose.
-
-## OpenTelemetry
-
-### Requirements for OpenTelemetry
+## Requirements for OpenTelemetry
 
 To access OpenTelemetry metrics with Keptn,
 you must have the following on your cluster:
@@ -97,13 +51,15 @@ you must have the following on your cluster:
   See [Prometheus Operator Setup](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/customizing.md).
 
   - The Prometheus Operator must have the required permissions
-    to watch resources of your Keptn namespace (default is `keptn-lifecycle-toolkit-system`) (see
+    to watch resources of your Keptn namespace
+    (default is `keptn-lifecycle-toolkit-system`).
+    See
     [Setup for Monitoring other Namespaces](https://prometheus-operator.dev/docs/kube/monitoring-other-namespaces/)).
 
   - To install Prometheus into the `monitoring` namespace
     using the example configuration included with Keptn,
     use the following command sequence.
-    Use similar commands if you define a different configuration:
+    You can modify these commands to define a different configuration:
 
     > **Note**
     You must clone the `lifecycle-toolkit` repository
@@ -135,13 +91,13 @@ you must have the following on your cluster:
     See
     [Accessing Metrics via the Kubernetes Custom Metrics API](evaluatemetrics.md/#accessing-metrics-via-the-kubernetes-custom-metrics-api)
 
-### Integrate OpenTelemetry into Keptn
+## Integrate OpenTelemetry into Keptn
 
 To integrate OpenTelemetry into Keptn:
 
 - Apply
   [basic annotations](./integrate.md#basic-annotations)
-  for your `Deployment` resource
+  for the `Deployment` resource(s)
   to integrate Keptn into your Kubernetes cluster.
 - To expose OpenTelemetry metrics,
   define a [KeptnConfig](../yaml-crd-ref/config.md) resource


### PR DESCRIPTION
# Summary

This PR:
* Deletes the "DORA Metrics" section from the "Observability" page since it duplicated what is in the separate "DORA metrics" page
* Minor modifications to the "Observability" page to update and correct it 

Fixes https://github.com/keptn/lifecycle-toolkit/issues/2465 

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [n/a ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
