### PR TITLE
docs: analysis for non-k8s deployments

### DIFF
--- a/docs-new/docs/migrate/strategy.md
+++ b/docs-new/docs/migrate/strategy.md
@@ -25,7 +25,8 @@ but must be rewritten to utilize Keptn components.
 
 Keptn targets deployments that run on Kubernetes
 but some Keptn functionality can be used with deployments
-that do not run on Kubernetes.  See
+that do not run on Kubernetes.
+See
 [Keptn for non-Kubernetes deployments](../use-cases/non-k8s.md)
 for details.
 

--- a/docs-new/docs/migrate/strategy.md
+++ b/docs-new/docs/migrate/strategy.md
@@ -1,12 +1,5 @@
 # Migration strategy
 
-> **Note**
-This section is under development.
-Information that is published here has been reviewed for technical accuracy
-but the format and content is still evolving.
-We hope you will contribute your experiences
-and questions that you have.
-
 Before you begin the migration project,
 we suggest that you run through the exercises in
 [Getting started](../getting-started/index.md)
@@ -29,6 +22,12 @@ than Keptn v1 and so migration requires technical adjustments.
 Much of the logic and functionality of your Keptn v1 projects
 can be migrated to Keptn
 but must be rewritten to utilize Keptn components.
+
+Keptn targets deployments that run on Kubernetes
+but some Keptn functionality can be used with deployments
+that do not run on Kubernetes.  See
+[Keptn for non-Kubernetes deployments](../use-cases/non-k8s.md)
+for details.
 
 Some key points:
 

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -23,7 +23,9 @@ Keptn tasks running on a Kubernetes cluster can be triggered for
 and applications that are deployed outside of Kubernetes.
 For example, Keptn can run (or "trigger")
 load and performance tests
-for an application that is deployed on a virtual machine.
+for an application that is deployed on a virtual machine,
+or any other environment, as long as it can be reached
+by the container running the KeptnTask.
 It does this by specifying a container image that should be executed.
 You specify the container in a `KeptnTaskDefinition` resource; see
 [Deployment tasks](../guides/tasks.md) for more information.

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -198,7 +198,7 @@ To implement a Keptn analysis for your deployment:
   assigns a `name` that Keptn uses to reference that provider,
   and can define a secret for the data provider if necessary.
 
-- Create `ValueTemplate` resources for each SLI
+- Create `AnalysisValueTemplate` resources for each SLI
   and an `AnalysisDefinition` resource that contains all SLOs
   to be used in your analysis
 

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -199,7 +199,7 @@ To implement a Keptn analysis for your deployment:
   and can define a secret for the data provider if necessary.
 
 - Create `ValueTemplate` resources for each SLI
-  and `AnalysisDefinition` resources for each SLO
+  and an `AnalysisDefinition` resource that contains all SLOs
   to be used in your analysis
 
 - Create and apply an `Analysis` resource

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -171,7 +171,8 @@ analyzes Service Level Objectives (SLOs)
 based on Service Level Indicators (SLIs).
 It can apply weights to reach a composite score
 about the health of the deployment,
-similar to what the Keptn v1 quality gates provided.
+similar to what the metrics evaluations of the
+Keptn v1 quality gates feature provided.
 The data used can come from multiple instances
 of multiple data providers
 (such as Prometheus, Dynatrace, and DataDog).

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -9,11 +9,11 @@ The following functionality is available for deployments not on Kubernetes:
 
 To use either of these features,
 you must set up a Kubernetes cluster and
-[install](../installation/_index.md#basic-installation)
+[install](../installation/index.md#basic-installation)
 Keptn on it,
 but this can be a very lightweight, single-node KinD cluster; see
 [Create local Kubernetes cluster](../installation/k8s.md#create-local-kubernetes-cluster).
-Keptn only runs  on-demand `KeptnTask` and `KeptnAnaylsis` resources
+Keptn only runs  on-demand `KeptnTask` and `KeptnAnalysis` resources
 so resource utilization is minimal.
 
 ## Run KeptnTask for a deployment not on Kubernetes
@@ -24,7 +24,7 @@ and applications that are deployed outside of Kubernetes.
 For example, Keptn can run (or "trigger")
 load and performance tests
 for an application that is deployed on a virtual machine.
-It does this by specifing a container image that should be executed.
+It does this by specifying a container image that should be executed.
 You specify the container in a `KeptnTaskDefinition` resource; see
 [Deployment tasks](../guides/tasks.md) for more information.
 The `KeptnTask` runs as a Kubernetes
@@ -80,7 +80,7 @@ You must manually create the
 In the standard operating mode,
 when Keptn is managing
 [workloads](https://kubernetes.io/docs/concepts/workloads/)
-for deploymens running on Kubernetes,
+for deployments running on Kubernetes,
 the creation of the `KeptnTask` resource is automatic.
 
 Moreover, each time you want to execute a `KeptnTask`,

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -38,7 +38,6 @@ as described above, then::
 
 - [Create a KeptnTaskDefinition](#create-a-keptntaskdefinition)
 - [Create and apply a KeptnTask](#create-and-apply-a-keptntask)
-- [Re-run the KeptnTask](#re-run-the-keptntask)
 
 ### Create a KeptnTaskDefinition
 
@@ -118,8 +117,6 @@ kubectl apply -f test-task.yaml -n my-keptn-annotated-namespace
 
 Applying this file causes Keptn to create a Kubernetes
 [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
-and a Kubernetes
-[pod](https://kubernetes.io/docs/concepts/workloads/pods/)
 and run the executables defined
 in the associated `KeptnTaskDefinition` resource.
 
@@ -130,12 +127,8 @@ kubectl get keptntasks -n my-keptn-annotated-namespace
 kubectl get pods -n my-keptn-annotated-namespace
 ```
 
-See the
-
-### Re-run the KeptnTask
-
 For subsequent KeptnTask runs,
-the `KeptnTask` name and version fields must be unique,
+the values of the `KeptnTask` `name` and `version` fields must be unique,
 so copy the `KeptnTask` yaml file you have and update the
 `metadata.name` field.
 

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -1,29 +1,44 @@
-# Keptn - Kubernetes
+# Keptn for non-Kubernetes deployments
 
-Keptn Tasks running on a Kubernetes cluster
-can be triggered for [workloads](https://kubernetes.io/docs/concepts/workloads/) and applications
-that are deployed outside of Kubernetes.
-For example, Keptn could trigger load and performance tests
+Keptn can interact with deployments that are not running on Kubernetes
+even though Keptn mainly targets Kubernetes deployments.
+The following functionality is available for deployments not on Kubernetes:
+
+- [Run Keptn tasks](#run-keptntask-for-a-deployment-not-on-kubernetes)
+- [Run Keptn analysis](#run-keptn-analysis-for-a-deployment-not-on-kubernetes)
+
+To use either of these features,
+you must set up a Kubernetes cluster and
+[install](../installation/_index.md#basic-installation)
+Keptn on it,
+but this can be a very lightweight, single-node KinD cluster; see
+[Create local Kubernetes cluster](../installation/k8s.md#create-local-kubernetes-cluster).
+Keptn only runs  on-demand `KeptnTask` and `KeptnAnaylsis` resources
+so resource utilization is minimal.
+
+## Run KeptnTask for a deployment not on Kubernetes
+
+Keptn tasks running on a Kubernetes cluster can be triggered for
+[workloads](https://kubernetes.io/docs/concepts/workloads/)
+and applications that are deployed outside of Kubernetes.
+For example, Keptn can run (or "trigger")
+load and performance tests
 for an application that is deployed on a virtual machine.
+It does this by specifing a container image that should be executed.
+You specify the container in a `KeptnTaskDefinition` resource; see
+[Deployment tasks](../guides/tasks.md) for more information.
+The `KeptnTask` runs as a Kubernetes
+[job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+on the cluster where Keptn is installed.
 
-To do this:
+To implement this, install Keptn on a Kubernetes cluster
+as described above, then::
 
-- [Install Keptn on a Kubernetes cluster](#install-keptn-on-a-kubernetes-cluster)
 - [Create a KeptnTaskDefinition](#create-a-keptntaskdefinition)
 - [Create and apply a KeptnTask](#create-and-apply-a-keptntask)
 - [Re-run the KeptnTask](#re-run-the-keptntask)
 
-## Install Keptn on a Kubernetes cluster
-
-You must set up a Kubernetes cluster and
-[install](../installation/index.md#basic-installation)
-Keptn on it,
-but this can be a very lightweight, single-node KinD cluster; see
-[Create local Kubernetes cluster](../installation/k8s.md#create-local-kubernetes-cluster).
-Keptn only triggers on-demand `KeptnTask` resources
-so resource utilization is minimal.
-
-## Create a KeptnTaskDefinition
+### Create a KeptnTaskDefinition
 
 When you have Keptn installed, create a
 YAML file that defines what you want to execute
@@ -58,11 +73,14 @@ See
 [Runners and containers](../guides/tasks.md#runners-and-containers)
 for more information.
 
-## Create and apply a KeptnTask
+### Create and apply a KeptnTask
 
 You must manually create the
 [KeptnTask](../reference/crd-reference/task.md) resource.
-In the standard operating mode, when Keptn is managing [workloads](https://kubernetes.io/docs/concepts/workloads/),
+In the standard operating mode,
+when Keptn is managing
+[workloads](https://kubernetes.io/docs/concepts/workloads/)
+for deploymens running on Kubernetes,
 the creation of the `KeptnTask` resource is automatic.
 
 Moreover, each time you want to execute a `KeptnTask`,
@@ -96,7 +114,10 @@ You can then apply this YAML file with the following command:
 kubectl apply -f test-task.yaml -n my-keptn-annotated-namespace
 ```
 
-Applying this file causes Keptn to create a Job and a Pod
+Applying this file causes Keptn to create a Kubernetes
+[job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+and a Kubernetes
+[pod](https://kubernetes.io/docs/concepts/workloads/pods/)
 and run the executables defined
 in the associated `KeptnTaskDefinition` resource.
 
@@ -107,7 +128,9 @@ kubectl get keptntasks -n my-keptn-annotated-namespace
 kubectl get pods -n my-keptn-annotated-namespace
 ```
 
-## Re-run the KeptnTask
+See the
+
+### Re-run the KeptnTask
 
 For subsequent KeptnTask runs,
 the `KeptnTask` name and version fields must be unique,
@@ -134,8 +157,55 @@ spec:
     workloadVersion: "1.0.1"
 ```
 
-You can then apply this file with the following command:
+Use the following command to apply this resource:
 
 ```shell
 kubectl apply -f test-task-2.yaml -n my-keptn-annotated-namespace
 ```
+
+See the
+[Deployment tasks](../guides/tasks.md)
+guide and associated reference pages
+for more information about running Keptn tasks
+with deployments that do not run on Kubernetes.
+
+## Run Keptn analysis for a deployment not on Kubernetes
+
+The Keptn analyses feature
+analyzes Service Level Objectives (SLOs)
+based on Service Level Inputs (SLIs).
+It can apply weights to reach a composite score
+about the health of the deployment,
+similar to what the Keptn v1 quality gates provided.
+The data used can come from multiple instances
+of multiple data providers
+(such as Prometheus, Dynatrace, and DataDog).
+
+A Keptn analysis can be run for any application running anywhere
+as long Keptn can access a monitoring provider endpoint
+that serves metrics for the application.
+You can point to multiple instances of the supported monitoring providers
+(Prometheus, Dynatrace, Datadog, and dql)
+so the application itself can run anywhere,
+
+To implement a Keptn analysis for your deployment:
+
+- Create a `KeptnMetricProvider` resource
+  for each data source to be used for your analysis.
+  This specifies the URL for the data source,
+  assigns a `name` that Keptn uses to reference that provider,
+  and can define a secret for the data provider if necessary.
+
+- Create `ValueTemplate` resources for each SLI
+  and `AnalysisDefinition` resources for each SLO
+  to be used in your analysis
+
+- Create and apply an `Analysis` resource
+  to define each specific analysis you want to run.
+
+See the
+[Analysis](../guides/slo.md)
+guide and the
+[Analyzing Application Performance with Keptn](https://keptn.sh/latest/blog/2023/12/19/analyzing-application-performance-with-keptn/)
+blog
+for more details and examples for the Keptn analysis feature.

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -168,7 +168,7 @@ with deployments that do not run on Kubernetes.
 
 The Keptn analyses feature
 analyzes Service Level Objectives (SLOs)
-based on Service Level Inputs (SLIs).
+based on Service Level Indicators (SLIs).
 It can apply weights to reach a composite score
 about the health of the deployment,
 similar to what the Keptn v1 quality gates provided.

--- a/docs-new/docs/use-cases/non-k8s.md
+++ b/docs-new/docs/use-cases/non-k8s.md
@@ -188,7 +188,7 @@ as long Keptn can access a monitoring provider endpoint
 that serves metrics for the application.
 You can point to multiple instances of the supported monitoring providers
 (Prometheus, Dynatrace, Datadog, and dql)
-so the application itself can run anywhere,
+so the application itself can run anywhere.
 
 To implement a Keptn analysis for your deployment:
 


### PR DESCRIPTION
# Summary

This captures information @bacherfl provided in a Slack discussion about using Keptn with deployments that do not run on Kubernetes.

* Change title of this page to be more appropriate and descriptive
* Remove metadata from the file
* Add information about running analyses on a non-k8s deployment
* Required some restructuring of the file

Fixes # https://github.com/keptn/lifecycle-toolkit/issues/2760 

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [ x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [x] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
