### PR TITLE
fix(examples): adapt jaeger service port number for OTel exporter

### DIFF
--- a/examples/support/observability/config/otel-collector.yaml
+++ b/examples/support/observability/config/otel-collector.yaml
@@ -27,7 +27,7 @@ data:
       health_check: {}
     exporters:
       otlp:
-        endpoint: "jaeger-collector:14250"
+        endpoint: "jaeger-collector:4317"
         tls:
           insecure: true
       prometheus:


### PR DESCRIPTION
This PR adapts the port number for the otlp exporter to use the Jaeger service that supports the otlp proto service used by the OTel exporter. With the old port the trace export was not working due to the used grpc service not being implemented in the Jaeger counterpart.