### PR TITLE
chore: setup workload dashboard as default in observability example

### DIFF
--- a/examples/support/observability/config/prometheus/grafana-config.yaml
+++ b/examples/support/observability/config/prometheus/grafana-config.yaml
@@ -17,5 +17,5 @@ stringData:
     traceToMetrics = true
     
     [dashboards]
-    default_home_dashboard_path = /grafana-dashboard-definitions/0/keptn-workloads/grafana_dashboard_workloads.json
+    default_home_dashboard_path = /grafana-dashboard-definitions/0/keptn-workloads-dora/grafana_dashboard_workloads.json
 type: Opaque

--- a/examples/support/observability/config/prometheus/grafana-config.yaml
+++ b/examples/support/observability/config/prometheus/grafana-config.yaml
@@ -15,4 +15,7 @@ stringData:
     
     [feature_toggles]
     traceToMetrics = true
+    
+    [dashboards]
+    default_home_dashboard_path = /grafana-dashboard-definitions/0/keptn-workloads/grafana_dashboard_workloads.json
 type: Opaque

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
@@ -805,4 +805,4 @@ metadata:
   name: grafana-dashboard-keptn-applications
   namespace: monitoring
   labels:
-    grafana_dashboard: "1"
+    grafana_dashboard: "0"

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
@@ -891,4 +891,4 @@ metadata:
   name: grafana-dashboard-keptn-overview
   namespace: monitoring
   labels:
-    grafana_dashboard: "1"
+    grafana_dashboard: "0"

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
@@ -639,4 +639,4 @@ metadata:
   name: grafana-dashboard-keptn-workloads-dora
   namespace: monitoring
   labels:
-    grafana_dashboard: "1"
+    grafana_dashboard: "0"

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
@@ -628,7 +628,7 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Keptn Workloads",
+      "title": "Keptn Workloads DORA",
       "uid": "hIXRvXS4k",
       "version": 1,
       "weekStart": ""
@@ -636,7 +636,7 @@ data:
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: grafana-dashboard-keptn-workloads
+  name: grafana-dashboard-keptn-workloads-dora
   namespace: monitoring
   labels:
     grafana_dashboard: "1"

--- a/examples/support/observability/config/prometheus/grafana-deployment.yaml
+++ b/examples/support/observability/config/prometheus/grafana-deployment.yaml
@@ -143,8 +143,8 @@ spec:
             - mountPath: /grafana-dashboard-definitions/0/keptn-applications
               name: grafana-dashboard-keptn-applications
               readOnly: false
-            - mountPath: /grafana-dashboard-definitions/0/keptn-workloads
-              name: grafana-dashboard-keptn-workloads
+            - mountPath: /grafana-dashboard-definitions/0/keptn-workloads-dora
+              name: grafana-dashboard-keptn-workloads-dora
               readOnly: false
             - mountPath: /grafana-dashboard-definitions/0/keptn-overview
               name: grafana-dashboard-keptn-overview
@@ -247,8 +247,8 @@ spec:
             name: grafana-dashboard-workload-total
           name: grafana-dashboard-workload-total
         - configMap:
-            name: grafana-dashboard-keptn-workloads
-          name: grafana-dashboard-keptn-workloads
+            name: grafana-dashboard-keptn-workloads-dora
+          name: grafana-dashboard-keptn-workloads-dora
         - configMap:
             name: grafana-dashboard-keptn-applications
           name: grafana-dashboard-keptn-applications


### PR DESCRIPTION
closes #1816

![image](https://github.com/keptn/lifecycle-toolkit/assets/89971034/c0723ee3-53e8-40ed-99ef-d4bab7263aaf)

this pr sets up DORA dashboard as default in the observability example and renames it to help the user understand the data