### PR TITLE
chore: fix sonarcloud duplication detections in API folders

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,9 +4,13 @@ sonar.cpd.exclusions= **/*_test.go,\
   scheduler/test/e2e/fake/**/*.go,\
   lifecycle-operator/apis/lifecycle/v1alpha1/**/*.go,\
   lifecycle-operator/apis/lifecycle/v1alpha2/**/*.go,\
+  lifecycle-operator/apis/lifecycle/v1alpha3/**/*.go,\
+  lifecycle-operator/apis/lifecycle/v1alpha4/**/*.go,\
+  lifecycle-operator/apis/lifecycle/v1beta1/**/*.go,\
   metrics-operator/api/v1alpha1/**/*.go,\
   metrics-operator/api/v1alpha2/**/*.go,\
   metrics-operator/api/v1alpha3/**/*.go,\
+  metrics-operator/api/v1beta1/**/*.go,\
   **/zz_generated.deepcopy.go,\
   **/fake/**/*.go
 sonar.go.exclusions=**/vendor/**,\


### PR DESCRIPTION
### This PR
- adds all API folders for all operators to the ignore sections for duplication detection for SonarCloud
- This should fix the failing sonarcloud checks