### PR TITLE
docs: add documentation for the refinement process in the contribute guide

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -510,6 +510,7 @@ previousversion
 printargs
 printcolumn
 privs
+Process
 proj
 promapi
 promhttp

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -258,6 +258,7 @@ ikbr
 imagepullsecret
 IManager
 IMeter
+inclusivity
 Infof
 inlines
 Intelli

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -621,6 +621,7 @@ teststep
 tgz
 thisthatdc
 thschue
+timeblock
 timeframe
 Timerange
 timeseries

--- a/docs-new/docs/contribute/general/contrib-guidelines-gen.md
+++ b/docs-new/docs/contribute/general/contrib-guidelines-gen.md
@@ -49,10 +49,10 @@ please create an issue on the GitHub repository.
 * Create and refine a ticket
   * When proposing new work, start by creating an issue or ticket in the project's
   [issue tracker](https://github.com/keptn/lifecycle-toolkit/issues).
-  * Actively participate in the refinement meetings sessions that are part of the weekly
+  * Actively participate in the refinement sessions that are part of the weekly
   [community meetings](https://community.cncf.io/keptn-community/).
   * In these sessions, everyone discusses the proposed work, whether it is a good idea,
-  what exactly should be done and how it aligns with project goals.
+  what exactly should be done and how it aligns with the project goals.
   * After the discussions, maintainers engage in a process known as **Scrum Poker**.
   This involves a voting mechanism where maintainers collectively assess the size
   and complexity of the proposed work, helping to decide whether it should proceed.

--- a/docs-new/docs/contribute/general/contrib-guidelines-gen.md
+++ b/docs-new/docs/contribute/general/contrib-guidelines-gen.md
@@ -43,3 +43,17 @@ please create an issue on the GitHub repository.
 * If you want to do the work on an issue,
   include that information in your description of the issue
   or in a comment to the issue.
+
+## Proposing new work
+
+* Create and refine a ticket
+  * When proposing new work, start by creating an issue or ticket in the project's
+  [issue tracker](https://github.com/keptn/lifecycle-toolkit/issue).
+  * Actively participate in the refinement meetings sessions that are part of the weekly
+  [community meetings](https://community.cncf.io/keptn-community/).
+  * In these sessions, everyone discusses the proposed work, whether it is a good idea,
+  what exactly should be done and how it aligns with project goals.
+  * After the discussions, maintainers engage in a process known as **Scrum Poker**.
+  This involves a voting mechanism where maintainers collectively assess the size
+  and complexity of the proposed work, helping to decide whether it should proceed.
+  

--- a/docs-new/docs/contribute/general/contrib-guidelines-gen.md
+++ b/docs-new/docs/contribute/general/contrib-guidelines-gen.md
@@ -48,7 +48,7 @@ please create an issue on the GitHub repository.
 
 * Create and refine a ticket
   * When proposing new work, start by creating an issue or ticket in the project's
-  [issue tracker](https://github.com/keptn/lifecycle-toolkit/issue).
+  [issue tracker](https://github.com/keptn/lifecycle-toolkit/issues).
   * Actively participate in the refinement meetings sessions that are part of the weekly
   [community meetings](https://community.cncf.io/keptn-community/).
   * In these sessions, everyone discusses the proposed work, whether it is a good idea,

--- a/docs-new/docs/contribute/general/refinement-guide.md
+++ b/docs-new/docs/contribute/general/refinement-guide.md
@@ -1,0 +1,49 @@
+# Refinement timeblock
+
+During Refinement timeblock, maintainers engage in technical
+discussions on open issues and pull requests.
+This dedicated time allows for in-depth conversations, knowledge sharing,
+and collective decision-making.
+It is an opportunity for the team to synchronize their understanding of
+ongoing developments, address challenges, and ensure a common vision for the project.
+
+**Purpose and goals:**
+
+- **Alignment:** Ensure a shared understanding among maintainers regarding ongoing
+developments, project goals, and upcoming tickets.
+- **Technical Depth:** Delve into the technical aspects of open issues and pull
+requests, facilitating a deeper understanding of proposed Pull requests.
+- **Decision-Making:** Make collective decisions on the adoption of new features,
+changes, and improvements based on technical merit.
+
+This process aligns with our commitment to open-source principles, ensuring that
+technical discussions are inclusive, transparent, and beneficial for the
+entire Keptn community.
+
+## Contributor guidance
+
+Contributors proposing new features are encouraged to participate in
+[refinement meetings](https://community.cncf.io/keptn-community/) related
+to their contributions.
+This provides valuable insights into ongoing technical discussions and
+aligns their efforts with the broader project vision.
+Follow these steps:
+
+1. Review the project's [contributing guide](../docs/contrib-guidelines-docs.md)
+for information on upcoming refinement meetings.
+1. Attend relevant refinement meetings to present and discuss proposed features.
+1. Actively engage in technical discussions, seeking feedback and guidance from
+maintainers.
+1. Iteratively refine contributions based on insights gained during meetings.
+
+By following this process, contributors contribute not only code but also valuable
+perspectives and insights, fostering a collaborative and innovative
+community environment.
+
+## Outcome
+
+- Shared understanding among maintainers and contributors on ongoing developments.
+- Improved contributions via collaborative discussions and refinement.
+- Documented decisions and action items for future reference in project documentation.
+This refined process aligns with our commitment to open-source principles, ensuring
+transparency, inclusivity, and technical excellence within the Keptn community.

--- a/docs-new/docs/contribute/general/refinement-guide.md
+++ b/docs-new/docs/contribute/general/refinement-guide.md
@@ -1,6 +1,6 @@
-# Refinement timeblock
+# Refinement process
 
-During Refinement timeblock, maintainers engage in technical
+During the Refinement timeblock in community meetings, maintainers engage in technical
 discussions on open issues and pull requests.
 This dedicated time allows for in-depth conversations, knowledge sharing,
 and collective decision-making.
@@ -23,13 +23,13 @@ entire Keptn community.
 ## Contributor guidance
 
 Contributors proposing new features are encouraged to participate in
-[refinement meetings](https://community.cncf.io/keptn-community/) related
-to their contributions.
+refinement sessions during [community meetings](https://community.cncf.io/keptn-community/) to talk
+about their contributions.
 This provides valuable insights into ongoing technical discussions and
 aligns their efforts with the broader project vision.
 Follow these steps:
 
-1. Review the project's [contributing guide](../docs/contrib-guidelines-docs.md)
+1. Review the project's [contributing guide](../index.md)
 for information on upcoming refinement meetings.
 1. Attend relevant refinement meetings to present and discuss proposed features.
 1. Actively engage in technical discussions, seeking feedback and guidance from
@@ -45,5 +45,6 @@ community environment.
 - Shared understanding among maintainers and contributors on ongoing developments.
 - Improved contributions via collaborative discussions and refinement.
 - Documented decisions and action items for future reference in project documentation.
+
 This refined process aligns with our commitment to open-source principles, ensuring
 transparency, inclusivity, and technical excellence within the Keptn community.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,7 @@ nav:
               - Create PR: docs/contribute/general/git/pr-create.md
               - PR review process: docs/contribute/general/git/review.md
           - Contribution Guidelines: docs/contribute/general/contrib-guidelines-gen.md
+          - Refinement Timeblock: docs/contribute/general/refinement-guide.md
       - Software contributions:
           - docs/contribute/software/index.md
           - Software development environment: docs/contribute/software/dev-environ.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,7 +171,7 @@ nav:
               - Create PR: docs/contribute/general/git/pr-create.md
               - PR review process: docs/contribute/general/git/review.md
           - Contribution Guidelines: docs/contribute/general/contrib-guidelines-gen.md
-          - Refinement Timeblock: docs/contribute/general/refinement-guide.md
+          - Refinement Process: docs/contribute/general/refinement-guide.md
       - Software contributions:
           - docs/contribute/software/index.md
           - Software development environment: docs/contribute/software/dev-environ.md


### PR DESCRIPTION
# Description

This pull request addresses the issue #2675, where the goal is to document the refinement process in the contribute guide.

Fixes #2675

### Changes Made:

- Added a new page named `refinement-guide.md` in the contribute/general section.
- Updated the `contribut-guidelines-gen.md` file to include guidance on creating and refining tickets for proposed work.
- Provided detailed for contributors and members on how to participate in refinement meetings and improve their contributions iteratively.

# Checks

- [ ] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [X] I used descriptive commit messages to help reviewers understand my thought process
- [X] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [X] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [X] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [X] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
