### PR TITLE
docs: fix link to analysis example

### DIFF
--- a/docs/.htmltest.yml
+++ b/docs/.htmltest.yml
@@ -8,6 +8,7 @@ IgnoreURLs:
   - "localhost"
   - "twitter.com"
   - "fonts.gstatic.com"
+  - "medium.com"
   - "github.com/keptn/lifecycle-toolkit/edit/main/docs"
   - "github.com/keptn/lifecycle-toolkit/raw/main/docs"
   - "keptn.sh/stable/"

--- a/docs/docs/guides/slo.md
+++ b/docs/docs/guides/slo.md
@@ -150,7 +150,7 @@ so, in this case, the query becomes:
 The other key-value pairs such as 'project' and 'stage' are just examples of how one could pass to the provider
 information similar to Keptn v1 objectives.
 For a working example, you can
-check [here](https://github.com/keptn/lifecycle-toolkit/tree/main/test/testanalysis/analysis-controller-multiple-providers).
+check [here](https://github.com/keptn/lifecycle-toolkit/tree/main/test/kuttl/testanalysis/analysis-controller-multiple-providers).
 
 ## Accessing Analysis
 


### PR DESCRIPTION
This should fix the currently failing markdown check