### PR TITLE
docs: add links to official Grafana documentation for creating and modifying dashboards 

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -18,3 +18,4 @@ ignores:
   - "**/CHANGELOG.md"
   - "node_modules"
   - "docs/tmp"
+  - "readme-generator-for-helm"

--- a/dashboards/grafana/README.md
+++ b/dashboards/grafana/README.md
@@ -34,3 +34,17 @@ If you prefer to prepare the dashboards for the examples and importing them as j
 ```shell
 make import-json
 ```
+
+---
+
+## Guide to Custom Dashboards with Grafana
+
+This section provides links to the official Grafana documentation for creating and modifying custom dashboards using Grafana.
+
+## How to Create Custom Dashboards
+
+Craft personalized Grafana dashboards tailored to your specific needs by exploring the [official Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/). Discover detailed steps, best practices, and tips for creating visualizations, adding panels, utilizing various data sources, and more.
+
+## Modifying the Dashboards
+
+Refine and adapt visualizations in existing Grafana dashboards to meet evolving requirements. Visit the [relevant sections](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/modify-dashboard-settings/) of the Grafana documentation to gain insights on adjusting, enhancing, or reconfiguring dashboards efficiently. Learn about editing panels, incorporating new data sources, applying filters, and optimizing dashboard layouts.

--- a/dashboards/grafana/README.md
+++ b/dashboards/grafana/README.md
@@ -43,9 +43,14 @@ This section provides links to the official Grafana documentation for creating a
 
 ## How to Create Custom Dashboards
 
-Craft personalized Grafana dashboards tailored to your specific needs by exploring the [official Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/). Discover detailed steps, best practices, and tips for creating visualizations, adding panels, utilizing various data sources, and more.
+Craft personalized Grafana dashboards tailored to your specific needs by exploring the [official Grafana documentation](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/).
+Discover detailed steps, best practices, and tips for creating visualizations, adding panels,
+utilizing various data sources, and more.
 
 ## Modifying the Dashboards
 
-Refine and adapt visualizations in existing Grafana dashboards to meet evolving requirements. Visit the [relevant sections](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/modify-dashboard-settings/) of the Grafana documentation to gain insights on adjusting, enhancing, or reconfiguring dashboards efficiently. Learn about editing panels, incorporating new data sources, applying filters, and optimizing dashboard layouts.
-
+Refine and adapt visualizations in existing Grafana dashboards to meet evolving requirements.
+Visit the
+[relevant sections](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/modify-dashboard-settings/)
+of the Grafana documentation to gain insights on adjusting, enhancing, or reconfiguring dashboards efficiently.
+Learn about editing panels, incorporating new data sources, applying filters, and optimizing dashboard layouts.


### PR DESCRIPTION
This pull request adds links to the official Grafana documentation for creating and modifying dashboards in the README.md file.

Changes made:
- Added links to the relevant sections of the Grafana documentation.
- Ensured the links are accurate and functional.

Fixes #2538
