### PR TITLE
feat(lifecycle-operator): add `KEPTN_CONTEXT` to task container env vars

### DIFF
--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
@@ -2,6 +2,7 @@ package keptntask
 
 import (
 	"encoding/json"
+
 	klcv1alpha3 "github.com/keptn/lifecycle-toolkit/lifecycle-operator/apis/lifecycle/v1alpha3"
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common/taskdefinition"
 	"golang.org/x/net/context"

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
@@ -2,10 +2,10 @@ package keptntask
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 
 	klcv1alpha3 "github.com/keptn/lifecycle-toolkit/lifecycle-operator/apis/lifecycle/v1alpha3"
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common/taskdefinition"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
@@ -30,6 +30,9 @@ func NewContainerBuilder(options BuilderOptions) *ContainerBuilder {
 
 func (c *ContainerBuilder) CreateContainer(ctx context.Context) (*corev1.Container, error) {
 	result := c.containerSpec.Container
+	if result == nil {
+		return nil, nil
+	}
 
 	taskContext := c.taskSpec.Context
 

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
@@ -11,22 +11,24 @@ import (
 
 // ContainerBuilder implements container builder interface for python
 type ContainerBuilder struct {
-	containerSpec *klcv1alpha3.ContainerSpec
-	taskSpec      *klcv1alpha3.KeptnTaskSpec
+	containerSpec klcv1alpha3.ContainerSpec
+	taskSpec      klcv1alpha3.KeptnTaskSpec
 }
 
 func NewContainerBuilder(options BuilderOptions) *ContainerBuilder {
-	return &ContainerBuilder{
-		containerSpec: options.containerSpec,
+	builder := &ContainerBuilder{
+		containerSpec: *options.containerSpec,
 	}
+
+	if options.task != nil {
+		builder.taskSpec = options.task.Spec
+	}
+
+	return builder
 }
 
 func (c *ContainerBuilder) CreateContainer(ctx context.Context) (*corev1.Container, error) {
 	result := c.containerSpec.Container
-
-	if c.taskSpec == nil {
-		return result, nil
-	}
 
 	taskContext := c.taskSpec.Context
 
@@ -74,7 +76,7 @@ func (c *ContainerBuilder) getVolumeSource() *corev1.EmptyDirVolumeSource {
 }
 
 func (c *ContainerBuilder) generateVolume() *corev1.Volume {
-	if !taskdefinition.IsVolumeMountPresent(c.containerSpec) {
+	if !taskdefinition.IsVolumeMountPresent(&c.containerSpec) {
 		return nil
 	}
 	return &corev1.Volume{

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder.go
@@ -2,6 +2,7 @@ package keptntask
 
 import (
 	"encoding/json"
+	"github.com/pkg/errors"
 
 	klcv1alpha3 "github.com/keptn/lifecycle-toolkit/lifecycle-operator/apis/lifecycle/v1alpha3"
 	"github.com/keptn/lifecycle-toolkit/lifecycle-operator/controllers/common/taskdefinition"
@@ -29,10 +30,10 @@ func NewContainerBuilder(options BuilderOptions) *ContainerBuilder {
 }
 
 func (c *ContainerBuilder) CreateContainer(ctx context.Context) (*corev1.Container, error) {
-	result := c.containerSpec.Container
-	if result == nil {
-		return nil, nil
+	if c.containerSpec.Container == nil {
+		return nil, errors.New("no container definition provided")
 	}
+	result := c.containerSpec.Container
 
 	taskContext := c.taskSpec.Context
 

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder_test.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder_test.go
@@ -15,6 +15,7 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 		name          string
 		builder       ContainerBuilder
 		wantContainer *v1.Container
+		wantError     bool
 	}{
 		{
 			name: "defined, no task spec",
@@ -97,12 +98,18 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 				},
 			},
 			wantContainer: nil,
+			wantError:     true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			container, _ := tt.builder.CreateContainer(context.TODO())
+			container, err := tt.builder.CreateContainer(context.TODO())
 			require.Equal(t, tt.wantContainer, container)
+			if tt.wantError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
 		})
 	}
 }

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder_test.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder_test.go
@@ -17,9 +17,9 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 		wantContainer *v1.Container
 	}{
 		{
-			name: "defined, no",
+			name: "defined, no task spec",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: &v1.Container{
 						Image: "image",
 					},
@@ -32,12 +32,12 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 		{
 			name: "defined, adding context",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: &v1.Container{
 						Image: "image",
 					},
 				},
-				taskSpec: &v1alpha3.KeptnTaskSpec{
+				taskSpec: v1alpha3.KeptnTaskSpec{
 					Context: v1alpha3.TaskContext{
 						WorkloadName: "my-workload",
 					},
@@ -56,7 +56,7 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 		{
 			name: "defined, replacing context",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: &v1.Container{
 						Image: "image",
 						Env: []v1.EnvVar{
@@ -67,7 +67,7 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 						},
 					},
 				},
-				taskSpec: &v1alpha3.KeptnTaskSpec{
+				taskSpec: v1alpha3.KeptnTaskSpec{
 					Context: v1alpha3.TaskContext{
 						WorkloadName: "my-workload",
 					},
@@ -86,7 +86,7 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 		{
 			name: "nil",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: nil,
 				},
 			},
@@ -110,7 +110,7 @@ func TestContainerBuilder_CreateVolume(t *testing.T) {
 		{
 			name: "defined without volume",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: &v1.Container{
 						Image: "image",
 					},
@@ -121,7 +121,7 @@ func TestContainerBuilder_CreateVolume(t *testing.T) {
 		{
 			name: "defined with volume",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: &v1.Container{
 						Image: "image",
 						VolumeMounts: []v1.VolumeMount{
@@ -146,7 +146,7 @@ func TestContainerBuilder_CreateVolume(t *testing.T) {
 		{
 			name: "defined with volume and limits",
 			builder: ContainerBuilder{
-				containerSpec: &v1alpha3.ContainerSpec{
+				containerSpec: v1alpha3.ContainerSpec{
 					Container: &v1.Container{
 						Image: "image",
 						Resources: v1.ResourceRequirements{
@@ -219,7 +219,7 @@ func Test_GenerateVolumes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		builder := ContainerBuilder{
-			containerSpec: tt.spec,
+			containerSpec: *tt.spec,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, builder.generateVolume())
@@ -268,7 +268,7 @@ func Test_GetVolumeSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		builder := ContainerBuilder{
-			containerSpec: tt.spec,
+			containerSpec: *tt.spec,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, builder.getVolumeSource())

--- a/lifecycle-operator/controllers/lifecycle/keptntask/container_builder_test.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/container_builder_test.go
@@ -27,6 +27,12 @@ func TestContainerBuilder_CreateContainerWithVolumes(t *testing.T) {
 			},
 			wantContainer: &v1.Container{
 				Image: "image",
+				Env: []v1.EnvVar{
+					{
+						Name:  KeptnContextEnvVarName,
+						Value: `{"workloadName":"","appName":"","appVersion":"","workloadVersion":"","taskType":"","objectType":""}`,
+					},
+				},
 			},
 		},
 		{

--- a/lifecycle-operator/controllers/lifecycle/keptntask/job_runner_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/job_runner_builder.go
@@ -12,7 +12,7 @@ import (
 
 // JobRunnerBuilder is the interface that describes the operations needed to help build job specs of a task
 type JobRunnerBuilder interface {
-	// CreateContainerWithVolumes returns a job container and volumes based on the task definition spec
+	// CreateContainer returns a job container based on the task definition spec
 	CreateContainer(ctx context.Context) (*corev1.Container, error)
 	CreateVolume(ctx context.Context) (*corev1.Volume, error)
 }

--- a/lifecycle-operator/controllers/lifecycle/keptntask/runtime_builder.go
+++ b/lifecycle-operator/controllers/lifecycle/keptntask/runtime_builder.go
@@ -39,12 +39,13 @@ type RuntimeExecutionParams struct {
 }
 
 const (
-	Context           = "CONTEXT"
-	SecureData        = "SECURE_DATA"
-	Data              = "DATA"
-	CmdArgs           = "CMD_ARGS"
-	Script            = "SCRIPT"
-	FunctionMountName = "function-mount"
+	Context                = "CONTEXT"
+	KeptnContextEnvVarName = "KEPTN_CONTEXT"
+	SecureData             = "SECURE_DATA"
+	Data                   = "DATA"
+	CmdArgs                = "CMD_ARGS"
+	Script                 = "SCRIPT"
+	FunctionMountName      = "function-mount"
 )
 
 func (fb *RuntimeBuilder) CreateContainer(ctx context.Context) (*corev1.Container, error) {

--- a/test/integration/container-runtime/00-assert.yaml
+++ b/test/integration/container-runtime/00-assert.yaml
@@ -30,6 +30,19 @@ metadata:
     keptn.sh/app: waiter
     keptn.sh/version: '0.4'
     keptn.sh/workload: waiter-waiter
+spec:
+  template:
+    spec:
+      containers:
+        - name: testy-test
+          image: busybox:1.36.1
+          env:
+            - name: KEPTN_CONTEXT
+              value: ""
+          command:
+            - 'sh'
+            - '-c'
+            - 'sleep 30'
 status:
   conditions:
     - type: Complete

--- a/test/integration/container-runtime/00-assert.yaml
+++ b/test/integration/container-runtime/00-assert.yaml
@@ -38,7 +38,7 @@ spec:
           image: busybox:1.36.1
           env:
             - name: KEPTN_CONTEXT
-              value: ""
+              value: '{"workloadName":"waiter-waiter","appName":"waiter","appVersion":"","workloadVersion":"0.4","taskType":"pre","objectType":"Workload"}'
           command:
             - 'sh'
             - '-c'


### PR DESCRIPTION
Closes [#2483](https://github.com/keptn/lifecycle-toolkit/issues/2483)

Note: Renaming the environment variable for the other runtimes will be done in https://github.com/keptn/lifecycle-toolkit/issues/2491