### PR TITLE
docs: remove custom label from migration KeptnApp sample

### DIFF
--- a/docs/docs/migrate/keptnapp/assets/keptnapp-migrated.yaml
+++ b/docs/docs/migrate/keptnapp/assets/keptnapp-migrated.yaml
@@ -4,7 +4,6 @@ metadata:
   name: "some-keptn-app"
   namespace: "my-app-ns"
   labels:
-    my-custom-label: customValue
     app.kubernetes.io/managed-by: keptn # added annotation
 spec:
   version: "1.2.3"


### PR DESCRIPTION
This PR removes the `my-custom-label` line from the sample migrated `KeptnApp` resource in the Migration Guide