### PR TITLE
chore: enable HTMLTest debug logging

### DIFF
--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -35,12 +35,5 @@ jobs:
             tmp/.htmltest
           key: ${{ runner.os }}-htmltest
 
-      - name: Cache Hugo packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            docs/tmp/.hugo
-          key: ${{ runner.os }}-hugo-${{ hashFiles('docs/go.sum') }}
-
       - name: Check HTML
         run: make htmltest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -53,7 +53,7 @@ htmltest: docs-build
 		-v $(PWD)/docs/.htmltest.yml:/.htmltest.yml \
 		-v ${PWD}/site:/site \
 		-v ${PWD}/tmp/.htmltest:/tmp/.htmltest \
-		wjdp/htmltest:$(HTMLTEST_VERSION) -c /.htmltest.yml /site
+		wjdp/htmltest:$(HTMLTEST_VERSION) --log-level 0 -c /.htmltest.yml /site
 
 .PHONY: lint lint-fix
 lint: markdownlint


### PR DESCRIPTION
### This PR
- enables debug level logs for HTMLTest
- removes caching of hugo packages since hugo is not used anymore

Fixes #2919