### PR TITLE
test: add collectors to analysis integration tests.

### DIFF
--- a/test/testanalysis/analysis-controller-existing-status/00-assert.yaml
+++ b/test/testanalysis/analysis-controller-existing-status/00-assert.yaml
@@ -1,3 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: kubectl logs -l control-plane=metrics-operator -n keptn-system
+  - command: kubectl describe Analysis -n $NAMESPACE
+---
 apiVersion: metrics.keptn.sh/v1beta1
 kind: Analysis
 metadata:

--- a/test/testanalysis/analysis-controller-existing-status/01-assert.yaml
+++ b/test/testanalysis/analysis-controller-existing-status/01-assert.yaml
@@ -1,3 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: kubectl logs -l control-plane=metrics-operator -n keptn-system
+  - command: kubectl describe Analysis -n $NAMESPACE
+---
 apiVersion: metrics.keptn.sh/v1beta1
 kind: Analysis
 metadata:

--- a/test/testanalysis/analysis-controller-multiple-providers/01-assert.yaml
+++ b/test/testanalysis/analysis-controller-multiple-providers/01-assert.yaml
@@ -1,3 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: kubectl logs -l control-plane=metrics-operator -n keptn-system
+  - command: kubectl describe Analysis -n $NAMESPACE
+---
 apiVersion: metrics.keptn.sh/v1beta1
 kind: Analysis
 metadata:

--- a/test/testanalysis/analysis-controller-with-duration-timeframe/01-assert.yaml
+++ b/test/testanalysis/analysis-controller-with-duration-timeframe/01-assert.yaml
@@ -1,3 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: kubectl logs -l control-plane=metrics-operator -n keptn-system
+  - command: kubectl describe Analysis -n $NAMESPACE
+---
 apiVersion: metrics.keptn.sh/v1beta1
 kind: Analysis
 metadata:

--- a/test/testanalysis/analysis-controller/01-assert.yaml
+++ b/test/testanalysis/analysis-controller/01-assert.yaml
@@ -1,3 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: kubectl logs -l control-plane=metrics-operator -n keptn-system
+  - command: kubectl describe Analysis -n $NAMESPACE
+---
 apiVersion: metrics.keptn.sh/v1beta1
 kind: Analysis
 metadata:


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description
I added collectors to analysis integration tests.
Fixes #2697 

# How to test
We have to manually fail a test and then check if the collectors are giving the expected output or not. I manually failed `analysis-controller` test and recorded the output in  [test_manual_fail.txt](https://github.com/keptn/lifecycle-toolkit/files/14047265/test_manual_fail.txt) for reference.
Command to test:
```bash
 kubectl kuttl test --start-kind=false ./test/testanalysis/ --config=kuttl-test-local.yaml
```
