### PR TITLE
chore: clean up unused volumes

### DIFF
--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -9106,11 +9106,6 @@ spec:
           runAsUser: 65532
           seccompProfile:
             type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
-        - mountPath: /tmp/metrics-adapter/serving-certs
-          name: adapter-certs-dir
         livenessProbe:
           httpGet:
             path: /healthz
@@ -9128,11 +9123,6 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
-      volumes:
-      - emptyDir: {}
-        name: certs-dir
-      - emptyDir: {}
-        name: adapter-certs-dir
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
 apiVersion: apps/v1
@@ -9305,8 +9295,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
         - mountPath: /tmp/metrics-adapter/serving-certs
           name: adapter-certs-dir
         livenessProbe:
@@ -9327,8 +9315,6 @@ spec:
       serviceAccountName: metrics-operator
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: certs-dir
       - emptyDir: {}
         name: adapter-certs-dir
 ---

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -6593,11 +6593,6 @@ spec:
           runAsUser: 65532
           seccompProfile:
             type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
-        - mountPath: /tmp/metrics-adapter/serving-certs
-          name: adapter-certs-dir
         livenessProbe:
           httpGet:
             path: /healthz
@@ -6615,11 +6610,6 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
-      volumes:
-      - emptyDir: {}
-        name: certs-dir
-      - emptyDir: {}
-        name: adapter-certs-dir
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
 apiVersion: apps/v1

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -6849,11 +6849,6 @@ spec:
           runAsUser: 65532
           seccompProfile:
             type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
-        - mountPath: /tmp/metrics-adapter/serving-certs
-          name: adapter-certs-dir
         livenessProbe:
           httpGet:
             path: /healthz
@@ -6871,11 +6866,6 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
-      volumes:
-      - emptyDir: {}
-        name: certs-dir
-      - emptyDir: {}
-        name: adapter-certs-dir
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
 apiVersion: apps/v1

--- a/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
@@ -2327,8 +2327,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
         - mountPath: /tmp/metrics-adapter/serving-certs
           name: adapter-certs-dir
         livenessProbe:
@@ -2349,8 +2347,6 @@ spec:
       serviceAccountName: metrics-operator
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: certs-dir
       - emptyDir: {}
         name: adapter-certs-dir
 ---

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -2348,8 +2348,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
         - mountPath: /tmp/metrics-adapter/serving-certs
           name: adapter-certs-dir
         livenessProbe:
@@ -2370,8 +2368,6 @@ spec:
       serviceAccountName: metrics-operator
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: certs-dir
       - emptyDir: {}
         name: adapter-certs-dir
 ---

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -2604,8 +2604,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
         - mountPath: /tmp/metrics-adapter/serving-certs
           name: adapter-certs-dir
         livenessProbe:
@@ -2626,8 +2624,6 @@ spec:
       serviceAccountName: metrics-operator
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: certs-dir
       - emptyDir: {}
         name: adapter-certs-dir
 ---

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -130,11 +130,6 @@ spec:
             }}
           seccompProfile: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleOperator.containerSecurityContext.seccompProfile
             "context" $) | nindent 12 }}
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
-        - mountPath: /tmp/metrics-adapter/serving-certs
-          name: adapter-certs-dir
         {{- if .Values.lifecycleOperator.livenessProbe }}
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleOperator.livenessProbe "context" $) | nindent 10 }}
          {{- else }}
@@ -160,11 +155,6 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
-      volumes:
-      - emptyDir: {}
-        name: certs-dir
-      - emptyDir: {}
-        name: adapter-certs-dir
 {{- if .Values.lifecycleOperator.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleOperator.topologySpreadConstraints "context" $) | nindent 8 }}
 {{- end }}

--- a/lifecycle-operator/config/manager/manager.yaml
+++ b/lifecycle-operator/config/manager/manager.yaml
@@ -31,11 +31,6 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
-      volumes:
-        - emptyDir: {}
-          name: certs-dir
-        - emptyDir: {}
-          name: adapter-certs-dir
       containers:
         - command:
             - /manager
@@ -118,10 +113,5 @@ spec:
             requests:
               cpu: 5m
               memory: 64Mi
-          volumeMounts:
-            - name: certs-dir
-              mountPath: /tmp/k8s-webhook-server/serving-certs/
-            - name: adapter-certs-dir
-              mountPath: /tmp/metrics-adapter/serving-certs
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10

--- a/metrics-operator/chart/templates/deployment.yaml
+++ b/metrics-operator/chart/templates/deployment.yaml
@@ -87,8 +87,6 @@ spec:
           seccompProfile: {{- include "common.tplvalues.render" (dict "value" .Values.containerSecurityContext.seccompProfile
             "context" $) | nindent 12 }}
         volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs/
-          name: certs-dir
         - mountPath: /tmp/metrics-adapter/serving-certs
           name: adapter-certs-dir
         {{- if .Values.livenessProbe }}
@@ -117,8 +115,6 @@ spec:
       serviceAccountName: metrics-operator
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: certs-dir
       - emptyDir: {}
         name: adapter-certs-dir
 {{- if .Values.topologySpreadConstraints }}

--- a/metrics-operator/config/manager/manager.yaml
+++ b/metrics-operator/config/manager/manager.yaml
@@ -38,8 +38,6 @@ spec:
         #   type: RuntimeDefault
       volumes:
         - emptyDir: {}
-          name: certs-dir
-        - emptyDir: {}
           name: adapter-certs-dir
       containers:
         - command:
@@ -114,8 +112,6 @@ spec:
               cpu: 10m
               memory: 64Mi
           volumeMounts:
-            - name: certs-dir
-              mountPath: /tmp/k8s-webhook-server/serving-certs/
             - name: adapter-certs-dir
               mountPath: /tmp/metrics-adapter/serving-certs
       serviceAccountName: metrics-operator


### PR DESCRIPTION
Some volumes in lifecycle-operator and metrics-operator  Deployments are not used, we can remove them