### PR TITLE
docs: fix the navigation to Keptn v1 Docs

### DIFF
--- a/docs/config/_default/config.yaml
+++ b/docs/config/_default/config.yaml
@@ -39,7 +39,7 @@ menu:
     - name: Keptn v1
       params:
         rel: external
-      url: https://v1.keptn.sh/
+      url: https://v1.keptn.sh/docs
       weight: 1
     - name: GitHub
       params:


### PR DESCRIPTION
### This PR
- ports the url change from #2676 into the live page