### PR TITLE
fix: changed jaeger to otlp

### DIFF
--- a/examples/support/observability/config/otel-collector.yaml
+++ b/examples/support/observability/config/otel-collector.yaml
@@ -26,7 +26,7 @@ data:
     extensions:
       health_check: {}
     exporters:
-      jaeger:
+      otlp:
         endpoint: "jaeger-collector:14250"
         tls:
           insecure: true
@@ -40,7 +40,7 @@ data:
         traces:
           receivers: [otlp]
           processors: []
-          exporters: [jaeger]
+          exporters: [otlp]
 
         metrics:
           receivers: [otlp,prometheus]


### PR DESCRIPTION
This pr fixes the broken opentelemetry collector, 
the bug was introduced by this renovate pr #2109
v0.85.0 removed jeager as exporter https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.85.0
for more info see here https://stackoverflow.com/questions/77475771/error-when-running-otel-collector-with-jaeger-in-docker-containers