### PR TITLE
chore: set up giscus comment integration for docs page

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -87,7 +87,6 @@ configmapref
 configmapreference
 containedctx
 containerspec
-contextcommon
 contextdata
 controllercommon
 controllererrors
@@ -193,6 +192,7 @@ gha
 ghrs
 ghtoken
 ginkgotypes
+giscus
 Gitlab
 gke
 gms
@@ -213,7 +213,6 @@ graphql
 groupversion
 gstatic
 GVK
-HCNAH
 healthz
 hellopy
 helloworldtask
@@ -238,7 +237,6 @@ ifeq
 ifile
 ifndef
 IHandler
-ikbr
 imagepullsecret
 IManager
 IMeter
@@ -263,10 +261,8 @@ javascripts
 jetstack
 jgehrcke
 Jhb
-Jmn
 jsonschema
 jwt
-Jymo
 kacr
 kauz
 kav
@@ -416,7 +412,6 @@ myservice
 myuser
 myversion
 namespacedelete
-Nde
 netlify
 nifi
 nilnil
@@ -487,7 +482,6 @@ previousversion
 printargs
 printcolumn
 privs
-Process
 proj
 promapi
 promhttp
@@ -612,6 +606,7 @@ trivyignore
 trunc
 ttlsecondsafterfinished
 ttlsecondstask
+typeof
 UIDs
 undeploy
 unmarshal
@@ -651,7 +646,6 @@ WORKLOADOVERALLSTATUS
 workloadsstate
 workloadstatus
 workloadversion
-WZC
 xxxx
 XXXXXXXXXXXXXXXXXXXXXXXX
 yannh

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -109,5 +109,10 @@ LS0[a-zA-Z0-9]+
 # k8s CRD validation patterns
 pattern\: .*$
 
+# data-category-id from Giscus integration
+data-category-id=\".*\"$
+data-repo-id=\".*\"$
+
 # GA tag
 G-[A-Z0-9]+
+\<meta name=\"google-site-verification\" content=".*" \/\>$

--- a/docs/blog/posts/analyzing-application-performance.md
+++ b/docs/blog/posts/analyzing-application-performance.md
@@ -7,6 +7,7 @@ categories:
   - SRE
   - Application Performance
   - Analysis
+comments: true
 ---
 
 # Analyzing Application Performance with Keptn

--- a/docs/blog/posts/keptn-helm-umbrella-charts.md
+++ b/docs/blog/posts/keptn-helm-umbrella-charts.md
@@ -8,6 +8,7 @@ categories:
   - Helm
   - Installation
   - Upgrade
+comments: true
 ---
 
 # Configure Keptn via the new Helm umbrella chart

--- a/docs/docs/components/certificate-operator.md
+++ b/docs/docs/components/certificate-operator.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Cert Manager
 
 The Keptn Cert Manager is a Kubernetes operator that

--- a/docs/docs/components/index.md
+++ b/docs/docs/components/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Components
 
 ## Keptn Components

--- a/docs/docs/components/lifecycle-operator/deployment-flow.md
+++ b/docs/docs/components/lifecycle-operator/deployment-flow.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Flow of deployment
 
 Keptn deploys a

--- a/docs/docs/components/lifecycle-operator/index.md
+++ b/docs/docs/components/lifecycle-operator/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Lifecycle Operator
 
 **Keptn's Lifecycle Operator** is

--- a/docs/docs/components/lifecycle-operator/keptn-apps.md
+++ b/docs/docs/components/lifecycle-operator/keptn-apps.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnApp and KeptnWorkload resources
 
 ## Keptn Workloads

--- a/docs/docs/components/metrics-operator.md
+++ b/docs/docs/components/metrics-operator.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Metrics Operator
 
 The Keptn Metrics Operator collects, processes,

--- a/docs/docs/components/scheduling.md
+++ b/docs/docs/components/scheduling.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn integration with Scheduling
 
 Keptn integrates with Kubernetes scheduling to block

--- a/docs/docs/contribute/docs/assets/yaml-crd-ref-template.md
+++ b/docs/docs/contribute/docs/assets/yaml-crd-ref-template.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # CRD name
 
 Copy this template to create a new CRD reference page.

--- a/docs/docs/contribute/docs/contrib-guidelines-docs.md
+++ b/docs/docs/contribute/docs/contrib-guidelines-docs.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Contribution guidelines for documentation
 
 The [Contribution Guidelines](../general/contrib-guidelines-gen.md) page

--- a/docs/docs/contribute/docs/index.md
+++ b/docs/docs/contribute/docs/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Documentation contributions
 
 This section is under development.

--- a/docs/docs/contribute/docs/linter-requirements.md
+++ b/docs/docs/contribute/docs/linter-requirements.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Linter Requirements
 
 This project uses a set of linters to ensure good code quality.

--- a/docs/docs/contribute/docs/local-building.md
+++ b/docs/docs/contribute/docs/local-building.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Build Documentation Locally
 
 You can run MkDocs locally so that you can view the formatted version

--- a/docs/docs/contribute/docs/publish.md
+++ b/docs/docs/contribute/docs/publish.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Published Doc Structure
 
 New writing goes to the `main` branch and can be viewed on the Keptn website under the `latest` version.

--- a/docs/docs/contribute/docs/source-file-structure.md
+++ b/docs/docs/contribute/docs/source-file-structure.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Source File Structure
 
 The source files for the Keptn documentation

--- a/docs/docs/contribute/docs/spell-check.md
+++ b/docs/docs/contribute/docs/spell-check.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Spell Checker
 
 All PRs that are pushed to a Keptn repository

--- a/docs/docs/contribute/docs/word-list.md
+++ b/docs/docs/contribute/docs/word-list.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Word list
 
 This document summarizes information

--- a/docs/docs/contribute/general/codespace.md
+++ b/docs/docs/contribute/general/codespace.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Codespaces
 
 Use GitHub codespaces as a pre-built and pre-configured development environment.

--- a/docs/docs/contribute/general/contrib-guidelines-gen.md
+++ b/docs/docs/contribute/general/contrib-guidelines-gen.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Contribution Guidelines
 
 Before using Keptn
@@ -56,4 +60,3 @@ please create an issue on the GitHub repository.
   * After the discussions, maintainers engage in a process known as **Scrum Poker**.
   This involves a voting mechanism where maintainers collectively assess the size
   and complexity of the proposed work, helping to decide whether it should proceed.
-  

--- a/docs/docs/contribute/general/dco.md
+++ b/docs/docs/contribute/general/dco.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # DCO
 
 ## Developer Certification of Origin (DCO)

--- a/docs/docs/contribute/general/git/branch-create.md
+++ b/docs/docs/contribute/general/git/branch-create.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Create local branch
 
 After you

--- a/docs/docs/contribute/general/git/fork-clone.md
+++ b/docs/docs/contribute/general/git/fork-clone.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Fork and clone the repository
 
 Perform the following steps to create a copy

--- a/docs/docs/contribute/general/git/index.md
+++ b/docs/docs/contribute/general/git/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Working with Git
 
 Keptn source for software and documentation is stored in the

--- a/docs/docs/contribute/general/git/pr-create.md
+++ b/docs/docs/contribute/general/git/pr-create.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Create PR
 
 When you have completed the checking and testing of your work

--- a/docs/docs/contribute/general/git/review.md
+++ b/docs/docs/contribute/general/git/review.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # PR review process
 
 After you

--- a/docs/docs/contribute/general/index.md
+++ b/docs/docs/contribute/general/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # General information about contributing
 
 This section is under development.

--- a/docs/docs/contribute/general/refinement-guide.md
+++ b/docs/docs/contribute/general/refinement-guide.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Refinement process
 
 During the Refinement timeblock in community meetings, maintainers engage in technical

--- a/docs/docs/contribute/general/technologies.md
+++ b/docs/docs/contribute/general/technologies.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Technologies and concepts you should know
 
 You should understand some related technologies

--- a/docs/docs/contribute/index.md
+++ b/docs/docs/contribute/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Contributing to Keptn
 
 This section is under development.

--- a/docs/docs/contribute/software/dev-environ.md
+++ b/docs/docs/contribute/software/dev-environ.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Software development environment
 
 This page gives instructions and hints for setting up a development environment

--- a/docs/docs/contribute/software/index.md
+++ b/docs/docs/contribute/software/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Software contributions
 
 This section is under development.

--- a/docs/docs/core-concepts/index.md
+++ b/docs/docs/core-concepts/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Core Concepts
 
 Keptn integrates seamlessly with cloud-native deployment tools

--- a/docs/docs/getting-started/index.md
+++ b/docs/docs/getting-started/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Get started
 
 This section provides tutorials to familiarize you

--- a/docs/docs/getting-started/lifecycle-management.md
+++ b/docs/docs/getting-started/lifecycle-management.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Release Lifecycle Management
 
 The Release Lifecycle Management tools run

--- a/docs/docs/getting-started/metrics.md
+++ b/docs/docs/getting-started/metrics.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Metrics
 
 The Keptn metrics component

--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Observability
 
 Keptn provides sophisticated observability features

--- a/docs/docs/guides/auto-app-discovery.md
+++ b/docs/docs/guides/auto-app-discovery.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Auto app discovery
 
 The automatically generated `KeptnApp` file

--- a/docs/docs/guides/dora.md
+++ b/docs/docs/guides/dora.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # DORA metrics
 
 DORA metrics are an industry-standard set of measurements

--- a/docs/docs/guides/evaluatemetrics.md
+++ b/docs/docs/guides/evaluatemetrics.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Metrics
 
 The Keptn Metrics Operator provides a single entry point

--- a/docs/docs/guides/evaluations.md
+++ b/docs/docs/guides/evaluations.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Evaluations
 
 A `KeptnEvaluation` does a simple evaluation of the metrics data you capture,

--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Guides
 
 This section provides comprehensive guides about specific features of Keptn.

--- a/docs/docs/guides/integrate.md
+++ b/docs/docs/guides/integrate.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Integrate Keptn with your Applications
 
 Keptn works

--- a/docs/docs/guides/otel.md
+++ b/docs/docs/guides/otel.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # OpenTelemetry observability
 
 Keptn makes any Kubernetes deployment observable.

--- a/docs/docs/guides/restart-application-deployment.md
+++ b/docs/docs/guides/restart-application-deployment.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Redeploy/Restart an Application
 
 A [KeptnApp](../reference/crd-reference/app.md) can fail

--- a/docs/docs/guides/slo.md
+++ b/docs/docs/guides/slo.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Analysis
 
 The Keptn Metrics Operator Analysis feature

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Deployment tasks
 
 A

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn Documentation
 
 This is the documentation homepage.

--- a/docs/docs/installation/configuration/cert-manager.md
+++ b/docs/docs/installation/configuration/cert-manager.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn + cert-manager.io
 
 Keptn includes

--- a/docs/docs/installation/configuration/index.md
+++ b/docs/docs/installation/configuration/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Configuration
 
 This section contains guides for specific configuration use cases for Keptn.

--- a/docs/docs/installation/configuration/namespace.md
+++ b/docs/docs/installation/configuration/namespace.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # How to structure your namespaces
 
 You have significant flexibility to decide how many namespaces to use

--- a/docs/docs/installation/configuration/vcluster.md
+++ b/docs/docs/installation/configuration/vcluster.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # vCluster installation
 
 Keptn running on Kubernetes versions 1.26 and older

--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Installation
 
 Keptn must be installed onto each Kubernetes cluster you want to monitor.

--- a/docs/docs/installation/k8s.md
+++ b/docs/docs/installation/k8s.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Kubernetes cluster
 
 Keptn is meant to be installed

--- a/docs/docs/installation/tips-tricks.md
+++ b/docs/docs/installation/tips-tricks.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Installation Tips and Tricks
 
 The

--- a/docs/docs/installation/troubleshooting.md
+++ b/docs/docs/installation/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Troubleshooting Guide
 
 Welcome to the Keptn troubleshooting guide.

--- a/docs/docs/installation/uninstall.md
+++ b/docs/docs/installation/uninstall.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Uninstall
 
 > **Warning**

--- a/docs/docs/installation/upgrade.md
+++ b/docs/docs/installation/upgrade.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Upgrade
 
 If you installed the previous version of Keptn using `helm`,

--- a/docs/docs/migrate/index.md
+++ b/docs/docs/migrate/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Migrating to Keptn
 
 Keptn uses a different paradigm than that used for Keptn v1

--- a/docs/docs/migrate/metrics-observe.md
+++ b/docs/docs/migrate/metrics-observe.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Migrate Quality Gates
 
 The SLIs and SLOs used for Keptn v1 quality gates can be ported to

--- a/docs/docs/migrate/strategy.md
+++ b/docs/docs/migrate/strategy.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Migration strategy
 
 Before you begin the migration project,

--- a/docs/docs/reference/api-reference/index.md
+++ b/docs/docs/reference/api-reference/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # API Reference
 
 This section provides comprehensive reference information about all APIs

--- a/docs/docs/reference/crd-reference/analysis.md
+++ b/docs/docs/reference/crd-reference/analysis.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Analysis
 
 An `Analysis` resource customizes the templates

--- a/docs/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/docs/reference/crd-reference/analysisdefinition.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # AnalysisDefinition
 
 An `AnalysisDefinition` resource defines the

--- a/docs/docs/reference/crd-reference/analysisvaluetemplate.md
+++ b/docs/docs/reference/crd-reference/analysisvaluetemplate.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # AnalysisValueTemplate
 
 An `AnalysisValueTemplate` resource

--- a/docs/docs/reference/crd-reference/app.md
+++ b/docs/docs/reference/crd-reference/app.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnApp
 
 A `KeptnApp` resource lists all the [workloads](https://kubernetes.io/docs/concepts/workloads/)

--- a/docs/docs/reference/crd-reference/config.md
+++ b/docs/docs/reference/crd-reference/config.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnConfig
 
 `KeptnConfig` defines Keptn configuration values.

--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnEvaluationDefinition
 
 A `KeptnEvaluationDefinition` assigns target values

--- a/docs/docs/reference/crd-reference/index.md
+++ b/docs/docs/reference/crd-reference/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # CRD Reference
 
 This section provides comprehensive reference information about the

--- a/docs/docs/reference/crd-reference/metric.md
+++ b/docs/docs/reference/crd-reference/metric.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnMetric
 
 A `KeptnMetric` represents a metric that is collected from a provider.

--- a/docs/docs/reference/crd-reference/metricsprovider.md
+++ b/docs/docs/reference/crd-reference/metricsprovider.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnMetricsProvider
 
 KeptnMetricsProvider defines an instance of the data provider

--- a/docs/docs/reference/crd-reference/task.md
+++ b/docs/docs/reference/crd-reference/task.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnTask
 
 Keptn uses KeptnTask resources internally

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # KeptnTaskDefinition
 
 A `KeptnTaskDefinition` defines tasks

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Reference
 
 This section of the Keptn documentation contains reference documentation for the various APIs and CRDs that are used in Keptn.

--- a/docs/docs/use-cases/day-2-operations.md
+++ b/docs/docs/use-cases/day-2-operations.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Day 2 Operations
 
 After you have successfully rolled out your application by following

--- a/docs/docs/use-cases/hpa.md
+++ b/docs/docs/use-cases/hpa.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn + HorizontalPodAutoscaler
 
 ## Scaling Workloads based on Keptn metrics

--- a/docs/docs/use-cases/index.md
+++ b/docs/docs/use-cases/index.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Use Cases
 
 This section contains specific use cases and integration scenarios with other Cloud Native tools.

--- a/docs/docs/use-cases/non-k8s.md
+++ b/docs/docs/use-cases/non-k8s.md
@@ -1,3 +1,7 @@
+---
+comments: true
+---
+
 # Keptn for non-Kubernetes deployments
 
 Keptn can interact with deployments that are not running on Kubernetes

--- a/docs/overrides/partials/comments.html
+++ b/docs/overrides/partials/comments.html
@@ -1,6 +1,6 @@
 {% if page.meta.comments %}
 
-{% if config.site_url and 'keptn.sh' in config.site_url %}
+{% if config.site_url and 'https://keptn.sh/' in config.site_url %}
 <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
 
 <script src="https://giscus.app/client.js"

--- a/docs/overrides/partials/comments.html
+++ b/docs/overrides/partials/comments.html
@@ -15,6 +15,7 @@
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"
+        integrity="sha256-UV9KuqJ2bueZ/Fmd9HH51anivyyIrvJalrpcEMZtmOU="
         async>
 </script>
 

--- a/docs/overrides/partials/comments.html
+++ b/docs/overrides/partials/comments.html
@@ -1,0 +1,56 @@
+{% if page.meta.comments %}
+<h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+
+<script src="https://giscus.app/client.js"
+        data-repo="keptn/lifecycle-toolkit"
+        data-repo-id="R_kgDOH7M67A"
+        data-category="Giscus"
+        data-category-id="DIC_kwDOH7M67M4Ccgrx"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="top"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>
+
+<!-- Synchronize Giscus theme with palette -->
+<script>
+    var giscus = document.querySelector("script[src*=giscus]")
+
+    // Set palette on initial load
+    var palette = __md_get("__palette")
+    if (palette && typeof palette.color === "object") {
+        var theme = palette.color.scheme === "slate"
+            ? "transparent_dark"
+            : "light"
+
+        // Instruct Giscus to set theme
+        giscus.setAttribute("data-theme", theme)
+    }
+
+    // Register event handlers after documented loaded
+    document.addEventListener("DOMContentLoaded", function() {
+        var ref = document.querySelector("[data-md-component=palette]")
+        ref.addEventListener("change", function() {
+            var palette = __md_get("__palette")
+            if (palette && typeof palette.color === "object") {
+                var theme = palette.color.scheme === "slate"
+                    ? "transparent_dark"
+                    : "light"
+
+                // Instruct Giscus to change theme
+                var frame = document.querySelector(".giscus-frame")
+                frame.contentWindow.postMessage(
+                    { giscus: { setConfig: { theme } } },
+                    "https://giscus.app"
+                )
+            }
+        })
+    })
+</script>
+{% endif %}

--- a/docs/overrides/partials/comments.html
+++ b/docs/overrides/partials/comments.html
@@ -15,7 +15,6 @@
         data-lang="en"
         data-loading="lazy"
         crossorigin="anonymous"
-        integrity="sha256-UV9KuqJ2bueZ/Fmd9HH51anivyyIrvJalrpcEMZtmOU="
         async>
 </script>
 

--- a/docs/overrides/partials/comments.html
+++ b/docs/overrides/partials/comments.html
@@ -1,4 +1,6 @@
 {% if page.meta.comments %}
+
+{% if config.site_url and 'keptn.sh' in config.site_url %}
 <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
 
 <script src="https://giscus.app/client.js"
@@ -53,4 +55,5 @@
         })
     })
 </script>
+{% endif %}
 {% endif %}


### PR DESCRIPTION
### This PR
- sets up [Giscus](https://github.com/giscus) as the comment system for the docs page
- adds the `comments: true` tag to all docs pages except the auto-generated API reference so that giscus is enable on most pages
- fixes some minor spelling things where matching patterns can be used
- comments will be saved by giscus in the [github discussions "giscus" category](https://github.com/keptn/lifecycle-toolkit/discussions/categories/giscus)

Fixes #2288

#### Notes
**This PR can be reviewed much easier by looking at separate commits.**
An example comment for testing can be found here: https://keptn--2837.org.readthedocs.build/2837/docs/reference/ .