### PR TITLE
ci: ignore spell-checker adaptations in CI workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,6 +15,7 @@ on:
       - "**.md"
       - "netlify.toml"
       - "mkdocs.yml"
+      - ".github/actions/spelling/*"
 
 env:
   GO_VERSION: "~1.20"


### PR DESCRIPTION
### This PR
- adds an ignore path for the spell checker files to the CI pipeline to reduce docs PR build time