### PR TITLE
docs: link to contrib guide from docs-new/CONTRIBUTING.md

### DIFF
--- a/docs-new/CONTRIBUTING.md
+++ b/docs-new/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contribute to the Keptn documentation
 
 This is the root of the source code for
-the [Keptn documentation](https://lifecycle.keptn.sh/docs/),
+the
+[Keptn documentation](https://lifecycle.keptn.sh/docs/),
 which is part of the
 [Keptn](https://keptn.sh) website.
 

--- a/docs-new/CONTRIBUTING.md
+++ b/docs-new/CONTRIBUTING.md
@@ -59,4 +59,3 @@ For information about previewing `.md` files
 that are outside the documentation NAV path
 (such as `README.md` and `CONTRIBUTING.md` files), see
 [Building markdown files without Hugo](https://keptn.sh/latest/docs/contribute/docs/local-building/#building-markdown-files-without-hugo).
-

--- a/docs-new/CONTRIBUTING.md
+++ b/docs-new/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 This is the root of the source code for
 the [Keptn documentation](https://lifecycle.keptn.sh/docs/),
-which is part of the [Keptn](https://keptn.sh) website.
+which is part of the
+[Keptn](https://keptn.sh) website.
 
 The Keptn documentation is authored with
 [markdown](https://www.markdownguide.org/basic-syntax/)

--- a/docs-new/CONTRIBUTING.md
+++ b/docs-new/CONTRIBUTING.md
@@ -18,18 +18,18 @@ You can make modifications in various ways:
   this works well for small modifications.
 - Use GitHub Codespaces.
    See
-  [Codespaces](./docs/contribute/general/codespace.md).
+  [Codespaces](https://keptn.sh/latest/docs/contribute/general/codespace/)
 - If you are making significant changes,
   you may find it better to fork and clone the repository
   and make changes using the text editor or IDE of your choice.
-  See [Working with git](docs/contribute/general/git/index.md).
+  See [Working with Git](https://keptn.sh/latest/docs/contribute/general/git/)
 
   You can run the website locally
   to check the rendered documentation.
   and then push your changes to the repository as a pull request.
 
 See the
-[Contributing guide](./docs/contribute/index.md)
+[Contributing guide](https://keptn.sh/latest/docs/contribute/)
 for more information about tools and practices to use
 when contributing to the Keptn project.
 
@@ -53,4 +53,10 @@ is displayed in the logs.
 By default this should be `http://0.0.0.0:8000/`
 
 For more details, see
-[Build documentation locally](docs/contribute/docs/local-building.md).
+[Build documentation locally](https://keptn.sh/latest/docs/contribute/docs/local-building/)
+
+For information about previewing `.md` files
+that are outside the documentation NAV path
+(such as `README.md` and `CONTRIBUTING.md` files), see
+[Building markdown files without Hugo](https://keptn.sh/latest/docs/contribute/docs/local-building/#building-markdown-files-without-hugo).
+

--- a/docs-new/CONTRIBUTING.md
+++ b/docs-new/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribute to the Keptn documentation
 
-This document provides information about contributing to
+This is the root of the source code for
 the [Keptn documentation](https://lifecycle.keptn.sh/docs/),
 which is part of the [Keptn](https://keptn.sh) website.
 
@@ -10,14 +10,26 @@ and rendered using
 [MkDocs](https://www.mkdocs.org/).
 
 We welcome and encourage contributions of all levels.
-You can make modifications using the GitHub editor;
-this works well for small modifications but,
-if you are making significant changes,
-you may find it better to fork and clone the repository
-and make changes using the text editor or IDE of your choice.
-You can also run the website locally
-to check the rendered documentation
-and then push your changes to the repository as a pull request.
+You can make modifications in various ways:
+
+- Use the GitHub editor;
+  this works well for small modifications.
+- Use GitHub Codespaces.
+   See
+  [Codespaces](./docs/contribute/general/codespace.md).
+- If you are making significant changes,
+  you may find it better to fork and clone the repository
+  and make changes using the text editor or IDE of your choice.
+  See [Working with git](docs/contribute/general/git/index.md).
+
+  You can run the website locally
+  to check the rendered documentation.
+  and then push your changes to the repository as a pull request.
+
+See the
+[Contributing guide](./docs/contribute/index.md)
+for more information about tools and practices to use
+when contributing to the Keptn project.
 
 If you need help getting started,
 feel free to ask for help on the `#keptn` channel on the [CNCF Slack](https://cloud-native.slack.com).
@@ -31,9 +43,12 @@ To build and deploy the documentation in a container, execute
 make docs-serve
 ```
 
-This will setup a container, install all needed dependencies,
-build the documentation and serve it.
+This sets up a container, installs all needed dependencies,
+builds the documentation, and serves it.
 
-The URL on which your local documentation website is deployed will be
-displayed in the logs.
+The URL on which your local documentation website is deployed
+is displayed in the logs.
 By default this should be `http://0.0.0.0:8000/`
+
+For more details, see
+[Build documentation locally](docs/contribute/docs/local-building.md).


### PR DESCRIPTION
# Summary
Link to Contributing Guide from docs-new/CONTRIBUTING.md

Fixes https://github.com/keptn/lifecycle-toolkit/issues/2757