### PR TITLE
docs: remove k8s job from word list examples

### DIFF
--- a/docs-new/docs/contribute/docs/word-list.md
+++ b/docs-new/docs/contribute/docs/word-list.md
@@ -58,7 +58,7 @@ Here are some guidelines for using these terms in Keptn documentation.
   We should not be maintaining documentation
   for software in other projects and products.
 
-* Kubernetes concepts and objects (such as workload, job, resource)
+* Kubernetes concepts and objects (such as workload or resource)
   should be lowercase unless they are the proper name of an object.
 
 * The first instance of one of these terms in a section

--- a/docs/content/en/contribute/docs/word-list/_index.md
+++ b/docs/content/en/contribute/docs/word-list/_index.md
@@ -62,7 +62,7 @@ Here are some guidelines for using these terms in Keptn documentation.
   We should not be maintaining documentation
   for software in other projects and products.
 
-* Kubernetes concepts and objects (such as workload, job, resource)
+* Kubernetes concepts and objects (such as workload or resource)
   should be lowercase unless they are the proper name of an object.
 
 * The first instance of one of these terms in a section


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

This PR removes the k8s job as an example for lower case general k8s terms. This is needed, because a k8s Job is actually the proper name for the [k8s Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) object so it's not a good example here.