### PR TITLE
chore(scheduler): adapt namespace name

### DIFF
--- a/scheduler/manifests/install/base/deployment.yaml
+++ b/scheduler/manifests/install/base/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     component: scheduler
   name: scheduler
-  namespace: keptn-lifecycle-toolkit-system
+  namespace: keptn-system
 spec:
   selector:
     matchLabels:

--- a/scheduler/manifests/install/base/rbac.yaml
+++ b/scheduler/manifests/install/base/rbac.yaml
@@ -81,7 +81,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: keptn-scheduler
-    namespace: keptn-lifecycle-toolkit-system
+    namespace: keptn-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -95,4 +95,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: keptn-scheduler
-    namespace: keptn-lifecycle-toolkit-system
+    namespace: keptn-system

--- a/scheduler/manifests/install/base/serviceaccount.yaml
+++ b/scheduler/manifests/install/base/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: keptn-scheduler
-  namespace: keptn-lifecycle-toolkit-system
+  namespace: keptn-system

--- a/scheduler/manifests/install/kustomization.yaml
+++ b/scheduler/manifests/install/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: keptn-lifecycle-toolkit-system
+namespace: keptn-system
 resources:
   - base/deployment.yaml
   - base/rbac.yaml
@@ -19,4 +19,4 @@ patches:
     target:
       kind: Deployment
       name: scheduler
-      namespace: keptn-lifecycle-toolkit-system
+      namespace: keptn-system


### PR DESCRIPTION
This PR adapts the namespace of the scheduler to `keptn-system`, as the previously used `keptn-lifecycle-toolkit-system` namespace is not used anywhere else anymore