### PR TITLE
chore(metrics-operator): make Dynatrace DQL provider oAuth URL configurable

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -43,6 +43,7 @@ argoproj
 ARMO
 artifacthub
 asdfg
+authurl
 automerge
 automountserviceaccounttokenspec
 autoprefixer

--- a/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,23 +14,22 @@ import (
 const mockSecret = "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 func TestNewConfigInvalidSecretFormat(t *testing.T) {
-	secretValue := secretValues{
+	secretValue := SecretValues{
 		"my-secret",
 		"authurl",
 	}
-	jsonData, _ := json.Marshal(secretValue)
-	config, err := NewAPIConfig("", jsonData)
+
+	config, err := NewAPIConfig("", secretValue)
 
 	require.ErrorIs(t, err, ErrClientSecretInvalid)
 	require.Nil(t, config)
 }
 
 func TestAPIClient(t *testing.T) {
-	secretValue := secretValues{
+	secretValue := SecretValues{
 		mockSecret,
-		"authurl",
+		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
 	}
-	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -45,7 +43,7 @@ func TestAPIClient(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		jsonData,
+		secretValue,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
 		WithAuthURL(server.URL+"/auth"),
 	)
@@ -71,11 +69,10 @@ func TestAPIClient(t *testing.T) {
 }
 
 func TestAPIClientAuthError(t *testing.T) {
-	secretValue := secretValues{
+	secretValue := SecretValues{
 		mockSecret,
-		"authurl",
+		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
 	}
-	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusInternalServerError)
@@ -85,7 +82,7 @@ func TestAPIClientAuthError(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		jsonData,
+		secretValue,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -108,11 +105,10 @@ func TestAPIClientAuthError(t *testing.T) {
 }
 
 func TestAPIClientAuthNoToken(t *testing.T) {
-	secretValue := secretValues{
+	secretValue := SecretValues{
 		mockSecret,
-		"authurl",
+		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
 	}
-	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -126,7 +122,7 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		jsonData,
+		secretValue,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -149,11 +145,10 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 }
 
 func TestAPIClientRequestError(t *testing.T) {
-	secretValue := secretValues{
+	secretValue := SecretValues{
 		mockSecret,
-		"authurl",
+		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
 	}
-	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -167,7 +162,7 @@ func TestAPIClientRequestError(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		jsonData,
+		secretValue,
 		WithAuthURL(server.URL+"/auth"),
 	)
 

--- a/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
@@ -19,8 +19,8 @@ func TestNewConfigInvalidSecretFormat(t *testing.T) {
 		"my-secret",
 		"authurl",
 	}
-	new, _ := json.Marshal(secretValue)
-	config, err := NewAPIConfig("", new)
+	jsonData, _ := json.Marshal(secretValue)
+	config, err := NewAPIConfig("", jsonData)
 
 	require.ErrorIs(t, err, ErrClientSecretInvalid)
 	require.Nil(t, config)
@@ -31,7 +31,7 @@ func TestAPIClient(t *testing.T) {
 		mockSecret,
 		"authurl",
 	}
-	new, _ := json.Marshal(secretValue)
+	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -45,7 +45,7 @@ func TestAPIClient(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		new,
+		jsonData,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
 		WithAuthURL(server.URL+"/auth"),
 	)
@@ -75,7 +75,7 @@ func TestAPIClientAuthError(t *testing.T) {
 		mockSecret,
 		"authurl",
 	}
-	new, _ := json.Marshal(secretValue)
+	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusInternalServerError)
@@ -85,7 +85,7 @@ func TestAPIClientAuthError(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		new,
+		jsonData,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -112,7 +112,7 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 		mockSecret,
 		"authurl",
 	}
-	new, _ := json.Marshal(secretValue)
+	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -124,11 +124,9 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 
 	defer server.Close()
 
-	// mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-
 	config, err := NewAPIConfig(
 		server.URL,
-		new,
+		jsonData,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -155,7 +153,7 @@ func TestAPIClientRequestError(t *testing.T) {
 		mockSecret,
 		"authurl",
 	}
-	new, _ := json.Marshal(secretValue)
+	jsonData, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -167,11 +165,9 @@ func TestAPIClientRequestError(t *testing.T) {
 
 	defer server.Close()
 
-	// mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-
 	config, err := NewAPIConfig(
 		server.URL,
-		new,
+		jsonData,
 		WithAuthURL(server.URL+"/auth"),
 	)
 

--- a/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
@@ -13,24 +13,7 @@ import (
 
 const mockSecret = "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
-func TestNewConfigInvalidSecretFormat(t *testing.T) {
-	secretValue := SecretValues{
-		"my-secret",
-		"authurl",
-	}
-
-	config, err := NewAPIConfig("", secretValue)
-
-	require.ErrorIs(t, err, ErrClientSecretInvalid)
-	require.Nil(t, config)
-}
-
 func TestAPIClient(t *testing.T) {
-	secretValue := SecretValues{
-		mockSecret,
-		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
-	}
-
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
 			_, _ = writer.Write([]byte(`{"access_token": "my-token"}`))
@@ -43,7 +26,7 @@ func TestAPIClient(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		secretValue,
+		mockSecret,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
 		WithAuthURL(server.URL+"/auth"),
 	)
@@ -69,11 +52,6 @@ func TestAPIClient(t *testing.T) {
 }
 
 func TestAPIClientAuthError(t *testing.T) {
-	secretValue := SecretValues{
-		mockSecret,
-		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
-	}
-
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -82,7 +60,7 @@ func TestAPIClientAuthError(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		secretValue,
+		mockSecret,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -105,11 +83,6 @@ func TestAPIClientAuthError(t *testing.T) {
 }
 
 func TestAPIClientAuthNoToken(t *testing.T) {
-	secretValue := SecretValues{
-		mockSecret,
-		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
-	}
-
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
 			_, _ = writer.Write([]byte(`{"something": "else"}`))
@@ -122,7 +95,7 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		secretValue,
+		mockSecret,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -145,11 +118,6 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 }
 
 func TestAPIClientRequestError(t *testing.T) {
-	secretValue := SecretValues{
-		mockSecret,
-		"https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
-	}
-
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
 			_, _ = writer.Write([]byte(`{"access_token": "my-token"}`))
@@ -162,7 +130,7 @@ func TestAPIClientRequestError(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		secretValue,
+		mockSecret,
 		WithAuthURL(server.URL+"/auth"),
 	)
 

--- a/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,14 +15,23 @@ import (
 const mockSecret = "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 func TestNewConfigInvalidSecretFormat(t *testing.T) {
-
-	config, err := NewAPIConfig("", "my-secret")
+	secretValue := secretValues{
+		"my-secret",
+		"authurl",
+	}
+	new, _ := json.Marshal(secretValue)
+	config, err := NewAPIConfig("", new)
 
 	require.ErrorIs(t, err, ErrClientSecretInvalid)
 	require.Nil(t, config)
 }
 
 func TestAPIClient(t *testing.T) {
+	secretValue := secretValues{
+		mockSecret,
+		"authurl",
+	}
+	new, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -35,7 +45,7 @@ func TestAPIClient(t *testing.T) {
 
 	config, err := NewAPIConfig(
 		server.URL,
-		mockSecret,
+		new,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
 		WithAuthURL(server.URL+"/auth"),
 	)
@@ -61,6 +71,11 @@ func TestAPIClient(t *testing.T) {
 }
 
 func TestAPIClientAuthError(t *testing.T) {
+	secretValue := secretValues{
+		mockSecret,
+		"authurl",
+	}
+	new, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusInternalServerError)
@@ -68,11 +83,9 @@ func TestAPIClientAuthError(t *testing.T) {
 
 	defer server.Close()
 
-	mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-
 	config, err := NewAPIConfig(
 		server.URL,
-		mockSecret,
+		new,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -95,6 +108,11 @@ func TestAPIClientAuthError(t *testing.T) {
 }
 
 func TestAPIClientAuthNoToken(t *testing.T) {
+	secretValue := secretValues{
+		mockSecret,
+		"authurl",
+	}
+	new, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -106,11 +124,11 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 
 	defer server.Close()
 
-	mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	// mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 	config, err := NewAPIConfig(
 		server.URL,
-		mockSecret,
+		new,
 		WithAuthURL(server.URL+"/auth"),
 	)
 
@@ -133,6 +151,11 @@ func TestAPIClientAuthNoToken(t *testing.T) {
 }
 
 func TestAPIClientRequestError(t *testing.T) {
+	secretValue := secretValues{
+		mockSecret,
+		"authurl",
+	}
+	new, _ := json.Marshal(secretValue)
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/auth" {
@@ -144,11 +167,11 @@ func TestAPIClientRequestError(t *testing.T) {
 
 	defer server.Close()
 
-	mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	// mockSecret := "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 	config, err := NewAPIConfig(
 		server.URL,
-		mockSecret,
+		new,
 		WithAuthURL(server.URL+"/auth"),
 	)
 

--- a/metrics-operator/controllers/common/providers/dynatrace/client/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/common.go
@@ -12,7 +12,6 @@ var ErrRequestFailed = errors.New("the API returned a response with a status out
 var ErrAuthenticationFailed = errors.New("could not retrieve an OAuth token from the API")
 
 const (
-	defaultAuthURL                  = "https://dev.token.internal.dynatracelabs.com/sso/oauth2/token"
 	oAuthGrantType                  = "grant_type"
 	oAuthGrantTypeClientCredentials = "client_credentials"
 	oAuthScope                      = "scope"

--- a/metrics-operator/controllers/common/providers/dynatrace/client/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/common.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,7 @@ import (
 var ErrClientSecretInvalid = errors.New("the Dynatrace token has an invalid format")
 var ErrRequestFailed = errors.New("the API returned a response with a status outside of the 2xx range")
 var ErrAuthenticationFailed = errors.New("could not retrieve an OAuth token from the API")
+var ErrClientUrlInvalid = errors.New("the Dynatrace authurl is not a valid url")
 
 const (
 	oAuthGrantType                  = "grant_type"
@@ -21,7 +23,7 @@ const (
 
 const dtTokenPrefix = "dt0s08"
 
-func validateOAuthSecret(token string) error {
+func validateOAuthSecret(token string, authurl string) error {
 	// must start with dt0s08
 	// must have 2 dots
 	// third part (split by dot) must be 64 chars
@@ -35,6 +37,10 @@ func validateOAuthSecret(token string) error {
 	secret := split[2]
 	if secretLen := len(secret); secretLen != 64 {
 		return fmt.Errorf("length of secret is %d, which is not equal to 64: %w", secretLen, ErrClientSecretInvalid)
+	}
+	_, err := url.ParseRequestURI(authurl)
+	if err != nil {
+		return fmt.Errorf("authurl is not a valid url: %w", ErrClientUrlInvalid)
 	}
 	return nil
 }

--- a/metrics-operator/controllers/common/providers/dynatrace/client/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/common.go
@@ -1,49 +1,20 @@
 package client
 
 import (
-	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/pkg/errors"
 )
 
-var ErrClientSecretInvalid = errors.New("the Dynatrace token has an invalid format")
 var ErrRequestFailed = errors.New("the API returned a response with a status outside of the 2xx range")
 var ErrAuthenticationFailed = errors.New("could not retrieve an OAuth token from the API")
-var ErrClientUrlInvalid = errors.New("the Dynatrace authurl is not a valid url")
 
 const (
+	defaultAuthURL                  = "https://dev.token.internal.dynatracelabs.com/sso/oauth2/token"
 	oAuthGrantType                  = "grant_type"
 	oAuthGrantTypeClientCredentials = "client_credentials"
 	oAuthScope                      = "scope"
 	oAuthClientID                   = "client_id"
 	oAuthClientSecret               = "client_secret"
 )
-
-const dtTokenPrefix = "dt0s08"
-
-func validateOAuthSecret(token string, authurl string) error {
-	// must start with dt0s08
-	// must have 2 dots
-	// third part (split by dot) must be 64 chars
-	if !strings.HasPrefix(token, dtTokenPrefix) {
-		return fmt.Errorf("secret does not start with required prefix %s: %w", dtTokenPrefix, ErrClientSecretInvalid)
-	}
-	split := strings.Split(token, ".")
-	if len(split) != 3 {
-		return fmt.Errorf("secret does not contain three components: %w", ErrClientSecretInvalid)
-	}
-	secret := split[2]
-	if secretLen := len(secret); secretLen != 64 {
-		return fmt.Errorf("length of secret is %d, which is not equal to 64: %w", secretLen, ErrClientSecretInvalid)
-	}
-	_, err := url.ParseRequestURI(authurl)
-	if err != nil {
-		return fmt.Errorf("authurl is not a valid url: %w", ErrClientUrlInvalid)
-	}
-	return nil
-}
 
 func isErrorStatus(statusCode int) bool {
 	return statusCode < 200 || statusCode >= 300

--- a/metrics-operator/controllers/common/providers/dynatrace/client/common_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/common_test.go
@@ -3,52 +3,7 @@ package client
 import (
 	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
-
-func Test_validateOAuthSecret(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		result  error
-		authurl string
-	}{
-		{
-			name:    "good token",
-			input:   "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-			result:  nil,
-			authurl: "https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
-		},
-		{
-			name:    "wrong prefix",
-			input:   "",
-			result:  ErrClientSecretInvalid,
-			authurl: "",
-		},
-		{
-			name:    "wrong format",
-			input:   "",
-			result:  ErrClientSecretInvalid,
-			authurl: "",
-		},
-		{
-			name:    "wrong secret part",
-			input:   "",
-			result:  ErrClientSecretInvalid,
-			authurl: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateOAuthSecret(tt.input, tt.authurl)
-
-			require.ErrorIs(t, err, tt.result)
-		})
-
-	}
-}
 
 func Test_isErrorStatus(t *testing.T) {
 	type args struct {

--- a/metrics-operator/controllers/common/providers/dynatrace/client/common_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/common_test.go
@@ -9,35 +9,40 @@ import (
 
 func Test_validateOAuthSecret(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  string
-		result error
+		name    string
+		input   string
+		result  error
+		authurl string
 	}{
 		{
-			name:   "good token",
-			input:  "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-			result: nil,
+			name:    "good token",
+			input:   "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			result:  nil,
+			authurl: "https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
 		},
 		{
-			name:   "wrong prefix",
-			input:  "",
-			result: ErrClientSecretInvalid,
+			name:    "wrong prefix",
+			input:   "",
+			result:  ErrClientSecretInvalid,
+			authurl: "",
 		},
 		{
-			name:   "wrong format",
-			input:  "",
-			result: ErrClientSecretInvalid,
+			name:    "wrong format",
+			input:   "",
+			result:  ErrClientSecretInvalid,
+			authurl: "",
 		},
 		{
-			name:   "wrong secret part",
-			input:  "",
-			result: ErrClientSecretInvalid,
+			name:    "wrong secret part",
+			input:   "",
+			result:  ErrClientSecretInvalid,
+			authurl: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOAuthSecret(tt.input)
+			err := validateOAuthSecret(tt.input, tt.authurl)
 
 			require.ErrorIs(t, err, tt.result)
 		})

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -9,6 +10,10 @@ type apiConfig struct {
 	serverURL        string
 	authURL          string
 	oAuthCredentials oAuthCredentials
+}
+type secretValues struct {
+	Token   string `json:"token"`
+	AuthUrl string `json:"authurl"`
 }
 
 type APIConfigOption func(config *apiConfig)
@@ -27,18 +32,23 @@ func WithScopes(scopes []OAuthScope) APIConfigOption {
 }
 
 // NewAPIConfig returns a new apiConfig that can be used for initializing a DTAPIClient with the NewAPIClient function
-func NewAPIConfig(serverURL string, secret string, opts ...APIConfigOption) (*apiConfig, error) {
-	if err := validateOAuthSecret(secret); err != nil {
+func NewAPIConfig(serverURL string, secret []byte, opts ...APIConfigOption) (*apiConfig, error) {
+	var sec secretValues
+	if err := json.Unmarshal(secret, &sec); err != nil {
 		return nil, err
 	}
 
-	secretParts := strings.Split(secret, ".")
+	if err := validateOAuthSecret(sec.Token); err != nil {
+		return nil, err
+	}
+
+	secretParts := strings.Split(sec.Token, ".")
 	clientId := fmt.Sprintf("%s.%s", secretParts[0], secretParts[1])
 	clientSecret := fmt.Sprintf("%s.%s", clientId, secretParts[2])
 
 	cfg := &apiConfig{
 		serverURL: serverURL,
-		authURL:   defaultAuthURL,
+		authURL:   sec.AuthUrl,
 		oAuthCredentials: oAuthCredentials{
 			clientID:     clientId,
 			clientSecret: clientSecret,

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config.go
@@ -33,22 +33,22 @@ func WithScopes(scopes []OAuthScope) APIConfigOption {
 
 // NewAPIConfig returns a new apiConfig that can be used for initializing a DTAPIClient with the NewAPIClient function
 func NewAPIConfig(serverURL string, secret []byte, opts ...APIConfigOption) (*apiConfig, error) {
-	var sec secretValues
-	if err := json.Unmarshal(secret, &sec); err != nil {
+	var secValue secretValues
+	if err := json.Unmarshal(secret, &secValue); err != nil {
 		return nil, err
 	}
 
-	if err := validateOAuthSecret(sec.Token); err != nil {
+	if err := validateOAuthSecret(secValue.Token); err != nil {
 		return nil, err
 	}
 
-	secretParts := strings.Split(sec.Token, ".")
+	secretParts := strings.Split(secValue.Token, ".")
 	clientId := fmt.Sprintf("%s.%s", secretParts[0], secretParts[1])
 	clientSecret := fmt.Sprintf("%s.%s", clientId, secretParts[2])
 
 	cfg := &apiConfig{
 		serverURL: serverURL,
-		authURL:   sec.AuthUrl,
+		authURL:   secValue.AuthUrl,
 		oAuthCredentials: oAuthCredentials{
 			clientID:     clientId,
 			clientSecret: clientSecret,

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config.go
@@ -11,16 +11,13 @@ type apiConfig struct {
 	oAuthCredentials oAuthCredentials
 }
 
-type SecretValues struct {
-	Token   string `json:"token"`
-	AuthUrl string `json:"authurl"`
-}
-
 type APIConfigOption func(config *apiConfig)
 
 func WithAuthURL(authURL string) APIConfigOption {
 	return func(config *apiConfig) {
-		config.authURL = authURL
+		if authURL != "" {
+			config.authURL = authURL
+		}
 	}
 }
 
@@ -32,19 +29,14 @@ func WithScopes(scopes []OAuthScope) APIConfigOption {
 }
 
 // NewAPIConfig returns a new apiConfig that can be used for initializing a DTAPIClient with the NewAPIClient function
-func NewAPIConfig(serverURL string, secret SecretValues, opts ...APIConfigOption) (*apiConfig, error) {
-
-	if err := validateOAuthSecret(secret.Token, secret.AuthUrl); err != nil {
-		return nil, err
-	}
-
-	secretParts := strings.Split(secret.Token, ".")
+func NewAPIConfig(serverURL, token string, opts ...APIConfigOption) (*apiConfig, error) {
+	secretParts := strings.Split(token, ".")
 	clientId := fmt.Sprintf("%s.%s", secretParts[0], secretParts[1])
 	clientSecret := fmt.Sprintf("%s.%s", clientId, secretParts[2])
 
 	cfg := &apiConfig{
 		serverURL: serverURL,
-		authURL:   secret.AuthUrl,
+		authURL:   defaultAuthURL,
 		oAuthCredentials: oAuthCredentials{
 			clientID:     clientId,
 			clientSecret: clientSecret,

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -11,7 +10,8 @@ type apiConfig struct {
 	authURL          string
 	oAuthCredentials oAuthCredentials
 }
-type secretValues struct {
+
+type SecretValues struct {
 	Token   string `json:"token"`
 	AuthUrl string `json:"authurl"`
 }
@@ -32,23 +32,23 @@ func WithScopes(scopes []OAuthScope) APIConfigOption {
 }
 
 // NewAPIConfig returns a new apiConfig that can be used for initializing a DTAPIClient with the NewAPIClient function
-func NewAPIConfig(serverURL string, secret []byte, opts ...APIConfigOption) (*apiConfig, error) {
-	var secValue secretValues
-	if err := json.Unmarshal(secret, &secValue); err != nil {
+func NewAPIConfig(serverURL string, secret SecretValues, opts ...APIConfigOption) (*apiConfig, error) {
+	// var secValue dynatrace.SecretValues
+	// if err := json.Unmarshal(secret, &secValue); err != nil {
+	// 	return nil, err
+	// }
+
+	if err := validateOAuthSecret(secret.Token, secret.AuthUrl); err != nil {
 		return nil, err
 	}
 
-	if err := validateOAuthSecret(secValue.Token); err != nil {
-		return nil, err
-	}
-
-	secretParts := strings.Split(secValue.Token, ".")
+	secretParts := strings.Split(secret.Token, ".")
 	clientId := fmt.Sprintf("%s.%s", secretParts[0], secretParts[1])
 	clientSecret := fmt.Sprintf("%s.%s", clientId, secretParts[2])
 
 	cfg := &apiConfig{
 		serverURL: serverURL,
-		authURL:   secValue.AuthUrl,
+		authURL:   secret.AuthUrl,
 		oAuthCredentials: oAuthCredentials{
 			clientID:     clientId,
 			clientSecret: clientSecret,

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config.go
@@ -33,10 +33,6 @@ func WithScopes(scopes []OAuthScope) APIConfigOption {
 
 // NewAPIConfig returns a new apiConfig that can be used for initializing a DTAPIClient with the NewAPIClient function
 func NewAPIConfig(serverURL string, secret SecretValues, opts ...APIConfigOption) (*apiConfig, error) {
-	// var secValue dynatrace.SecretValues
-	// if err := json.Unmarshal(secret, &secValue); err != nil {
-	// 	return nil, err
-	// }
 
 	if err := validateOAuthSecret(secret.Token, secret.AuthUrl); err != nil {
 		return nil, err

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 func TestNewAPIConfig(t *testing.T) {
-	myData := SecretValues{"dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "https://dev.token.internal.my-auth-url.com/sso/oauth2/token"}
 	config, err := NewAPIConfig(
 		"my-url",
-		myData,
+		mockSecret,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
 		WithAuthURL("https://dev.token.internal.my-auth-url.com/sso/oauth2/token"),
 	)

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config_test.go
@@ -1,17 +1,20 @@
 package client
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAPIConfig(t *testing.T) {
+	myData := secretValues{"dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "my-authurl"}
+	jsonData, _ := json.Marshal(myData)
 	config, err := NewAPIConfig(
 		"my-url",
-		mockSecret,
+		jsonData,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
-		WithAuthURL("my-url/auth"),
+		WithAuthURL("my-authurl"),
 	)
 
 	require.Nil(t, err)
@@ -19,7 +22,7 @@ func TestNewAPIConfig(t *testing.T) {
 
 	expectedApiConfig := apiConfig{
 		serverURL: "my-url",
-		authURL:   "my-url/auth",
+		authURL:   "my-authurl",
 		oAuthCredentials: oAuthCredentials{
 			clientID:     "dt0s08.XX",
 			clientSecret: mockSecret,

--- a/metrics-operator/controllers/common/providers/dynatrace/client/config_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/client/config_test.go
@@ -1,20 +1,18 @@
 package client
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAPIConfig(t *testing.T) {
-	myData := secretValues{"dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "my-authurl"}
-	jsonData, _ := json.Marshal(myData)
+	myData := SecretValues{"dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "https://dev.token.internal.my-auth-url.com/sso/oauth2/token"}
 	config, err := NewAPIConfig(
 		"my-url",
-		jsonData,
+		myData,
 		WithScopes([]OAuthScope{OAuthScopeStorageMetricsRead, OAuthScopeEnvironmentRoleViewer}),
-		WithAuthURL("my-authurl"),
+		WithAuthURL("https://dev.token.internal.my-auth-url.com/sso/oauth2/token"),
 	)
 
 	require.Nil(t, err)
@@ -22,7 +20,7 @@ func TestNewAPIConfig(t *testing.T) {
 
 	expectedApiConfig := apiConfig{
 		serverURL: "my-url",
-		authURL:   "my-authurl",
+		authURL:   "https://dev.token.internal.my-auth-url.com/sso/oauth2/token",
 		oAuthCredentials: oAuthCredentials{
 			clientID:     "dt0s08.XX",
 			clientSecret: mockSecret,

--- a/metrics-operator/controllers/common/providers/dynatrace/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common.go
@@ -17,8 +17,8 @@ import (
 var ErrSecretKeyRefNotDefined = errors.New("the SecretKeyRef property with the Dynatrace token is missing")
 var ErrInvalidResult = errors.New("the answer does not contain any data")
 var ErrDQLQueryTimeout = errors.New("timed out waiting for result of DQL query")
-var ErrClientUrlInvalid = errors.New("the Dynatrace auth URL is not a valid URL")
-var ErrOAuthURLInvalid = errors.New("the Dynatrace token has an invalid format")
+var ErrInvalidAuthURL = errors.New("the Dynatrace auth URL is not a valid URL")
+var ErrInvalidToken = errors.New("the Dynatrace token has an invalid format")
 
 const (
 	ErrAPIMsg     = "provider api response: %s"
@@ -40,19 +40,19 @@ func (s DQLSecret) validate() error {
 	// must have 2 dots
 	// third part (split by dot) must be 64 chars
 	if !strings.HasPrefix(s.Token, dtTokenPrefix) {
-		return fmt.Errorf("secret does not start with required prefix %s: %w", dtTokenPrefix, ErrOAuthURLInvalid)
+		return fmt.Errorf("secret does not start with required prefix %s: %w", dtTokenPrefix, ErrInvalidToken)
 	}
 	split := strings.Split(s.Token, ".")
 	if len(split) != 3 {
-		return fmt.Errorf("secret does not contain three components: %w", ErrOAuthURLInvalid)
+		return fmt.Errorf("secret does not contain three components: %w", ErrInvalidToken)
 	}
 	secret := split[2]
 	if secretLen := len(secret); secretLen != 64 {
-		return fmt.Errorf("length of secret is %d, which is not equal to 64: %w", secretLen, ErrOAuthURLInvalid)
+		return fmt.Errorf("length of secret is %d, which is not equal to 64: %w", secretLen, ErrInvalidToken)
 	}
 	_, err := url.ParseRequestURI(s.AuthUrl)
 	if err != nil {
-		return fmt.Errorf("authurl is not a valid url: %w", ErrClientUrlInvalid)
+		return fmt.Errorf("authurl is not a valid url: %w", ErrInvalidAuthURL)
 	}
 	return nil
 }

--- a/metrics-operator/controllers/common/providers/dynatrace/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common.go
@@ -50,10 +50,13 @@ func (s DQLSecret) validate() error {
 	if secretLen := len(secret); secretLen != 64 {
 		return fmt.Errorf("length of secret is %d, which is not equal to 64: %w", secretLen, ErrInvalidToken)
 	}
-	_, err := url.ParseRequestURI(s.AuthUrl)
-	if err != nil {
-		return fmt.Errorf("authurl is not a valid url: %w", ErrInvalidAuthURL)
+
+	if s.AuthUrl != "" {
+		if _, err := url.ParseRequestURI(s.AuthUrl); err != nil {
+			return fmt.Errorf("authurl is not a valid url: %w", ErrInvalidAuthURL)
+		}
 	}
+
 	return nil
 }
 

--- a/metrics-operator/controllers/common/providers/dynatrace/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common.go
@@ -2,6 +2,7 @@ package dynatrace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -24,20 +25,37 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-func getDTSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) (string, error) {
+type SecretValues struct {
+	Token   string `json:"token"`
+	AuthUrl string `json:"authurl"`
+}
+
+func getDTSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) ([]byte, error) {
 	if !provider.HasSecretDefined() || !provider.HasSecretKeyDefined() {
-		return "", ErrSecretKeyRefNotDefined
+		return []byte{}, ErrSecretKeyRefNotDefined
 	}
 	dtCredsSecret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: provider.Spec.SecretKeyRef.Name, Namespace: provider.Namespace}, dtCredsSecret); err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
 	token := string(dtCredsSecret.Data[provider.Spec.SecretKeyRef.Key])
-	if len(token) == 0 {
-		return "", fmt.Errorf("secret contains invalid key %s", provider.Spec.SecretKeyRef.Key)
+	secretValues := SecretValues{
+		Token:   token,
+		AuthUrl: fmt.Sprintf("https://dev.%s.internal.dynatracelabs.com/sso/oauth2/%s", token, token),
 	}
-	return strings.Trim(token, "\n"), nil
+
+	// Use json.Marshal to encode the Person struct to JSON
+	jsonData, err := json.Marshal(secretValues)
+	if err != nil {
+		fmt.Println("Error encoding to JSON:", err)
+	}
+
+	if len(token) == 0 {
+		return []byte{}, fmt.Errorf("secret contains invalid key %s", provider.Spec.SecretKeyRef.Key)
+	}
+	// return strings.Trim(string(encoder.Bytes()), "\n"), nil
+	return jsonData, nil
 }
 
 func urlEncodeQuery(query string) string {

--- a/metrics-operator/controllers/common/providers/dynatrace/common.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common.go
@@ -2,13 +2,13 @@ package dynatrace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1beta1"
-	dynatraceclient "github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/providers/dynatrace/client"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,31 +17,84 @@ import (
 var ErrSecretKeyRefNotDefined = errors.New("the SecretKeyRef property with the Dynatrace token is missing")
 var ErrInvalidResult = errors.New("the answer does not contain any data")
 var ErrDQLQueryTimeout = errors.New("timed out waiting for result of DQL query")
+var ErrClientUrlInvalid = errors.New("the Dynatrace auth URL is not a valid URL")
+var ErrOAuthURLInvalid = errors.New("the Dynatrace token has an invalid format")
 
-const ErrAPIMsg = "provider api response: %s"
+const (
+	ErrAPIMsg     = "provider api response: %s"
+	dtTokenPrefix = "dt0s08"
+)
 
 type Error struct {
 	Code    int    `json:"-"` // optional
 	Message string `json:"message"`
 }
 
-func getDTSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) (dynatraceclient.SecretValues, error) {
+type DQLSecret struct {
+	Token   string `json:"token"`
+	AuthUrl string `json:"authUrl"`
+}
+
+func (s DQLSecret) validate() error {
+	// must start with dt0s08
+	// must have 2 dots
+	// third part (split by dot) must be 64 chars
+	if !strings.HasPrefix(s.Token, dtTokenPrefix) {
+		return fmt.Errorf("secret does not start with required prefix %s: %w", dtTokenPrefix, ErrOAuthURLInvalid)
+	}
+	split := strings.Split(s.Token, ".")
+	if len(split) != 3 {
+		return fmt.Errorf("secret does not contain three components: %w", ErrOAuthURLInvalid)
+	}
+	secret := split[2]
+	if secretLen := len(secret); secretLen != 64 {
+		return fmt.Errorf("length of secret is %d, which is not equal to 64: %w", secretLen, ErrOAuthURLInvalid)
+	}
+	_, err := url.ParseRequestURI(s.AuthUrl)
+	if err != nil {
+		return fmt.Errorf("authurl is not a valid url: %w", ErrClientUrlInvalid)
+	}
+	return nil
+}
+
+func getDTSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) (string, error) {
 	if !provider.HasSecretDefined() || !provider.HasSecretKeyDefined() {
-		return dynatraceclient.SecretValues{}, ErrSecretKeyRefNotDefined
+		return "", ErrSecretKeyRefNotDefined
 	}
 	dtCredsSecret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: provider.Spec.SecretKeyRef.Name, Namespace: provider.Namespace}, dtCredsSecret); err != nil {
-		return dynatraceclient.SecretValues{}, err
+		return "", err
 	}
 
 	token := string(dtCredsSecret.Data[provider.Spec.SecretKeyRef.Key])
-
 	if len(token) == 0 {
-		return dynatraceclient.SecretValues{}, fmt.Errorf("secret contains invalid key %s", provider.Spec.SecretKeyRef.Key)
+		return "", fmt.Errorf("secret contains invalid key %s", provider.Spec.SecretKeyRef.Key)
 	}
-	return dynatraceclient.SecretValues{
-		Token:   strings.Trim(token, "\n"),
-		AuthUrl: fmt.Sprintf("https://dev.%s.internal.dynatracelabs.com/sso/oauth2/%s", token, token)}, nil
+	return strings.Trim(token, "\n"), nil
+}
+
+func getDQLSecret(ctx context.Context, provider metricsapi.KeptnMetricsProvider, k8sClient client.Client) (*DQLSecret, error) {
+	if !provider.HasSecretDefined() || !provider.HasSecretKeyDefined() {
+		return nil, ErrSecretKeyRefNotDefined
+	}
+	dtCredsSecret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: provider.Spec.SecretKeyRef.Name, Namespace: provider.Namespace}, dtCredsSecret); err != nil {
+		return nil, err
+	}
+
+	credentialsStr := string(dtCredsSecret.Data[provider.Spec.SecretKeyRef.Key])
+
+	credentialsObj := &DQLSecret{}
+
+	if err := json.Unmarshal([]byte(credentialsStr), credentialsObj); err != nil {
+		return nil, fmt.Errorf("could not unmarshal secret containing access credentials: %w", err)
+	}
+
+	if err := credentialsObj.validate(); err != nil {
+		return nil, fmt.Errorf("secret contains invalid credentials: %w", err)
+	}
+
+	return credentialsObj, nil
 }
 
 func urlEncodeQuery(query string) string {

--- a/metrics-operator/controllers/common/providers/dynatrace/common_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common_test.go
@@ -2,14 +2,17 @@ package dynatrace
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1beta1"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/fake"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
+
+const dqlSecretString = `{"token": "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "authUrl":"https://my-auth-url.test"}`
 
 func TestGetSecret_NoKeyDefined(t *testing.T) {
 
@@ -59,6 +62,124 @@ func TestGetSecret_NoTokenData(t *testing.T) {
 	require.Empty(t, r)
 }
 
+func TestGetDQLSecret_NoKeyDefined(t *testing.T) {
+
+	fakeClient := fake.NewClient()
+
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: "svr.URL",
+		},
+	}
+	r, e := getDQLSecret(context.TODO(), p, fakeClient)
+	require.NotNil(t, e)
+	require.ErrorIs(t, e, ErrSecretKeyRefNotDefined)
+	require.Empty(t, r)
+}
+
+func TestGetDQLSecret_NoSecret(t *testing.T) {
+	fakeClient := fake.NewClient()
+
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: "svr.URL",
+		},
+	}
+	r, e := getDQLSecret(context.TODO(), p, fakeClient)
+	require.NotNil(t, e)
+	require.ErrorIs(t, e, ErrSecretKeyRefNotDefined)
+	require.Empty(t, r)
+}
+
+func TestGetDQLSecret_NoTokenData(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(dtpayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+	fakeClient := fake.NewClient()
+
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: svr.URL,
+		},
+	}
+	r, e := getDQLSecret(context.TODO(), p, fakeClient)
+	require.NotNil(t, e)
+	require.ErrorIs(t, e, ErrSecretKeyRefNotDefined)
+	require.Empty(t, r)
+}
+
+func TestGetDQLSecret_ValidSecret(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(dtpayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	dqlSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-dql-secret",
+		},
+		Data: map[string][]byte{
+			"creds": []byte(dqlSecretString),
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+	fakeClient := fake.NewClient(dqlSecret)
+
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: svr.URL,
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "my-dql-secret",
+				},
+				Key: "creds",
+			},
+		},
+	}
+	secretValue, e := getDQLSecret(context.TODO(), p, fakeClient)
+	require.Nil(t, e)
+	require.NotEmpty(t, secretValue)
+	require.Equal(t, "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", secretValue.Token)
+	require.Equal(t, "https://my-auth-url.test", secretValue.AuthUrl)
+}
+
+func TestGetDQLSecret_SecretIsNotAJsonObject(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(dtpayload))
+		require.Nil(t, err)
+	}))
+	defer svr.Close()
+
+	dqlSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-dql-secret",
+		},
+		Data: map[string][]byte{
+			"creds": []byte("wrong"),
+		},
+		Type: v1.SecretTypeOpaque,
+	}
+	fakeClient := fake.NewClient(dqlSecret)
+
+	p := metricsapi.KeptnMetricsProvider{
+		Spec: metricsapi.KeptnMetricsProviderSpec{
+			TargetServer: svr.URL,
+			SecretKeyRef: v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: "my-dql-secret",
+				},
+				Key: "creds",
+			},
+		},
+	}
+	secretValue, e := getDQLSecret(context.TODO(), p, fakeClient)
+	require.NotNil(t, e)
+	require.Nil(t, secretValue)
+}
+
 func Test_urlEncodeQuery(t *testing.T) {
 	type args struct {
 		query string
@@ -94,6 +215,67 @@ func Test_urlEncodeQuery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := urlEncodeQuery(tt.args.query)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDQLSecret_validate(t *testing.T) {
+	type fields struct {
+		Token   string
+		AuthUrl string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr error
+	}{
+		{
+			name: "good token",
+			fields: fields{
+				Token:   "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+				AuthUrl: "https://dev.token.internal.dynatracelabs.com/sso/oauth2/token",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "empty token",
+			fields: fields{
+				Token:   "",
+				AuthUrl: "",
+			},
+			wantErr: ErrOAuthURLInvalid,
+		},
+		{
+			name: "wrong format",
+			fields: fields{
+				Token: "dt0s08.wrong.token.with.too.many.components",
+			},
+			wantErr: ErrOAuthURLInvalid,
+		},
+		{
+			name: "wrong format",
+			fields: fields{
+				Token: "dt0s08.wrong.length",
+			},
+			wantErr: ErrOAuthURLInvalid,
+		},
+		{
+			name: "invalid auth url",
+			fields: fields{
+				Token:   "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+				AuthUrl: "wrong",
+			},
+			wantErr: ErrClientUrlInvalid,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := DQLSecret{
+				Token:   tt.fields.Token,
+				AuthUrl: tt.fields.AuthUrl,
+			}
+			err := s.validate()
+			require.ErrorIs(t, err, tt.wantErr)
 		})
 	}
 }

--- a/metrics-operator/controllers/common/providers/dynatrace/common_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common_test.go
@@ -244,21 +244,21 @@ func TestDQLSecret_validate(t *testing.T) {
 				Token:   "",
 				AuthUrl: "",
 			},
-			wantErr: ErrOAuthURLInvalid,
+			wantErr: ErrInvalidToken,
 		},
 		{
 			name: "wrong format",
 			fields: fields{
 				Token: "dt0s08.wrong.token.with.too.many.components",
 			},
-			wantErr: ErrOAuthURLInvalid,
+			wantErr: ErrInvalidToken,
 		},
 		{
 			name: "wrong format",
 			fields: fields{
 				Token: "dt0s08.wrong.length",
 			},
-			wantErr: ErrOAuthURLInvalid,
+			wantErr: ErrInvalidToken,
 		},
 		{
 			name: "invalid auth url",
@@ -266,7 +266,7 @@ func TestDQLSecret_validate(t *testing.T) {
 				Token:   "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
 				AuthUrl: "wrong",
 			},
-			wantErr: ErrClientUrlInvalid,
+			wantErr: ErrInvalidAuthURL,
 		},
 	}
 	for _, tt := range tests {

--- a/metrics-operator/controllers/common/providers/dynatrace/common_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/common_test.go
@@ -2,14 +2,15 @@ package dynatrace
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1beta1"
 	"github.com/keptn/lifecycle-toolkit/metrics-operator/controllers/common/fake"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 const dqlSecretString = `{"token": "dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "authUrl":"https://my-auth-url.test"}`

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -116,14 +116,8 @@ func (d *KeptnDynatraceProvider) performRequest(ctx context.Context, provider me
 	if err != nil {
 		return nil, nil, err
 	}
-	var sV SecretValues
 
-	err = json.Unmarshal(token, &sV)
-	if err != nil {
-		fmt.Println("Error:", err)
-	}
-
-	req.Header.Set("Authorization", "Api-Token "+fmt.Sprint(sV.Token))
+	req.Header.Set("Authorization", "Api-Token "+token.Token)
 	res, err := d.HttpClient.Do(req)
 
 	if err != nil {

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -112,11 +112,18 @@ func (d *KeptnDynatraceProvider) performRequest(ctx context.Context, provider me
 	}
 
 	token, err := getDTSecret(ctx, provider, d.K8sClient)
+
 	if err != nil {
 		return nil, nil, err
 	}
+	var sV SecretValues
 
-	req.Header.Set("Authorization", "Api-Token "+token)
+	err = json.Unmarshal(token, &sV)
+	if err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	req.Header.Set("Authorization", "Api-Token "+fmt.Sprint(sV.Token))
 	res, err := d.HttpClient.Do(req)
 
 	if err != nil {

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace.go
@@ -117,7 +117,7 @@ func (d *KeptnDynatraceProvider) performRequest(ctx context.Context, provider me
 		return nil, nil, err
 	}
 
-	req.Header.Set("Authorization", "Api-Token "+token.Token)
+	req.Header.Set("Authorization", "Api-Token "+token)
 	res, err := d.HttpClient.Do(req)
 
 	if err != nil {

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
@@ -253,12 +253,6 @@ func (d *keptnDynatraceDQLProvider) ensureDTClientIsSetUp(ctx context.Context, p
 	// try to initialize the DT API Client if it has not been set in the options
 	if d.dtClient == nil {
 		secret, err := getDTSecret(ctx, provider, d.k8sClient)
-		var sV SecretValues
-
-		Jsonerr := json.Unmarshal(secret, &sV)
-		if Jsonerr != nil {
-			fmt.Println("Error:", err)
-		}
 
 		if err != nil {
 			return err

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
@@ -253,6 +253,13 @@ func (d *keptnDynatraceDQLProvider) ensureDTClientIsSetUp(ctx context.Context, p
 	// try to initialize the DT API Client if it has not been set in the options
 	if d.dtClient == nil {
 		secret, err := getDTSecret(ctx, provider, d.k8sClient)
+		var sV SecretValues
+
+		Jsonerr := json.Unmarshal(secret, &sV)
+		if Jsonerr != nil {
+			fmt.Println("Error:", err)
+		}
+
 		if err != nil {
 			return err
 		}

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql.go
@@ -252,14 +252,15 @@ func (d *keptnDynatraceDQLProvider) parseDQLResults(b []byte, status int) (*DQLR
 func (d *keptnDynatraceDQLProvider) ensureDTClientIsSetUp(ctx context.Context, provider metricsapi.KeptnMetricsProvider) error {
 	// try to initialize the DT API Client if it has not been set in the options
 	if d.dtClient == nil {
-		secret, err := getDTSecret(ctx, provider, d.k8sClient)
+		secret, err := getDQLSecret(ctx, provider, d.k8sClient)
 
 		if err != nil {
 			return err
 		}
 		config, err := dtclient.NewAPIConfig(
 			provider.Spec.TargetServer,
-			secret,
+			secret.Token,
+			dtclient.WithAuthURL(secret.AuthUrl),
 		)
 		if err != nil {
 			return err

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
@@ -679,7 +679,7 @@ func TestGetDQLCannotPostQuery_EvaluateQuery(t *testing.T) {
 
 func TestDQLInitClientWithSecret_EvaluateQuery(t *testing.T) {
 
-	namespace := "keptn-lifecycle-toolkit-system"
+	namespace := "keptn-system"
 
 	mySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1047,7 +1047,7 @@ func TestGetDQLCannotPostQuery_EvaluateQueryForStep(t *testing.T) {
 
 func TestDQLInitClientWithSecret_EvaluateQueryForStep(t *testing.T) {
 
-	namespace := "keptn-lifecycle-toolkit-system"
+	namespace := "keptn-system"
 
 	mySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
@@ -679,7 +679,7 @@ func TestGetDQLCannotPostQuery_EvaluateQuery(t *testing.T) {
 
 func TestDQLInitClientWithSecret_EvaluateQuery(t *testing.T) {
 
-	namespace := "keptn-system"
+	namespace := "keptn-lifecycle-toolkit-system"
 
 	mySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1047,7 +1047,7 @@ func TestGetDQLCannotPostQuery_EvaluateQueryForStep(t *testing.T) {
 
 func TestDQLInitClientWithSecret_EvaluateQueryForStep(t *testing.T) {
 
-	namespace := "keptn-system"
+	namespace := "keptn-lifecycle-toolkit-system"
 
 	mySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_dql_test.go
@@ -687,7 +687,7 @@ func TestDQLInitClientWithSecret_EvaluateQuery(t *testing.T) {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"my-key": []byte("dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
+			"my-key": []byte(dqlSecretString),
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
@@ -1055,7 +1055,7 @@ func TestDQLInitClientWithSecret_EvaluateQueryForStep(t *testing.T) {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"my-key": []byte("dt0s08.XX.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"),
+			"my-key": []byte(dqlSecretString),
 		},
 		Type: corev1.SecretTypeOpaque,
 	}

--- a/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go
+++ b/metrics-operator/controllers/common/providers/dynatrace/dynatrace_test.go
@@ -447,7 +447,6 @@ func TestEvaluateQuery_MissingSecret(t *testing.T) {
 	_, _, e := kdp.EvaluateQuery(context.TODO(), keptnMetric, p)
 	require.NotNil(t, e)
 	require.ErrorIs(t, e, ErrSecretKeyRefNotDefined)
-
 }
 
 func TestEvaluateQuery_SecretNotFound(t *testing.T) {


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

* made AuthUrl in metrics-operator configurable
* removed `DefaultAuthUrl`
* added tests

Fixes #1968

# How to test


- [ ] Manual Test A
- [ ] Unit Test B
- [ ] Integration Test C

# Checklist

- [ ] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [ ] I used descriptive commit messages to help reviewers understand my thought process
- [ ] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [ ] New and existing unit and integration tests pass locally with my changes

<!-- DOCS SECTION -->
<!-- USE THIS FOR DOCS CONTRIBUTIONS -->
