### PR TITLE
chore: disable certmanager secret check when certmanager is not enabled.

### DIFF
--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -104,6 +104,9 @@ spec:
             }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
+        - name: CERT_MANAGER_ENABLED
+          value: {{ .Values.certManager.enabled | quote
+            }}
         image: {{ include "common.images.image" ( dict "imageRoot" .Values.lifecycleOperator.image "global" .Values.global ) }}
         imagePullPolicy: {{ .Values.lifecycleOperator.imagePullPolicy }}
         name: lifecycle-operator

--- a/lifecycle-operator/main.go
+++ b/lifecycle-operator/main.go
@@ -102,6 +102,8 @@ type envConfig struct {
 	KeptnOptionsControllerLogLevel            int `envconfig:"OPTIONS_CONTROLLER_LOG_LEVEL" default:"0"`
 
 	SchedulingGatesEnabled bool `envconfig:"SCHEDULING_GATES_ENABLED" default:"false"`
+
+	CertManagerEnabled bool `envconfig:"CERT_MANAGER_ENABLED" default:"false"`
 }
 
 const KeptnLifecycleActiveMetric = "keptn_lifecycle_active"
@@ -399,7 +401,7 @@ func main() {
 	// Set the metric value as soon as the operator starts
 	setupLog.Info("Keptn lifecycle-operator is alive")
 	keptnLifecycleActive.Add(context.Background(), 1)
-	if !disableWebhook {
+	if !disableWebhook && env.CertManagerEnabled {
 		webhookBuilder = webhookBuilder.SetCertificateWatcher(
 			certificates.NewCertificateWatcher(
 				mgr.GetAPIReader(),

--- a/lifecycle-operator/main.go
+++ b/lifecycle-operator/main.go
@@ -103,7 +103,7 @@ type envConfig struct {
 
 	SchedulingGatesEnabled bool `envconfig:"SCHEDULING_GATES_ENABLED" default:"false"`
 
-	CertManagerEnabled bool `envconfig:"CERT_MANAGER_ENABLED" default:"false"`
+	CertManagerEnabled bool `envconfig:"CERT_MANAGER_ENABLED" default:"true"`
 }
 
 const KeptnLifecycleActiveMetric = "keptn_lifecycle_active"

--- a/metrics-operator/chart/templates/deployment.yaml
+++ b/metrics-operator/chart/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
             }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
+        - name: CERT_MANAGER_ENABLED
+          value: {{ .Values.certManager.enabled | quote
+            }}
         image: {{- include "common.images.image" ( dict "imageRoot" .Values.image "global" .Values.global ) | indent 1}}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: metrics-operator

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -73,7 +73,7 @@ type envConfig struct {
 	AnalysisControllerLogLevel    int    `envconfig:"ANALYSIS_CONTROLLER_LOG_LEVEL" default:"0"`
 	ExposeKeptnMetrics            bool   `envconfig:"EXPOSE_KEPTN_METRICS" default:"true"`
 	EnableCustomMetricsAPIService bool   `envconfig:"ENABLE_CUSTOM_METRICS_API_SERVICE" default:"true"`
-	CertManagerEnabled            bool   `envconfig:"CERT_MANAGER_ENABLED" default:"false"`
+	CertManagerEnabled            bool   `envconfig:"CERT_MANAGER_ENABLED" default:"true"`
 }
 
 //nolint:gocyclo,funlen

--- a/metrics-operator/main.go
+++ b/metrics-operator/main.go
@@ -73,6 +73,7 @@ type envConfig struct {
 	AnalysisControllerLogLevel    int    `envconfig:"ANALYSIS_CONTROLLER_LOG_LEVEL" default:"0"`
 	ExposeKeptnMetrics            bool   `envconfig:"EXPOSE_KEPTN_METRICS" default:"true"`
 	EnableCustomMetricsAPIService bool   `envconfig:"ENABLE_CUSTOM_METRICS_API_SERVICE" default:"true"`
+	CertManagerEnabled            bool   `envconfig:"CERT_MANAGER_ENABLED" default:"false"`
 }
 
 //nolint:gocyclo,funlen
@@ -167,7 +168,7 @@ func main() {
 	}
 
 	var webhookBuilder certwebhook.Builder
-	if !disableWebhook {
+	if !disableWebhook && env.CertManagerEnabled {
 		webhookBuilder = certwebhook.NewWebhookServerBuilder().
 			LoadCertOptionsFromFlag().
 			SetPort(9443).


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description



Hi, I am trying to understand this issue hence made this Draft. 

**I was wondering what is the proper way to get this [values.yml](https://github.com/keptn/lifecycle-toolkit/blob/main/chart/values.yaml) into the templates of `lifecycle` and `metrics` operator.**


Fixes #2634 



- [ ] Manual Test A
- [ ] Unit Test B
- [ ] Integration Test C

# Checklist

- [ ] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [ ] I used descriptive commit messages to help reviewers understand my thought process
- [ ] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [ ] New and existing unit and integration tests pass locally with my changes


