### PR TITLE
docs: explain quantity data type for analysis targets

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -122,7 +122,6 @@ dario
 databranch
 datadog
 datasource
-datetime
 davidanson
 dawidd
 dco
@@ -145,7 +144,6 @@ docsembed
 docsy
 donath
 dql
-draggable
 DTAPI
 dtclient
 dupl
@@ -176,7 +174,6 @@ Eventqueue
 eventsender
 exampleuser
 fakeclient
-favicons
 fetchintervalseconds
 fieldpath
 fieldref
@@ -223,7 +220,6 @@ groupversion
 gstatic
 gtag
 GVK
-haspopup
 healthz
 hellopy
 helloworldtask
@@ -235,7 +231,6 @@ homeobservability
 homeorchestrate
 horizontalpodautoscalers
 hpa
-hreflang
 hsla
 htmltest
 httpref
@@ -272,7 +267,7 @@ ITarget
 itemstatus
 ITracer
 jaegertracing
-javascript
+javascripts
 jetstack
 jgehrcke
 Jhb
@@ -371,25 +366,20 @@ kustomizeconfig
 kuttl
 kwi
 kwv
-labelledby
 lastmod
 lastword
 Lato
 lfc
 Lifcycle
 lifecyclekeptnsh
-linecap
-linejoin
 linkedin
 linktitle
 linting
-listitem
 livenessprobe
 loadtests
 LOCALBIN
 logf
 logr
-lowbound
 makefiles
 markdownfiles
 markdownlint
@@ -432,7 +422,6 @@ myservice
 myuser
 myversion
 namespacedelete
-nbsp
 netlify
 Neue
 nifi
@@ -443,7 +432,6 @@ nodename
 nolint
 nonroot
 noreply
-nowrap
 nsa
 oac
 oauth
@@ -484,7 +472,6 @@ persistentvolumes
 phaseitem
 pid
 pipefail
-placeholders
 poc
 poddisruptionbudgets
 podgroups
@@ -590,7 +577,6 @@ storageclasses
 storageversion
 striptags
 sts
-stylesheet
 subchart
 subdir
 subjectaccessreviews
@@ -626,13 +612,10 @@ timeseries
 timespan
 timezone
 tmp
-tmpl
-toc
 tocstop
 tokenreviews
 toml
 totalscore
-tpl
 tplvalues
 traceparent
 tracerfactory
@@ -683,7 +666,6 @@ WORKLOADOVERALLSTATUS
 workloadsstate
 workloadstatus
 workloadversion
-xhtml
 xxxx
 XXXXXXXXXXXXXXXXXXXXXXXX
 yannh

--- a/docs-new/docs/guides/slo.md
+++ b/docs-new/docs/guides/slo.md
@@ -65,13 +65,13 @@ A Keptn Analysis is implemented with three resources:
   An `AnalysisDefinition` resource contains a list of objectives to satisfy.
   Each of these objectives must specify:
 
+  * The `AnalysisValueTemplate` resource that contains the SLIs,
+    defining the data provider from which to gather the data
+    and how to compute the Analysis
   * Failure or warning target criteria
   * Whether the objective is a key objective
     meaning that its failure fails the Analysis
   * Weight of the objective on the overall Analysis
-  * The `AnalysisValueTemplate` resource that contains the SLIs,
-    defining the data provider from which to gather the data
-    and how to compute the Analysis
 
 * [Analysis](../reference/crd-reference/analysis.md)
   define the specific configurations and the Analysis to report.
@@ -89,7 +89,7 @@ A Keptn Analysis is implemented with three resources:
 
 Consider the following `Analysis` resource:
 
-{% include "../assets/crd/analysis.yaml" %}
+{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysis.yaml" >}}
 
 This `Analysis` resource:
 
@@ -103,13 +103,20 @@ This `Analysis` resource:
 The `AnalysisDefinition` resource references this `Analysis` resource
 by its `name` and `namespace` and can be seen here:
 
-{% include "../assets/crd/analysis-definition.yaml" %}
+{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" >}}
 
 This simple definition contains a single objective, `response-time-p95`.
 For this objective, both failure and warning criteria are defined:
 
 * The objective fails if the percentile 95 is less than 600
 * A warning is issued when the value is between 300 and 500
+
+Use a Kubernetes
+[quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
+value for the value fields rather than a `float`.
+For example, use the `3m` quantity
+rather than the equivalent `0.003` float;
+the `float` value causes `Invalid value` errors.
 
 The total score shows that this `Analysis`
 should have an overall score of 90% to pass or 75% to get a warning.
@@ -119,7 +126,7 @@ this means that the analysis either passes with 100%
 or fails with 0% (slower response time).
 
 The objective points to the corresponding `AnalysisValueTemplate` resource:
-{% include "../assets/crd/analysis-template.yaml" %}
+{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisvaluetemplate.yaml" >}}
 
 This template defines a query to a provider called `prometheus`:
 

--- a/docs-new/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs-new/docs/reference/crd-reference/analysisdefinition.md
@@ -140,7 +140,7 @@ guide page.
 ## Files
 
 API reference:
-[AnalysisDefinition](../api-reference/metrics/v1beta1/_ndex.md#analysisdefinition)
+[AnalysisDefinition](../api-reference/metrics/v1beta1/index.md#analysisdefinition)
 
 ## Differences between versions
 

--- a/docs-new/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs-new/docs/reference/crd-reference/analysisdefinition.md
@@ -140,7 +140,7 @@ guide page.
 ## Files
 
 API reference:
-[AnalysisDefinition](../api-reference/metrics/v1beta1/_index.md#analysisdefinition)
+[AnalysisDefinition](../api-reference/metrics/v1beta1/_ndex.md#analysisdefinition)
 
 ## Differences between versions
 

--- a/docs-new/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs-new/docs/reference/crd-reference/analysisdefinition.md
@@ -14,27 +14,33 @@ metadata:
 spec:
   objectives:
     - analysisValueTemplateRef:
-        name: <name-of-referenced-analysisValueTemplateRef-resource>
-        namespace: <namespace-of-the-template-ref>
+        name: <name-of-referenced-analysisValueTemplate-resource>
+        namespace: <namespace-of-referenced-analysisValueTemplate-resource>
       target:
-        failure | warning:
+        failure:
           <operator>:
-            <operatorValue>: <quantity> |
-            <RangeValue>:
-                lowbound: <quantity>
-                highBound: <quantity>
+            fixedValue: <integer> | <quantity>
+          inRange: | notInRange:
+            lowBound: <integer> | <quantity>
+            highBound: <integer> | <quantity>
+        warning:
+          <operator>:
+            fixedValue: <integer> | <quantity>
+          inRange: | notInRange:
+            lowBound: <integer> | <quantity>
+            highBound: <integer> | <quantity>
       weight: <integer>
       keyObjective: <boolean>
   totalScore:
-    passPercentage: 90
-    warningPercentage: 75
+    passPercentage: <min-percentage-to-pass>
+    warningPercentage: <min-percentage-for-warning>
 ```
 
 ## Fields
 
 * **apiVersion** -- API version being used
 * **kind** -- Resource type.
-   Must be set to `AnalysisDefinition`.
+  Must be set to `AnalysisDefinition`.
 * **metadata**
   * **name** -- Unique name of this analysis definition.
     Names must comply with the
@@ -46,13 +52,13 @@ spec:
     unless it resides in the same namespace as the `Analysis` resource.
 * **spec**
   * **objectives**
-    This is a list of objectives whose results are combined
+    A list of objectives whose results are combined
     to determine whether the analysis fails, passes, or passes with a warning.
     * **analysisValueTemplateRef** (required) --
       This string marks the beginning of each objective
       * **name** (required) -- The `metadata.name` value of the
-      [AnalysisDefinition](analysisdefinition.md)
-      resource used for this objective.
+      [AnalysisValueTemplateRef](analysisvaluetemplate.md)
+      resource that defines the SLI used for this objective.
       That resource defines the data provider and the query to use.
       * **namespace** --
         Namespace of the `analysisValueTemplateRef` resource.
@@ -65,9 +71,17 @@ spec:
         of the
         [Analysis](analysis.md)
         resource after the analysis runs.
+
+        To use a value that includes a fraction, use a Kubernetes
+        [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
+        value rather than a `float`.
+        For example, use the `3m` quantity
+        rather than the `0.003` float;
+        a `float` value here causes `Invalid value` errors.
+        A whole number (integer) is also a legal `quantity` value.
         * **failure** -- criteria for failure, specified as
           `operator: <quantity>`.
-          This can be specified either as an absolute value
+          This can be specified either as an absolute `quantity` value
           or as a range of values.
 
           Valid operators for absolute values are:
@@ -83,15 +97,18 @@ spec:
 
             Each of these operators require two arguments:
 
-            * `lowBound` -- minimum value of the range included or excluded
-            * `highBound` -- maximum value of the range included or excluded
+            * `lowBound` -- minimum `quantity` value
+              of the range included or excluded
+            * `highBound` -- maximum `quantity` value
+              of the range included or excluded
         <!-- markdownlint-disable -->
         * **warning** -- criteria for a warning,
           specified in the same way as the `failure` field.
       * **weight**  -- used to emphasize the importance
         of one `objective` over others
       * **keyObjective** -- If set to `true`,
-        the entire analysis fails if this objective fails
+        the entire analysis fails if this particular objective fails,
+        no matter what the actual `score` of the analysis is
   * **totalScore** (required) --
     * **passPercentage** -- threshold to reach for the full analysis
       (all objectives) to pass
@@ -104,55 +121,26 @@ spec:
 An `AnalysisDefinition` resource contains a list of objectives to satisfy.
 Each of these objectives must specify:
 
+* The `AnalysisValueTemplate` resource that contains the SLIs,
+  defining the data provider from which to gather the data
+  and how to compute the Analysis
 * Failure or warning target criteria
 * Whether the objective is a key objective
   meaning that its failure fails the Analysis
 * Weight of the objective on the overall Analysis
-* The `AnalysisValueTemplate` resource that contains the SLIs,
-  defining the data provider from which to gather the data
-  and how to compute the Analysis
 
 ## Example
 
-```yaml
-apiVersion: metrics.keptn.sh/v1beta1
-kind: AnalysisDefinition
-metadata:
-  name: ed-my-proj-dev-svc1
-  namespace: keptn-system
-spec:
-  objectives:
-    - analysisValueTemplateRef:
-        name: response-time-p95
-        namespace: keptn-system
-      target:
-        failure:
-          <operator>:
-            fixedValue: integer> |
-            inRange: | notInRange:
-              lowBound: <integer-quantity>
-              highBound: <integer-quantity>
-        warning:
-          <operator>:
-            fixedValue: integer> |
-            inRange: | notInRange:
-              lowBound: <integer-quantity>
-              highBound: <integer-quantity>
-      weight: <integer>
-      keyObjective: <boolean>
-  totalScore:
-    passPercentage: <integer-percentage>
-    warningPercentage: <integer-percentage>
-```
+{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" >}}
 
-For an example of how to implement the Keptn Analysis feature, see the
+For a full example of how to implement the Keptn Analysis feature, see the
 [Analysis](../../guides/slo.md)
 guide page.
 
 ## Files
 
 API reference:
-[AnalysisDefinition](../api-reference/metrics/v1beta1/index.md#analysisdefinition)
+[AnalysisDefinition](../api-reference/metrics/v1beta1/_index.md#analysisdefinition)
 
 ## Differences between versions
 

--- a/docs/content/en/docs/guides/slo.md
+++ b/docs/content/en/docs/guides/slo.md
@@ -69,13 +69,13 @@ A Keptn Analysis is implemented with three resources:
   An `AnalysisDefinition` resource contains a list of objectives to satisfy.
   Each of these objectives must specify:
 
+  * The `AnalysisValueTemplate` resource that contains the SLIs,
+    defining the data provider from which to gather the data
+    and how to compute the Analysis
   * Failure or warning target criteria
   * Whether the objective is a key objective
     meaning that its failure fails the Analysis
   * Weight of the objective on the overall Analysis
-  * The `AnalysisValueTemplate` resource that contains the SLIs,
-    defining the data provider from which to gather the data
-    and how to compute the Analysis
 
 * [Analysis](../reference/crd-reference/analysis.md)
   define the specific configurations and the Analysis to report.

--- a/docs/content/en/docs/guides/slo.md
+++ b/docs/content/en/docs/guides/slo.md
@@ -115,6 +115,13 @@ For this objective, both failure and warning criteria are defined:
 * The objective fails if the percentile 95 is less than 600
 * A warning is issued when the value is between 300 and 500
 
+Use a Kubernetes
+[quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
+value for the value fields rather than a `float`.
+For example, use the `3m` quantity
+rather than the equivalent `0.003` float;
+the `float` value causes `Invalid value` errors.
+
 The total score shows that this `Analysis`
 should have an overall score of 90% to pass or 75% to get a warning.
 Since only one objective is defined,

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -19,7 +19,7 @@ spec:
   objectives:
     - analysisValueTemplateRef:
         name: <name-of-referenced-analysisValueTemplate-resource>
-        namespace: <namespace-of-referenced-analysisvalueTemplate-resource>
+        namespace: <namespace-of-referenced-analysisValueTemplate-resource>
       target:
         failure:
           <operator>:

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -29,7 +29,7 @@ spec:
             highBound: <integer> | <quantity>
         warning:
           <operator>:
-            fixedValue: <integer> | <quantity>]
+            fixedValue: <integer> | <quantity>
           inRange: | notInRange:
             lowBound: <integer> | <quantity>
             highBound: <integer> | <quantity>

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -139,7 +139,7 @@ spec:
       target:
         failure:
           <operator>:
-            fixedValue: <quantity> |
+            fixedValue: <integer-quantity> |
             inRange: | notInRange:
               lowBound: <integer-quantity>
               highBound: <integer-quantity>

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -19,7 +19,7 @@ spec:
   objectives:
     - analysisValueTemplateRef:
         name: <name-of-referenced-analysisValueTemplate-resource>
-        namespace: <namespace-of-referenced-analsisvalueTemplate-resource>
+        namespace: <namespace-of-referenced-analysisvalueTemplate-resource>
       target:
         failure:
           <operator>:

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -30,15 +30,15 @@ spec:
       weight: <integer>
       keyObjective: <boolean>
   totalScore:
-    passPercentage: 90
-    warningPercentage: 75
+    passPercentage: <min-percentage-to-pass>
+    warningPercentage: <min-percentage-for-warning>
 ```
 
 ## Fields
 
 * **apiVersion** -- API version being used
 * **kind** -- Resource type.
-   Must be set to `AnalysisDefinition`.
+  Must be set to `AnalysisDefinition`.
 * **metadata**
   * **name** -- Unique name of this analysis definition.
     Names must comply with the
@@ -69,6 +69,13 @@ spec:
         of the
         [Analysis](analysis.md)
         resource after the analysis runs.
+
+        Use a Kubernetes
+        [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
+        value for these fields rather than a `float`.
+        For example, use the `3m` quantity
+        rather than the nearly equivalent `0.003` float;
+        the `float` value causes `Invalid value` errors.
         * **failure** -- criteria for failure, specified as
           `operator: <quantity>`.
           This can be specified either as an absolute value
@@ -132,21 +139,21 @@ spec:
       target:
         failure:
           <operator>:
-            fixedValue: integer> |
+            fixedValue: <quantity> |
             inRange: | notInRange:
               lowBound: <integer-quantity>
               highBound: <integer-quantity>
         warning:
           <operator>:
-            fixedValue: integer> |
+            fixedValue: <quantity> |
             inRange: | notInRange:
               lowBound: <integer-quantity>
               highBound: <integer-quantity>
       weight: <integer>
       keyObjective: <boolean>
   totalScore:
-    passPercentage: <integer-percentage>
-    warningPercentage: <integer-percentage>
+    passPercentage: <min-percentage-to-pass>
+    warningPercentage: <min-percentage-for-warning>
 ```
 
 For an example of how to implement the Keptn Analysis feature, see the

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -70,12 +70,13 @@ spec:
         [Analysis](analysis.md)
         resource after the analysis runs.
 
-        Use a Kubernetes
+        To use a value that includes a fraction, use a Kubernetes
         [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
-        value for these fields rather than a `float`.
+        value rather than a `float`.
         For example, use the `3m` quantity
         rather than the nearly equivalent `0.003` float;
         the `float` value causes `Invalid value` errors.
+        A whole number (integer) is also a legal `quantity` value.
         * **failure** -- criteria for failure, specified as
           `operator: <quantity>`.
           This can be specified either as an absolute value
@@ -139,16 +140,16 @@ spec:
       target:
         failure:
           <operator>:
-            fixedValue: <integer-quantity> |
+            fixedValue: [<integer> | <quantity> |
             inRange: | notInRange:
-              lowBound: <integer-quantity>
-              highBound: <integer-quantity>
+              lowBound: <integer> | <quantity>
+              highBound: <integer> | <quantity>
         warning:
           <operator>:
-            fixedValue: <integer-quantity> |
+            fixedValue: [<integer> | <quantity>] |
             inRange: | notInRange:
-              lowBound: <integer-quantity>
-              highBound: <integer-quantity>
+              lowBound: <integer> | <quantity>
+              highBound: <integer> | <quantity>
       weight: <integer>
       keyObjective: <boolean>
   totalScore:

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -18,15 +18,21 @@ metadata:
 spec:
   objectives:
     - analysisValueTemplateRef:
-        name: <name-of-referenced-analysisValueTemplateRef-resource>
-        namespace: <namespace-of-the-template-ref>
+        name: <name-of-referenced-analysisValueTemplate-resource>
+        namespace: <namespace-of-referenced-analsisvalueTemplate-resource>
       target:
-        failure | warning:
+        failure:
           <operator>:
-            <operatorValue>: <quantity> |
-            <RangeValue>:
-                lowbound: <quantity>
-                highBound: <quantity>
+            fixedValue: <integer> | <quantity>
+          inRange: | notInRange:
+            lowBound: <integer> | <quantity>
+            highBound: <integer> | <quantity>
+        warning:
+          <operator>:
+            fixedValue: <integer> | <quantity>]
+          inRange: | notInRange:
+            lowBound: <integer> | <quantity>
+            highBound: <integer> | <quantity>
       weight: <integer>
       keyObjective: <boolean>
   totalScore:
@@ -50,13 +56,13 @@ spec:
     unless it resides in the same namespace as the `Analysis` resource.
 * **spec**
   * **objectives**
-    This is a list of objectives whose results are combined
+    A list of objectives whose results are combined
     to determine whether the analysis fails, passes, or passes with a warning.
     * **analysisValueTemplateRef** (required) --
       This string marks the beginning of each objective
       * **name** (required) -- The `metadata.name` value of the
-      [AnalysisDefinition](analysisdefinition.md)
-      resource used for this objective.
+      [AnalysisValueTemplateRef](analysisvaluetemplate.md)
+      resource that defines the SLI used for this objective.
       That resource defines the data provider and the query to use.
       * **namespace** --
         Namespace of the `analysisValueTemplateRef` resource.
@@ -74,12 +80,12 @@ spec:
         [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/)
         value rather than a `float`.
         For example, use the `3m` quantity
-        rather than the nearly equivalent `0.003` float;
-        the `float` value causes `Invalid value` errors.
+        rather than the `0.003` float;
+        a `float` value here causes `Invalid value` errors.
         A whole number (integer) is also a legal `quantity` value.
         * **failure** -- criteria for failure, specified as
           `operator: <quantity>`.
-          This can be specified either as an absolute value
+          This can be specified either as an absolute `quantity` value
           or as a range of values.
 
           Valid operators for absolute values are:
@@ -95,15 +101,18 @@ spec:
 
             Each of these operators require two arguments:
 
-            * `lowBound` -- minimum value of the range included or excluded
-            * `highBound` -- maximum value of the range included or excluded
+            * `lowBound` -- minimum `quantity` value
+              of the range included or excluded
+            * `highBound` -- maximum `quantity` value
+              of the range included or excluded
         <!-- markdownlint-disable -->
         * **warning** -- criteria for a warning,
           specified in the same way as the `failure` field.
       * **weight**  -- used to emphasize the importance
         of one `objective` over others
       * **keyObjective** -- If set to `true`,
-        the entire analysis fails if this objective fails
+        the entire analysis fails if this particular objective fails,
+        no matter what the actual `score` of the analysis is
   * **totalScore** (required) --
     * **passPercentage** -- threshold to reach for the full analysis
       (all objectives) to pass
@@ -116,48 +125,19 @@ spec:
 An `AnalysisDefinition` resource contains a list of objectives to satisfy.
 Each of these objectives must specify:
 
+* The `AnalysisValueTemplate` resource that contains the SLIs,
+  defining the data provider from which to gather the data
+  and how to compute the Analysis
 * Failure or warning target criteria
 * Whether the objective is a key objective
   meaning that its failure fails the Analysis
 * Weight of the objective on the overall Analysis
-* The `AnalysisValueTemplate` resource that contains the SLIs,
-  defining the data provider from which to gather the data
-  and how to compute the Analysis
 
 ## Example
 
-```yaml
-apiVersion: metrics.keptn.sh/v1beta1
-kind: AnalysisDefinition
-metadata:
-  name: ed-my-proj-dev-svc1
-  namespace: keptn-system
-spec:
-  objectives:
-    - analysisValueTemplateRef:
-        name: response-time-p95
-        namespace: keptn-system
-      target:
-        failure:
-          <operator>:
-            fixedValue: [<integer> | <quantity> |
-            inRange: | notInRange:
-              lowBound: <integer> | <quantity>
-              highBound: <integer> | <quantity>
-        warning:
-          <operator>:
-            fixedValue: [<integer> | <quantity>] |
-            inRange: | notInRange:
-              lowBound: <integer> | <quantity>
-              highBound: <integer> | <quantity>
-      weight: <integer>
-      keyObjective: <boolean>
-  totalScore:
-    passPercentage: <min-percentage-to-pass>
-    warningPercentage: <min-percentage-for-warning>
-```
+{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" >}}
 
-For an example of how to implement the Keptn Analysis feature, see the
+For a full example of how to implement the Keptn Analysis feature, see the
 [Analysis](../../guides/slo.md)
 guide page.
 

--- a/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/content/en/docs/reference/crd-reference/analysisdefinition.md
@@ -145,7 +145,7 @@ spec:
               highBound: <integer-quantity>
         warning:
           <operator>:
-            fixedValue: <quantity> |
+            fixedValue: <integer-quantity> |
             inRange: | notInRange:
               lowBound: <integer-quantity>
               highBound: <integer-quantity>


### PR DESCRIPTION
# Summary
Explains the use of Kubernetes `quantity` type rather than `float` for values specified for values in the `target` specification.

Fixes https://github.com/keptn/lifecycle-toolkit/issues/2610

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [ n/a] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
