### PR TITLE
chore: enable markdownlint for new/old docs folder

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,5 +17,4 @@ customRules:
 ignores:
   - "**/CHANGELOG.md"
   - "node_modules"
-  - "docs"
   - "readme-generator-for-helm"


### PR DESCRIPTION
### This PR
- adds back the docs folder for markdown lint