### PR TITLE
feat: introduce block-deployment Configuration Option

### DIFF
--- a/lifecycle-operator/apis/options/v1alpha1/keptnconfig_types.go
+++ b/lifecycle-operator/apis/options/v1alpha1/keptnconfig_types.go
@@ -41,6 +41,7 @@ type KeptnConfigSpec struct {
 	// CloudEventsEndpoint can be used to set the endpoint where Cloud Events should be posted by the lifecycle operator
 	// +optional
 	CloudEventsEndpoint string `json:"cloudEventsEndpoint,omitempty"`
+	BlockDeployment     bool   `json:"blockDeployment, omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -56,7 +57,8 @@ type KeptnConfig struct {
 	Spec KeptnConfigSpec `json:"spec,omitempty"`
 	// unused field
 	// +optional
-	Status string `json:"status,omitempty"`
+	Status          string `json:"status,omitempty"`
+	BlockDeployment bool   `json:"block-deployment,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/lifecycle-operator/controllers/common/config/config.go
+++ b/lifecycle-operator/controllers/common/config/config.go
@@ -5,7 +5,10 @@ import (
 	"time"
 )
 
-const defaultKeptnAppCreationRequestTimeout = 30 * time.Second
+const (
+	defaultKeptnAppCreationRequestTimeout = 30 * time.Second
+	defaultBlockDeployment                = true
+)
 
 //go:generate moq -pkg fake -skip-ensure -out ./fake/config_mock.go . IConfig:MockConfig
 type IConfig interface {
@@ -15,12 +18,15 @@ type IConfig interface {
 	GetCloudEventsEndpoint() string
 	SetDefaultNamespace(namespace string)
 	GetDefaultNamespace() string
+	SetBlockDeployment(blockDeployment bool)
+	GetBlockDeployment() bool
 }
 
 type ControllerConfig struct {
 	keptnAppCreationRequestTimeout time.Duration
 	cloudEventsEndpoint            string
 	defaultNamespace               string
+	blockDeployment                bool
 }
 
 var instance *ControllerConfig
@@ -28,7 +34,10 @@ var once = sync.Once{}
 
 func Instance() *ControllerConfig {
 	once.Do(func() {
-		instance = &ControllerConfig{keptnAppCreationRequestTimeout: defaultKeptnAppCreationRequestTimeout}
+		instance = &ControllerConfig{
+			keptnAppCreationRequestTimeout: defaultKeptnAppCreationRequestTimeout,
+			blockDeployment:                defaultBlockDeployment,
+		}
 	})
 	return instance
 }
@@ -55,4 +64,12 @@ func (o *ControllerConfig) SetDefaultNamespace(ns string) {
 
 func (o *ControllerConfig) GetDefaultNamespace() string {
 	return o.defaultNamespace
+}
+
+func (o *ControllerConfig) SetBlockDeployment(blockDeployment bool) {
+	o.blockDeployment = blockDeployment
+}
+
+func (o *ControllerConfig) GetBlockDeployment() bool {
+	return o.blockDeployment
 }

--- a/lifecycle-operator/controllers/options/keptnconfig_controller.go
+++ b/lifecycle-operator/controllers/options/keptnconfig_controller.go
@@ -73,6 +73,12 @@ func (r *KeptnConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.initConfig()
 	}
 
+	if r.LastAppliedSpec.BlockDeployment != cfg.Spec.BlockDeployment {
+		r.Log.Info("BlockDeployment configuration changed. Updating Controller Logic")
+
+		r.config.SetBlockDeployment(cfg.Spec.BlockDeployment)
+	}
+
 	// reconcile config values
 	r.config.SetCreationRequestTimeout(time.Duration(cfg.Spec.KeptnAppCreationRequestTimeoutSeconds) * time.Second)
 	r.config.SetCloudEventsEndpoint(cfg.Spec.CloudEventsEndpoint)


### PR DESCRIPTION
Fixes #1934

## Description

This PR addresses #1934 , introducing a new configuration option, block-deployment, in KeptnConfig. By default, it's set to true. When false, pre-checks won't block deployments, providing users with more flexibility.
## Changes:

- [X] Addition of a new configuration option, block-deployment, in KeptnConfig default value set to true.
- [X] Logic implemented to control the status of WorkloadInstance based on the value of block-deployment.


