### PR TITLE
docs: fix left frame title for keptn-no-k8s

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,7 @@ nav:
           - docs/use-cases/index.md
           - Day 2 Operations: docs/use-cases/day-2-operations.md
           - Keptn + HorizontalPodAutoscaler: docs/use-cases/hpa.md
-          - Keptn - Kubernetes: docs/use-cases/non-k8s.md
+          - Keptn for non-Kubernetes deployments: docs/use-cases/non-k8s.md
       - Components:
           - docs/components/index.md
           - Lifecycle Operator:
@@ -173,7 +173,6 @@ nav:
           - Contribution guidelines for documentation: docs/contribute/docs/contrib-guidelines-docs.md
           - Build Documentation Locally: docs/contribute/docs/local-building.md
           - Linter Requirements: docs/contribute/docs/linter-requirements.md
-          - Spell Checker: docs/contribute/docs/spell-check.md
           - Source File Structure: docs/contribute/docs/source-file-structure.md
           - Published Doc Structure: docs/contribute/docs/publish.md
           - Word list: docs/contribute/docs/word-list.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
           - Build Documentation Locally: docs/contribute/docs/local-building.md
           - Linter Requirements: docs/contribute/docs/linter-requirements.md
           - Source File Structure: docs/contribute/docs/source-file-structure.md
+          - Spell Checker: docs/contribute/docs/spell-check.md
           - Published Doc Structure: docs/contribute/docs/publish.md
           - Word list: docs/contribute/docs/word-list.md
   - Blog:


### PR DESCRIPTION
This makes the title for use-cases/keptn-non-k8s match the title in the main frame.