### PR TITLE
docs: fix formatting in CRD reference pages

### DIFF
--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -61,6 +61,7 @@ spec:
        This is used to define success or failure criteria
        for the referenced `KeptnMetric` in order to pass or fail
        the pre- and post-evaluation stages
+<!-- markdownlint-enable MD007 -->
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -26,6 +26,7 @@ spec:
 ```
 
 ## Fields
+<!-- markdownlint-disable MD007 -->
 
 * **apiVersion** -- API version being used.
   Must be `v1alpha3` or later for this syntax.

--- a/docs/docs/reference/crd-reference/metric.md
+++ b/docs/docs/reference/crd-reference/metric.md
@@ -82,6 +82,7 @@ spec:
        If the evaluation is not successful,
        this stores error details that you can use to understand the problem
        such as a forbidden code.
+<!-- markdownlint-enable MD007 -->
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/metric.md
+++ b/docs/docs/reference/crd-reference/metric.md
@@ -37,6 +37,7 @@ spec:
 ```
 
 ## Fields
+<!-- markdownlint-disable MD007 -->
 
 * **apiVersion** -- API version being used.
 
@@ -44,42 +45,43 @@ spec:
    Must be set to `KeptnMetric`.
 
 * **metadata**
-  * **name** -- Unique name of this metric.
-    Names must comply with the
-    [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
-    specification.
-  * **namespace** -- Namespace of the application using this metric.
+     * **name** -- Unique name of this metric.
+       Names must comply with the
+       [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+       specification.
+     * **namespace** -- Namespace of the application using this metric.
 
 * **spec**
-  * **provider.name** (required) --
-    Name of this instance of the data source
-    from which the metric is collected.
-    This value must match the value of the `metadata.name` field
-    of the corresponding [KeptnMetricsProvider](metricsprovider.md) CRD.
+     * **provider.name** (required) --
+       Name of this instance of the data source
+       from which the metric is collected.
+       This value must match the value of the `metadata.name` field
+       of the corresponding [KeptnMetricsProvider](metricsprovider.md) CRD.
 
-    Assigning your own name to the provider
-    rather than just the type of provider
-    enables you to support multiple instances of a data provider.
-    For example, you might have `dev-prometheus`
-    as the name of the Prometheus server that monitors the dev deployment
-    and `prod-prometheus` as the name of the Prometheus server
-    that monitors the production deployment.
-  * **query** (required) -- String in the provider-specific query language,
-    used to obtain a metric.
+          Assigning your own name to the provider
+          rather than just the type of provider
+          enables you to support multiple instances of a data provider.
+          For example, you might have `dev-prometheus`
+          as the name of the Prometheus server that monitors the dev deployment
+          and `prod-prometheus` as the name of the Prometheus server
+          that monitors the production deployment.
+     * **query** (required) -- String in the provider-specific query language,
+       used to obtain a metric.
 
-  * **fetchIntervalSeconds** (required) -- Number of seconds between updates of the metric.
-  * **range**
-    * **interval** -- Timeframe for which the metric is queried.
-    Defaults to 5m.
+     * **fetchIntervalSeconds** (required) --
+       Number of seconds between updates of the metric.
+     * **range**
+       * **interval** -- Timeframe for which the metric is queried.
+       Defaults to 5m.
 
-* **status**
-  * Keptn fills in this information when the metric is evaluated.
-    It always records the time the metric was last evaluated.
-    If the evaluation is successful,
-    this stores the result in both human-readable and raw format.
-    If the evaluation is not successful,
-    this stores error details that you can use to understand the problem
-    such as a forbidden code.
+     * **status** --
+       Keptn fills in this information when the metric is evaluated.
+       It always records the time the metric was last evaluated.
+       If the evaluation is successful,
+       this stores the result in both human-readable and raw format.
+       If the evaluation is not successful,
+       this stores error details that you can use to understand the problem
+       such as a forbidden code.
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/metricsprovider.md
+++ b/docs/docs/reference/crd-reference/metricsprovider.md
@@ -7,11 +7,13 @@ comments: true
 KeptnMetricsProvider defines an instance of the data provider
 (such as Prometheus, Dynatrace, or Datadog)
 that is used by the [KeptnMetric](metric.md) resource.
-One Keptn application can perform evaluations based on metrics
+
+One Keptn application can perform
+traces, evaluations, and analyses based on metrics
 from more than one data provider
 and, beginning with the v1alpha3 API version,
 can use more than one instance of each data provider.
-To implement this, create a KeptnMetricsProvider resource
+To implement this, create a `KeptnMetricsProvider` resource
 for each instance of each data provider being used,
 then reference the appropriate provider
 for each metric definition by its name.
@@ -34,6 +36,7 @@ spec:
 ```
 
 ## Fields
+<!-- markdownlint-disable MD007 -->
 
 * **apiVersion** -- API version being used.
 `
@@ -41,31 +44,31 @@ spec:
    Must be set to KeptnMetricsProvider
 
 * **metadata**
-  * **name** -- Unique name of this provider,
-    used to reference the provider for the
-    [KeptnEvaluationDefinition](evaluationdefinition.md)
-    and [KeptnMetric](metric.md) resources.
-    Names must comply with the
-    [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
-    specification.
+     * **name** -- Unique name of this provider,
+       used to reference the provider for the
+       [KeptnEvaluationDefinition](evaluationdefinition.md)
+       and [KeptnMetric](metric.md) resources.
+       Names must comply with the
+       [Kubernetes Object Names and IDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)
+       specification.
 
-    For example, you might define `dev-prometheus`
-    for the Prometheus instance that monitors the development deployment,
-    and `qa-prometheus` for the Prometheus instance
-    that monitors the Prometheus instance that monitors the QA deployment,
-    and `prod-dynatrace` for the Dynatrace instance
-    that monitors the production deployment.
+          For example, you might define `dev-prometheus`
+          for the Prometheus instance that monitors the development deployment,
+          and `qa-prometheus` for the Prometheus instance
+          that monitors the Prometheus instance that monitors the QA deployment,
+          and `prod-dynatrace` for the Dynatrace instance
+          that monitors the production deployment.
 
-  * **namespace** -- Namespace where this provider is used.
+     * **namespace** -- Namespace where this provider is used.
 
 * **spec**
 
-  * **type** (required) -- The type of data provider for this instance
-  * **targetServer** (required) -- URL of the data provider, enclosed in double quotes
-  * **secretKeyRef**
-    * **name:** -- Name of the Secret used by the provider
-    * **key:** -- Key of the Secret from which to select
-    * **optional** -- Specify whether the Secret or its key must be defined
+     * **type** (required) -- The type of data provider for this instance
+     * **targetServer** (required) -- URL of the data provider, enclosed in double quotes
+        * **secretKeyRef**
+             * **name:** -- Name of the Secret used by the provider
+             * **key:** -- Key of the Secret from which to select
+             * **optional** -- Specify whether the Secret or its key are required
 
 ## Usage
 
@@ -74,20 +77,22 @@ in the same namespace as the
 [KeptnMetric](metric.md)
 resources that are associated with it.
 KeptnMetric resources are used to generate metrics for the cluster
-and are used as the SLI (Service Level Indicator) for
+and are used as the SLI (Service Level Indicator) for the
 [KeptnEvaluationDefinition](evaluationdefinition.md)
-resources that are used for pre- and post-deployment evaluations.
+and
+[AnalysisValueTemplate](analysisvaluetemplate.md)
+resources.
 
 `KeptnEvaluationDefinition` resources can reference metrics
 from any namespace.
-This means that you can create KeptnMetricsProvider
-and KeptnMetric resources
+This means that you can create `KeptnMetricsProvider`
+and `KeptnMetric` resources
 in a centralized namespace (e.g. in `keptn-system`)
 and access those metrics in evaluations
 on all namespaces in the cluster.
 
 Metrics providers may require authentication data.
-These can be stored in a Secret and referenced in the KeptnMetricsProvider.
+These can be stored in a Secret and referenced in the `KeptnMetricsProvider`.
 Those Secret resources need to be configured differently for each metrics provider.
 The Secret holding the data must have a specific structure
 and contain the required data fields.
@@ -105,7 +110,7 @@ the authentication data looks like the following:
 ```
 
 > **Note**
-Setting the `.spec.secretKeyRef.key` field in KeptnMetricsProvider is not necessary,
+Setting the `.spec.secretKeyRef.key` field in `KeptnMetricsProvider` is not necessary,
 as `user` and `password` key names are required to be present in the linked Secret.
 Setting this field won't have any effect.
 
@@ -119,7 +124,7 @@ the authentication data looks like the following:
 ```
 
 > **Note**
-Setting the `.spec.secretKeyRef.key` field in KeptnMetricsProvider is not necessary,
+Setting the `.spec.secretKeyRef.key` field in `KeptnMetricsProvider` is not necessary,
 as `DD_CLIENT_API_KEY` and `DD_CLIENT_API_KEY` key names must be
 present in the linked Secret.
 Setting this field has no effect.
@@ -173,13 +178,14 @@ spec:
 ```
 
 Also note that, for the v1alpha1 and v1alpha2 API versions,
-KeptnMetricsProvider only specifies the provider
-for the KeptnMetric resource.
+`KeptnMetricsProvider` only specifies the provider
+for the `KeptnMetric` resource.
 Beginning with `v1alpha3` API version,
-KeptnMetricsProvider is also used to specify the provider
+`KeptnMetricsProvider` is also used to specify the provider
 for the KeptnEvaluationDefinition resource.
 
 ## See also
 
 * [KeptnEvaluationDefinition](evaluationdefinition.md)
+* [AnalysisValueTemplate](analysisvaluetemplate.md)
 * [KeptnMetric](metric.md)

--- a/docs/docs/reference/crd-reference/metricsprovider.md
+++ b/docs/docs/reference/crd-reference/metricsprovider.md
@@ -69,6 +69,7 @@ spec:
              * **name:** -- Name of the Secret used by the provider
              * **key:** -- Key of the Secret from which to select
              * **optional** -- Specify whether the Secret or its key are required
+<!-- markdownlint-enable MD007 -->
 
 ## Usage
 


### PR DESCRIPTION
This PR:
* Fixes formatting issues for "Fields" sections on the `KeptnMetricsProvider`, `KeptnMetric`, and `KeptnEvaluationDefinition` ref pages
* Also add mention of `AnalysisValueTemplate` to `KeptnMetricsProvider` descriptive text and "See also"