### PR TITLE
ci: remove some folders from release-please monorepo setup

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,8 +17,10 @@
         "lifecycle-operator",
         "metrics-operator",
         "scheduler",
-        "runtimes/deno-runtime",
-        "runtimes/python-runtime"
+        "runtimes",
+        ".github/actions/spelling",
+        "test",
+        "examples"
       ],
       "extra-files": [
         "README.md",


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description
This PR tries to fix some of the release issues currently occurring.
It removes some of the root-level folder from being picked up by release-please. This should ensure that when e.g. an integration test is changed or added as part of an operator feature, that won't show up in the keptn-overall changelog. Same with spelling issues and examples.

 Part of #2812