### PR TITLE
ci: fix HTMLTest HTTP 429 issues

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -515,6 +515,7 @@ readyz
 Reale
 realpath
 redis
+refcache
 remediations
 replicasets
 replicationcontrollers
@@ -621,10 +622,10 @@ tokenreviews
 toml
 totalscore
 tplvalues
+traceid
 traceparent
 tracerfactory
 tracetest
-traceid
 trivy
 trivyignore
 trunc

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            docs/tmp/.htmltest
             tmp/.htmltest
           key: ${{ runner.os }}-htmltest
 

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: |
             tmp/.htmltest
-          key: ${{ runner.os }}-htmltest
+          key: htmltest-{{ hashFiles('tmp/.htmltest/refcache.json') }}
 
       - name: Check HTML
         run: make htmltest


### PR DESCRIPTION
### This PR
- removes the `docs/tmp/.htmltest` path from the github cache since it's not needed anymore because of the recent docs tooling changes
- changes the cache key so that it includes a hash of the `refcache.json` file which stores external URLs checks from HTMLTest. This should fix recent HTTP 429 issues when new external links were added to the docs