### PR TITLE
docs: replace remaining embeds with includes

### DIFF
--- a/docs/docs/guides/slo.md
+++ b/docs/docs/guides/slo.md
@@ -94,7 +94,7 @@ A Keptn Analysis is implemented with three resources:
 Consider the following `Analysis` resource:
 
 ```yaml
-{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysis.yaml" %}
+{% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/metrics-operator/config/samples/metrics_v1beta1_analysis.yaml" %}
 ```
 
 This `Analysis` resource:
@@ -110,7 +110,7 @@ The `AnalysisDefinition` resource references this `Analysis` resource
 by its `name` and `namespace` and can be seen here:
 
 ```yaml
-{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" %}
+{% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" %}
 ```
 
 This simple definition contains a single objective, `response-time-p95`.
@@ -136,7 +136,7 @@ or fails with 0% (slower response time).
 The objective points to the corresponding `AnalysisValueTemplate` resource:
 
 ```yaml
-{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysisvaluetemplate.yaml" %}
+{% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/metrics-operator/config/samples/metrics_v1beta1_analysisvaluetemplate.yaml" %}
 ```
 
 This template defines a query to a provider called `prometheus`:

--- a/docs/docs/guides/slo.md
+++ b/docs/docs/guides/slo.md
@@ -93,7 +93,9 @@ A Keptn Analysis is implemented with three resources:
 
 Consider the following `Analysis` resource:
 
-{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysis.yaml" >}}
+```yaml
+{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysis.yaml" %}
+```
 
 This `Analysis` resource:
 
@@ -107,7 +109,9 @@ This `Analysis` resource:
 The `AnalysisDefinition` resource references this `Analysis` resource
 by its `name` and `namespace` and can be seen here:
 
-{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" >}}
+```yaml
+{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" %}
+```
 
 This simple definition contains a single objective, `response-time-p95`.
 For this objective, both failure and warning criteria are defined:
@@ -130,7 +134,10 @@ this means that the analysis either passes with 100%
 or fails with 0% (slower response time).
 
 The objective points to the corresponding `AnalysisValueTemplate` resource:
-{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisvaluetemplate.yaml" >}}
+
+```yaml
+{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysisvaluetemplate.yaml" %}
+```
 
 This template defines a query to a provider called `prometheus`:
 

--- a/docs/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/docs/reference/crd-reference/analysisdefinition.md
@@ -134,8 +134,9 @@ Each of these objectives must specify:
 * Weight of the objective on the overall Analysis
 
 ## Example
+
 ```yaml
-{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" %}
+{% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" %}
 ```
 
 For a full example of how to implement the Keptn Analysis feature, see the

--- a/docs/docs/reference/crd-reference/analysisdefinition.md
+++ b/docs/docs/reference/crd-reference/analysisdefinition.md
@@ -134,8 +134,9 @@ Each of these objectives must specify:
 * Weight of the objective on the overall Analysis
 
 ## Example
-
-{{< embed path="/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" >}}
+```yaml
+{% include "https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/config/samples/metrics_v1beta1_analysisdefinition.yaml" %}
+```
 
 For a full example of how to implement the Keptn Analysis feature, see the
 [Analysis](../../guides/slo.md)


### PR DESCRIPTION
### This PR
- replaces some remaining `embed` shortcodes from Hugo with `include` shortcodes from MkDocs

Fixes #2916