### PR TITLE
chore: use new search engine ID

### DIFF
--- a/docs/config/production/params.yaml
+++ b/docs/config/production/params.yaml
@@ -14,4 +14,4 @@ description: >-
 
 algolia_docsearch: false
 offlineSearch: false
-gcs_engine_id: '37a611225469c41ae' # needs to be replaced with a search engine ID from the keptn google account
+gcs_engine_id: '765817a15a3374e11'


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

This PR exchanges the previous google custom search engine for a new one that is owned by the keptnproject google account.

Fixes #2337