### PR TITLE
docs: add info on how to run kuttl tests

### DIFF
--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -160,7 +160,7 @@ Run the integration tests from the root directory of your clone:
 This runs a series of Kuttl
 ([KUbernetes Test TooL](https://kuttl.dev/))
 tests locally and then cleans up your local environment.
-You can run individual tests with the `kubectl` command;
+You can run individual tests with the `kubectl kuttl` command;
 see the *Makefile* for the specific syntax of each test.
 
 ### Component test

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -144,27 +144,50 @@ Tests are run on your local machine.
 Study the detailed log that is produced to identify why the test failed.
 Study these errors, modify your code, and rerun the test until it passes.
 
-1. Use your IDE to run unit tests on your code.
+### Unit tests
 
-1. Run the integration tests from the root directory of your clone:
+Use your IDE to run unit tests on your code.
+
+### Integration tests
+
+Run the integration tests from the root directory of your clone:
+
+  ```shell
+  make integration-test-local
+  ```
+
+`integration-test-local` cleans up after the test.
+
+### Component test
+
+From the `lifecycle-operator` directory, run the component test:
+
+  ```shell
+  make component-test
+  ```
+
+### Component test
+
+From the `lifecycle-operator` directory, run the end-to-end tests:
+
+  ```shell
+  make e2e-test
+  ```
+
+### Kuttl test
+
+Run the Kuttl [KUbernetes Test TooL](https://kuttl.dev/)
+if your PR modifies one of the operators.
+The syntax is:
 
 ```shell
-make integration-test-local
+kubectl kuttl test --start-kind=false ./test/integration/ \
+        --config=kuttl-test.yaml --test name-of-your-test-directory
 ```
 
-   `integration-test-local` cleans up after the test.
-
-1. From the `lifecycle-operator` directory, run the component test:
-
-```shell
-make component-test
-```
-
-1. From the `lifecycle-operator` directory, run the end-to-end tests:
-
-```shell
-make e2e-test
-```
+Logs are printed only when the test fails.
+To force a failure,
+modify some value that appears in an assert file of the test.
 
 ## Create and manage the PR
 

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -120,13 +120,14 @@ You are now ready to make your changes to the source code.
 1. Make your changes to the appropriate component.
 
 1. Deploy the component you modified and push the image to your private Github repository.
-   Note that you do not need to rebuild all components,
-   only the one you modified.
+   Note that you only need to rebuild the component you modified;
+   you do not need to rebuild all components.
    For example, if your modifications are to the `metrics-operator`, run:
 
-```shell
-make build-deploy-metrics-operator RELEASE_REGISTRY=docker.io/exampleuser TAG=my-feature
-```
+     ```shell
+     make build-deploy-metrics-operator \
+         RELEASE_REGISTRY=docker.io/exampleuser TAG=my-feature
+     ```
 
 ## Testing
 
@@ -156,7 +157,15 @@ Run the integration tests from the root directory of your clone:
   make integration-test-local
   ```
 
-`integration-test-local` cleans up after the test.
+This runs a series of Kuttl
+([KUbernetes Test TooL](https://kuttl.dev/))
+tests locally and then cleans up your local environment.
+You can run individual tests with the `kubectl` command;
+see the *Makefile* for the specific syntax of each test.
+
+Logs are printed only when the test fails.
+To force a failure,
+modify some value that appears in an assert file of the test.
 
 ### Component test
 
@@ -173,21 +182,6 @@ From the `lifecycle-operator` directory, run the end-to-end tests:
   ```shell
   make e2e-test
   ```
-
-### Kuttl test
-
-Run the Kuttl [KUbernetes Test TooL](https://kuttl.dev/)
-if your PR modifies one of the operators.
-The syntax is:
-
-```shell
-kubectl kuttl test --start-kind=false ./test/integration/ \
-        --config=kuttl-test.yaml --test name-of-your-test-directory
-```
-
-Logs are printed only when the test fails.
-To force a failure,
-modify some value that appears in an assert file of the test.
 
 ## Create and manage the PR
 

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -173,7 +173,7 @@ From the `lifecycle-operator` directory, run the component tests:
 
 ### End-to-end test
 
-From the `lifecycle-operator` directory, run the end-to-end tests:
+From the `lifecycle-operator` or `scheduler` directory, run the end-to-end tests:
 
   ```shell
   make e2e-test

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -163,7 +163,6 @@ tests locally and then cleans up your local environment.
 You can run individual tests with the `kubectl` command;
 see the *Makefile* for the specific syntax of each test.
 
-
 ### Component test
 
 From the `lifecycle-operator` directory, run the component tests:

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -166,7 +166,7 @@ From the `lifecycle-operator` directory, run the component test:
   make component-test
   ```
 
-### Component test
+### End-to-end test
 
 From the `lifecycle-operator` directory, run the end-to-end tests:
 

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -169,7 +169,7 @@ modify some value that appears in an assert file of the test.
 
 ### Component test
 
-From the `lifecycle-operator` directory, run the component test:
+From the `lifecycle-operator` directory, run the component tests:
 
   ```shell
   make component-test

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -164,8 +164,6 @@ You can run individual tests with the `kubectl` command;
 see the *Makefile* for the specific syntax of each test.
 
 Logs are printed only when the test fails.
-To force a failure,
-modify some value that appears in an assert file of the test.
 
 ### Component test
 

--- a/docs-new/docs/contribute/software/dev-environ.md
+++ b/docs-new/docs/contribute/software/dev-environ.md
@@ -163,7 +163,6 @@ tests locally and then cleans up your local environment.
 You can run individual tests with the `kubectl` command;
 see the *Makefile* for the specific syntax of each test.
 
-Logs are printed only when the test fails.
 
 ### Component test
 


### PR DESCRIPTION
* Captures info about running Kuttle test from slack discussion 15 Jan 2024
* Modified the "Testing" section to have a sub-section for each test rather than a numbered list for all tests.  This makes the types of tests pop a bit more in the page and in the contents in the right frame and is more accurate because people don't need to run all these tests on all PRs.