### PR TITLE
chore: add google analytics tag to docs page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,9 @@ site_description: >-
   Enhance Kubernetes monitoring, streamline metrics ingestion, and
   automate deployment validation. Join the Keptn community for insights.
 extra:
+  analytics:
+    provider: google
+    property: G-SJLS2F2J2B
   social:
     - icon: fontawesome/solid/house
       link: https://keptn.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ site_description: >-
 extra:
   analytics:
     provider: google
-    property: G-SJLS2F2J2B
+    property: !ENV GLOBAL_ANALYTICS_CODE
   social:
     - icon: fontawesome/solid/house
       link: https://keptn.sh


### PR DESCRIPTION
Since google analytics apparently doesn't work from the readthedocs integration, this adds GA through mkdocs material which I verified to work.