### PR TITLE
docs: add content to all section index pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,10 @@ docs-build:
 	docker run --rm -it -v ${PWD}/docs-new:/docs-new \
 		-v ${PWD}/mkdocs.yml:/mkdocs.yml \
 		-v ${PWD}/requirements.txt:/requirements.txt \
+		-v ${PWD}/.git:/.git \
 		--entrypoint "" \
 		${MKDOCS_DOCKER_IMAGE}:${MKDOCS_DOCKER_IMAGE_VERSION} \
-		sh -c 'cd /; pip install -r requirements.txt -q; mkdocs build -q'
+		sh -c 'cd /; pip install -r requirements.txt -q; mkdocs build'
 
 .PHONY: docs-serve
 docs-serve:
@@ -157,6 +158,7 @@ docs-serve:
 		-v ${PWD}/docs-new:/docs-new \
 		-v ${PWD}/mkdocs.yml:/mkdocs.yml \
 		-v ${PWD}/requirements.txt:/requirements.txt \
+		-v ${PWD}/.git:/.git \
 		--entrypoint "" \
 		${MKDOCS_DOCKER_IMAGE}:${MKDOCS_DOCKER_IMAGE_VERSION} \
 		sh -c 'cd /; pip install -r requirements.txt -q; mkdocs serve -a 0.0.0.0:8000'

--- a/docs-new/docs/components/index.md
+++ b/docs-new/docs/components/index.md
@@ -4,7 +4,7 @@
 
 Keptn consists of the following main components:
 
-* [Keptn Lifecycle Operator](./lifecycle-operator)
+* [Keptn Lifecycle Operator](./lifecycle-operator/index.md)
 * [Keptn Metrics Operator](./metrics-operator.md)
 * [Keptn Scheduler](./scheduling.md)
 * [Keptn Certificate Manager](./certificate-operator.md)

--- a/docs-new/docs/components/index.md
+++ b/docs-new/docs/components/index.md
@@ -2,23 +2,9 @@
 
 ## Keptn Components
 
-Keptn consists of two main components:
+Keptn consists of the following main components:
 
-* Keptn Lifecycle Operator, which splits into two separate operators
-  in Release 0.7.0 and later:
-  * Lifecycle-Operator
-  * Metrics-Operator
-* Keptn Lifecycle Scheduler
-
-```mermaid
-graph TD;
-    KeptnComponents-->Operators;
-    KeptnComponents-->Scheduler
-   Operators-->Lifecycle-Operator
-   Operators-->Metrics-Operator
-style KeptnComponents fill:#006bb8,stroke:#fff,stroke-width:px,color:#fff
-style Operators fill:#d8e6f4,stroke:#fff,stroke-width:px,color:#006bb8
-style Scheduler fill:#d8e6f4,stroke:#fff,stroke-width:px,color:#006bb8
-style Lifecycle-Operator fill:#d8e6f4,stroke:#fff,stroke-width:px,color:#006bb8
-style Metrics-Operator fill:#d8e6f4,stroke:#fff,stroke-width:px,color:#006bb8
-```
+* [Keptn Lifecycle Operator](./lifecycle-operator)
+* [Keptn Metrics Operator](./metrics-operator.md)
+* [Keptn Scheduler](./scheduling.md)
+* [Keptn Certificate Manager](./certificate-operator.md)

--- a/docs-new/docs/getting-started/index.md
+++ b/docs-new/docs/getting-started/index.md
@@ -1,3 +1,5 @@
 # Get started
 
-This section will guide you through some tutorials that show how to bootstrap and use Keptn.
+This section provides tutorials to familiarize you
+with some basic Keptin features
+and point you to other documentation that has more comprehensive information.

--- a/docs-new/docs/getting-started/index.md
+++ b/docs-new/docs/getting-started/index.md
@@ -1,1 +1,3 @@
 # Get started
+
+This section will guide you through some tutorials that show how to bootstrap and use Keptn.

--- a/docs-new/docs/getting-started/index.md
+++ b/docs-new/docs/getting-started/index.md
@@ -1,5 +1,5 @@
 # Get started
 
 This section provides tutorials to familiarize you
-with some basic Keptin features
+with some basic Keptn features
 and point you to other documentation that has more comprehensive information.

--- a/docs-new/docs/guides/index.md
+++ b/docs-new/docs/guides/index.md
@@ -1,1 +1,3 @@
 # Guides
+
+This section will help you with guides about specific features of Keptn.

--- a/docs-new/docs/guides/index.md
+++ b/docs-new/docs/guides/index.md
@@ -1,3 +1,3 @@
 # Guides
 
-This section will help you with guides about specific features of Keptn.
+This section provides comprehensive guides about specific features of Keptn.

--- a/docs-new/docs/index.md
+++ b/docs-new/docs/index.md
@@ -1,3 +1,8 @@
 # Keptn Documentation
 
 This is the documentation homepage.
+If you are new to Keptn, please check out the following sections:
+
+- [Core Concepts](./core-concepts) will help you understand what Keptn is all about
+- [Get Started](./getting-started) will help you get going with your first use cases for Keptn
+- [Installation](./installation) will guide you through the installation procedure of Keptn

--- a/docs-new/docs/index.md
+++ b/docs-new/docs/index.md
@@ -5,4 +5,16 @@ If you are new to Keptn, please check out the following sections:
 
 - [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about
 - [Get Started](./getting-started/index.md) helps you get going with your first use cases for Keptn
-- [Installation](./installation/index.md) will guide you through the installation procedure of Keptn
+- [Installation](./installation/index.md) guides you through
+the installation procedure for Keptn
+and provides information about special configuration options
+that are available.
+- [Guides](../guides/index.md) provide detailed and comprehensive how-to information
+for Keptn features and capabilities.
+- [Reference](../reference/index.md) provides comprehensive information
+about the CRDs and APIs that define how Keptn behaves.
+- [Components](../components/index.md) provides architectural information
+about how Keptn functionality is implemented
+for people who want a deeper understanding of Keptn
+or who need this information to troubleshoot their systems.
+It also includes information about updating and uninstalling Keptn.

--- a/docs-new/docs/index.md
+++ b/docs-new/docs/index.md
@@ -9,11 +9,11 @@ If you are new to Keptn, please check out the following sections:
 the installation procedure for Keptn
 and provides information about special configuration options
 that are available.
-- [Guides](../guides/index.md) provide detailed and comprehensive how-to information
+- [Guides](guides/index.md) provides detailed and comprehensive how-to information
 for Keptn features and capabilities.
-- [Reference](../reference/index.md) provides comprehensive information
+- [Reference](reference/index.md) provides comprehensive information
 about the CRDs and APIs that define how Keptn behaves.
-- [Components](../components/index.md) provides architectural information
+- [Components](components/index.md) provides architectural information
 about how Keptn functionality is implemented
 for people who want a deeper understanding of Keptn
 or who need this information to troubleshoot their systems.

--- a/docs-new/docs/index.md
+++ b/docs-new/docs/index.md
@@ -3,6 +3,6 @@
 This is the documentation homepage.
 If you are new to Keptn, please check out the following sections:
 
-- [Core Concepts](./core-concepts) will help you understand what Keptn is all about
-- [Get Started](./getting-started) will help you get going with your first use cases for Keptn
-- [Installation](./installation) will guide you through the installation procedure of Keptn
+- [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about
+- [Get Started](./getting-started/index.md) will help you get going with your first use cases for Keptn
+- [Installation](./installation/index.md) will guide you through the installation procedure of Keptn

--- a/docs-new/docs/index.md
+++ b/docs-new/docs/index.md
@@ -4,5 +4,5 @@ This is the documentation homepage.
 If you are new to Keptn, please check out the following sections:
 
 - [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about
-- [Get Started](./getting-started/index.md) will help you get going with your first use cases for Keptn
+- [Get Started](./getting-started/index.md) helps you get going with your first use cases for Keptn
 - [Installation](./installation/index.md) will guide you through the installation procedure of Keptn

--- a/docs-new/docs/installation/configuration/index.md
+++ b/docs-new/docs/installation/configuration/index.md
@@ -1,1 +1,4 @@
 # Configuration
+
+This section contains guides for specific configuration use cases for Keptn.
+Those will help you adjust settings that need to be set at installation time.

--- a/docs-new/docs/reference/api-reference/lifecycle/index.md
+++ b/docs-new/docs/reference/api-reference/lifecycle/index.md
@@ -1,1 +1,3 @@
 # Lifecycle API
+
+Reference information about the Lifecycle API.

--- a/docs-new/docs/reference/api-reference/metrics/index.md
+++ b/docs-new/docs/reference/api-reference/metrics/index.md
@@ -1,1 +1,3 @@
 # Metrics API
+
+Reference information about the Metrics API.

--- a/docs-new/docs/reference/api-reference/options/index.md
+++ b/docs-new/docs/reference/api-reference/options/index.md
@@ -1,1 +1,3 @@
 # Options API
+
+Reference information about the Options API.

--- a/docs-new/docs/reference/index.md
+++ b/docs-new/docs/reference/index.md
@@ -2,7 +2,8 @@
 
 This section of the Keptn documentation contains reference documentation for the various APIs and CRDs that are used in Keptn.
 
-If you want to learn more about specific Custom Resource Definitions, go to the [CRD Reference](./crd-reference/index.md) section.
+If you want to learn more about specific Custom Resource Definitions, go to the
+[CRD Reference](./crd-reference/index.md) section.
 
 If you want to look up some specific object properties or want ot know more about the internal APIs of Keptn,
 Go to the [API Reference](./api-reference/index.md) section.

--- a/docs-new/docs/reference/index.md
+++ b/docs-new/docs/reference/index.md
@@ -2,7 +2,7 @@
 
 This section of the Keptn documentation contains reference documentation for the various APIs and CRDs that are used in Keptn.
 
-If you want to learn more about specific Custom Resource Definitions, go to the [CRD Reference](./crd-reference) section.
+If you want to learn more about specific Custom Resource Definitions, go to the [CRD Reference](./crd-reference/index.md) section.
 
 If you want to look up some specific object properties or want ot know more about the internal APIs of Keptn,
-Go to the [API Reference](./api-reference) section.
+Go to the [API Reference](./api-reference/index.md) section.

--- a/docs-new/docs/reference/index.md
+++ b/docs-new/docs/reference/index.md
@@ -2,7 +2,9 @@
 
 This section of the Keptn documentation contains reference documentation for the various APIs and CRDs that are used in Keptn.
 
-If you want to learn more about specific Custom Resource Definitions, go to the
+If you want to learn more about specific Custom Resource Definitions
+that you may need to populate to use Keptn,
+go to the
 [CRD Reference](./crd-reference/index.md) section.
 
 If you want to look up some specific object properties or want ot know more about the internal APIs of Keptn,

--- a/docs-new/docs/reference/index.md
+++ b/docs-new/docs/reference/index.md
@@ -1,3 +1,8 @@
 # Reference
 
-This section of the Keptn documentation contains reference documentation.
+This section of the Keptn documentation contains reference documentation for the various APIs and CRDs that are used in Keptn.
+
+If you want to learn more about specific Custom Resource Definitions, go to the [CRD Reference](./crd-reference) section.
+
+If you want to look up some specific object properties or want ot know more about the internal APIs of Keptn,
+Go to the [API Reference](./api-reference) section.

--- a/docs-new/docs/use-cases/index.md
+++ b/docs-new/docs/use-cases/index.md
@@ -1,1 +1,3 @@
 # Use Cases
+
+This section contains specific use cases and integration scenarios with other Cloud Native tools.


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

This PR adds basic content to all section index pages so that users are not presented with empty pages.

Fixes #2586 
