### PR TITLE
docs: fix AnalysisValueTemplate query in blog post

### DIFF
--- a/docs-new/blog/posts/analyzing-application-performance/memory-usage.yaml
+++ b/docs-new/blog/posts/analyzing-application-performance/memory-usage.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   provider:
     name: my-dynatrace-provider
-  query: 'metricSelector=builtin:kubernetes.workload.memory_working_set:filter(eq("dt.entity.cloud_application",CLOUD_APPLICATION-3B2BD00402B933C2)):splitBy("dt.entity.cloud_application"):sum' # yamllint disable-line rule:line-length
+  query: 'builtin:kubernetes.workload.memory_working_set:filter(eq("dt.entity.cloud_application",CLOUD_APPLICATION-3B2BD00402B933C2)):splitBy("dt.entity.cloud_application"):sum' # yamllint disable-line rule:line-length


### PR DESCRIPTION
The example query was including the `metricSelector=` prefix, which is added by the dynatrace provider later on as well 