### PR TITLE
feat(lifecycle-operator): add option to exclude additional namespaces

### DIFF
--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -9393,11 +9393,7 @@ webhooks:
       - lifecycle-operator
     - key: kubernetes.io/metadata.name
       operator: NotIn
-      values:
-      - cert-manager
-      - keptn-lifecycle-toolkit-system
-      - observability
-      - monitoring
+      values:  ["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -6719,11 +6719,7 @@ webhooks:
       - lifecycle-operator
     - key: kubernetes.io/metadata.name
       operator: NotIn
-      values:
-      - cert-manager
-      - keptn-lifecycle-toolkit-system
-      - observability
-      - monitoring
+      values:  ["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -6719,7 +6719,7 @@ webhooks:
       - lifecycle-operator
     - key: kubernetes.io/metadata.name
       operator: NotIn
-      values:  ["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]
+      values:  ["foo","bar"]
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:

--- a/.github/scripts/.helm-tests/lifecycle-only/values.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/values.yaml
@@ -14,6 +14,7 @@ lifecycleOperator:
   scheduler:
     image:
       tag: v0.0.0
+  deniedNamespaces: ["foo", "bar"]
 
 metricsOperator:
   enabled: false

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -6975,11 +6975,7 @@ webhooks:
       - lifecycle-operator
     - key: kubernetes.io/metadata.name
       operator: NotIn
-      values:
-      - cert-manager
-      - keptn-lifecycle-toolkit-system
-      - observability
-      - monitoring
+      values:  ["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]
     - key: kubernetes.io/metadata.name
       operator: NotIn
       values:

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -68,13 +68,14 @@ and application health checks
 
 ### Global
 
-| Name                      | Description                                                                                                                                     | Value           |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `kubernetesClusterDomain` | overrides cluster.local                                                                                                                         | `cluster.local` |
-| `annotations`             | add deployment level annotations                                                                                                                | `{}`            |
-| `podAnnotations`          | adds pod level annotations                                                                                                                      | `{}`            |
-| `schedulingGatesEnabled`  | enables the scheduling gates in lifecycle-operator. This feature is available in alpha version from K8s 1.27 or 1.26 enabling the alpha version | `false`         |
-| `allowedNamespaces`       | specifies the allowed namespaces for the lifecycle orchestration functionality                                                                  | `[]`            |
+| Name                      | Description                                                                                                                                     | Value                                                                            |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `kubernetesClusterDomain` | overrides cluster.local                                                                                                                         | `cluster.local`                                                                  |
+| `annotations`             | add deployment level annotations                                                                                                                | `{}`                                                                             |
+| `podAnnotations`          | adds pod level annotations                                                                                                                      | `{}`                                                                             |
+| `schedulingGatesEnabled`  | enables the scheduling gates in lifecycle-operator. This feature is available in alpha version from K8s 1.27 or 1.26 enabling the alpha version | `false`                                                                          |
+| `allowedNamespaces`       | specifies the allowed namespaces for the lifecycle orchestration functionality                                                                  | `[]`                                                                             |
+| `deniedNamespaces`        | specifies a list of namespaces where the lifecycle orchestration functionality is disabled, ignored if `allowedNamespaces`` is set              | `["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]` |
 
 ### Keptn Scheduler
 

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -75,7 +75,7 @@ and application health checks
 | `podAnnotations`          | adds pod level annotations                                                                                                                      | `{}`                                                                             |
 | `schedulingGatesEnabled`  | enables the scheduling gates in lifecycle-operator. This feature is available in alpha version from K8s 1.27 or 1.26 enabling the alpha version | `false`                                                                          |
 | `allowedNamespaces`       | specifies the allowed namespaces for the lifecycle orchestration functionality                                                                  | `[]`                                                                             |
-| `deniedNamespaces`        | specifies a list of namespaces where the lifecycle orchestration functionality is disabled, ignored if `allowedNamespaces`` is set              | `["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]` |
+| `deniedNamespaces`        | specifies a list of namespaces where the lifecycle orchestration functionality is disabled, ignored if `allowedNamespaces` is set               | `["cert-manager","keptn-lifecycle-toolkit-system","observability","monitoring"]` |
 
 ### Keptn Scheduler
 

--- a/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
+++ b/lifecycle-operator/chart/templates/lifecycle-mutating-webhook-configuration.yaml
@@ -28,11 +28,7 @@ webhooks:
 {{- if eq (len .Values.allowedNamespaces) 0 }}
     - key: kubernetes.io/metadata.name
       operator: NotIn
-      values:
-      - cert-manager
-      - keptn-lifecycle-toolkit-system
-      - observability
-      - monitoring
+      values:  {{ .Values.deniedNamespaces | default list | toJson }}
 {{- else }}
     - key: kubernetes.io/metadata.name
       operator: In

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -174,7 +174,7 @@ podAnnotations: {}
 schedulingGatesEnabled: false
 ## @param  allowedNamespaces specifies the allowed namespaces for the lifecycle orchestration functionality
 allowedNamespaces: []
-## @param  deniedNamespaces specifies a list of namespaces where the lifecycle orchestration functionality is disabled, ignored if `allowedNamespaces`` is set
+## @param  deniedNamespaces specifies a list of namespaces where the lifecycle orchestration functionality is disabled, ignored if `allowedNamespaces` is set
 deniedNamespaces:
   - cert-manager
   - keptn-lifecycle-toolkit-system

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -163,7 +163,7 @@ lifecycleOperatorMetricsService:
   type: ClusterIP
 
 ## @section Global
-## Current available parameters: kubernetesClusterDomain, imagePullSecrets, schedulingGatesEnabled
+## Current available parameters: kubernetesClusterDomain, imagePullSecrets, schedulingGatesEnabled, allowedNamespaces, deniedNamespaces
 ## @param     kubernetesClusterDomain overrides cluster.local
 kubernetesClusterDomain: cluster.local
 ## @param     annotations add deployment level annotations
@@ -174,6 +174,12 @@ podAnnotations: {}
 schedulingGatesEnabled: false
 ## @param  allowedNamespaces specifies the allowed namespaces for the lifecycle orchestration functionality
 allowedNamespaces: []
+## @param  deniedNamespaces specifies a list of namespaces where the lifecycle orchestration functionality is disabled, ignored if `allowedNamespaces`` is set
+deniedNamespaces:
+  - cert-manager
+  - keptn-lifecycle-toolkit-system
+  - observability
+  - monitoring
 
 # yamllint disable rule:line-length
 ## @section Keptn Scheduler


### PR DESCRIPTION
# Description

Adds the option an option to the `lifecycle-operator` chart to exclude namespaces  in the `MutatingWebhookConfiguration`. This is useful to prevent possible deadlocks with other mutating webhooks running in other namespace, which might also prevent pods from being started.

This change should not result in any unexpected changes for users when upgrading. It preserves the default values for the excluded namespaces and does not change the logic of `allowedNamespaces`. In my opinion it also adds the benefit to be more explicit about the namespaces ("cert-manager" etc.)  which are excluded by default right now.

Fixes #2512

# How to test

The change is rather trivial as it mimics the already implemented features. I only tested it manually by rendering the Helm Chart:

```
echo 'deniedNamespaces: ["foo"]' > test_values.yaml
helm template lifecycle-operator/chart -f test_values.yaml | yq e ' select(.kind == "MutatingWebhookConfiguration")'
```

I can try to add automated tests, but maybe someone could point me to the relevant ones (kuttl, helm-test...).

# Checklist

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [x] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [ ] New and existing unit and integration tests pass locally with my changes

# Summary
Adds the option an option to the `lifecycle-operator` chart to exclude namespaces  in the `MutatingWebhookConfiguration`. 

Fixes #2512
