### PR TITLE
fix: xref to keptn-cert-manager repo

### DIFF
--- a/docs/content/en/contribute/software/dev-environ/_index.md
+++ b/docs/content/en/contribute/software/dev-environ/_index.md
@@ -24,7 +24,7 @@ To prepare to contribute to the Keptn project, we recommend that you:
   * [lifecycle-operator](https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator)
   * [metrics-operator](https://github.com/keptn/lifecycle-toolkit/tree/main/metrics-operator)
   * [scheduler](https://github.com/keptn/lifecycle-toolkit/tree/main/scheduler)
-  * [keptn-cert-manager](https://github.com/keptn/lifecycle-toolkit/tree/main/klt-cert-manager)
+  * [keptn-cert-manager](https://github.com/keptn/lifecycle-toolkit/tree/main/keptn-cert-manager)
 
   Each of these is described in the
   [Architecture](../../../docs/components/)


### PR DESCRIPTION
Fix xref to keptn-cert-manager repo