### PR TITLE
ci: add sbom attestation step to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,17 @@ jobs:
         with:
           tag_name: ${{ matrix.config.tagName }}
           files: ./sbom-${{ matrix.config.name }}.spdx.json
+
+      - name: Attest the Image with SBOM
+        env:
+          IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
+        run: |
+          cosign attest --yes --type spdx --predicate ./sbom-${{ matrix.config.name }}.spdx.json ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
+          cosign verify-attestation --type spdx \
+            --certificate-identity-regexp="https://github.com/keptn/lifecycle-toolkit/.*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
+
   update-examples:
     name: Update examples
     needs:


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

Fixes #2872 

Just a small change to the `release` action to enhance supply chain security best practices by [attesting](https://docs.sigstore.dev/verifying/attestation/) the container images with cosign.
No additional dependencies required to test.
Please also refer to the associated issue for more details.


# How to test

Simply trigger the release action.

# Checklist

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [x] I have performed a self-review of my code
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [x] New and existing unit and integration tests pass locally with my changes

