### PR TITLE
chore: changed all ref to v1beta1 in docs links

### DIFF
--- a/docs/docs/assets/crd/eval.yaml
+++ b/docs/docs/assets/crd/eval.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnEvaluationDefinition
 metadata:
   name: app-pre-deploy-eval-2

--- a/docs/docs/assets/crd/python-configmap.yaml
+++ b/docs/docs/assets/crd/python-configmap.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment

--- a/docs/docs/assets/crd/python-context.yaml
+++ b/docs/docs/assets/crd/python-context.yaml
@@ -6,7 +6,7 @@ type: Opaque
 data:
   SECURE_DATA: dG9rZW46IG15dG9rZW4=
 ---
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello

--- a/docs/docs/assets/crd/python-inline.yaml
+++ b/docs/docs/assets/crd/python-inline.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment-inline

--- a/docs/docs/assets/crd/python-libs.yaml
+++ b/docs/docs/assets/crd/python-libs.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: python-inline

--- a/docs/docs/assets/crd/python-recursive.yaml
+++ b/docs/docs/assets/crd/python-recursive.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment-2

--- a/docs/docs/assets/crd/task-definition.yaml
+++ b/docs/docs/assets/crd/task-definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: container-sleep

--- a/docs/docs/components/lifecycle-operator/keptn-apps.md
+++ b/docs/docs/components/lifecycle-operator/keptn-apps.md
@@ -7,7 +7,7 @@ comments: true
 ## Keptn Workloads
 
 A
-[KeptnWorkload](../../reference/api-reference/lifecycle/v1alpha3/index.md#keptnworkload)
+[KeptnWorkload](../../reference/api-reference/lifecycle/v1beta1/index.md#keptnworkload)
 resource augments a Kubernetes
 [Workload](https://kubernetes.io/docs/concepts/workloads/)
 with the ability to handle extra phases.

--- a/docs/docs/guides/assets/tasks/dummy-task.yaml
+++ b/docs/docs/guides/assets/tasks/dummy-task.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: dummy-task

--- a/docs/docs/guides/assets/tasks/multi-secret.yaml
+++ b/docs/docs/guides/assets/tasks/multi-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: dummy-task

--- a/docs/docs/guides/assets/tasks/slack.yaml
+++ b/docs/docs/guides/assets/tasks/slack.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha2
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: slack-notification-dev

--- a/docs/docs/guides/assets/tasks/taskdef-secure-data.yaml
+++ b/docs/docs/guides/assets/tasks/taskdef-secure-data.yaml
@@ -1,4 +1,4 @@
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: deployment-hello

--- a/docs/docs/guides/evaluations.md
+++ b/docs/docs/guides/evaluations.md
@@ -113,7 +113,7 @@ Note the following:
   has no effect on whether other evaluations are completed.
 - The results of each evaluation
   are written to a
-  [KeptnEvaluation](../reference/api-reference/lifecycle/v1alpha3/index.md#keptnevaluation)
+  [KeptnEvaluation](../reference/api-reference/lifecycle/v1beta1/index.md#keptnevaluation)
   resource.
 
 ## Annotate the workload resource for workload level evaluations

--- a/docs/docs/guides/integrate.md
+++ b/docs/docs/guides/integrate.md
@@ -39,7 +39,7 @@ with either Keptn or Kubernetes keys.
     are required only for the Release lifecycle management feature.
 
 Keptn uses these annotations to the Kubernetes workloads to create the
-[KeptnWorkload](../reference/api-reference/lifecycle/v1alpha3/index.md#keptnworkload)
+[KeptnWorkload](../reference/api-reference/lifecycle/v1beta1/index.md#keptnworkload)
 and
 [KeptnApp](../reference/crd-reference/app.md)
 resources that it uses to provide observability
@@ -68,7 +68,7 @@ resources in the namespaces where Keptn is enabled.
 If Keptn finds any of these resources and the resource has either
 the `keptn.sh` or the `kubernetes` annotations/labels,
 it creates appropriate
-[KeptnWorkload](../reference/api-reference/lifecycle/v1alpha3/index.md#keptnworkload)
+[KeptnWorkload](../reference/api-reference/lifecycle/v1beta1/index.md#keptnworkload)
 and
 [KeptnApp](../reference/crd-reference/app.md)
 resources for the version it detects.
@@ -96,7 +96,7 @@ These keys are defined as:
 
 - `keptn.sh/workload` or `app.kubernetes.io/name`: Determines the name
   of the generated
-  [KeptnWorkload](../reference/api-reference/lifecycle/v1alpha3/index.md#keptnworkload)
+  [KeptnWorkload](../reference/api-reference/lifecycle/v1beta1/index.md#keptnworkload)
   resource.
 - `keptn.sh/version` or `app.kubernetes.io/version`:
   Determines the version of the `KeptnWorkload`

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -11,7 +11,7 @@ resource defines one or more "executables"
 that Keptn runs
 as part of the pre- and post-deployment phases of a
 [KeptnApp](../reference/crd-reference/app.md) or
-[KeptnWorkload](../reference/api-reference/lifecycle/v1alpha3/index.md#keptnworkload).
+[KeptnWorkload](../reference/api-reference/lifecycle/v1beta1/index.md#keptnworkload).
 
 - pre-deployment (before the pod is scheduled)
 - post-deployment (after the pod is scheduled)
@@ -22,7 +22,7 @@ These `KeptnTask` resources and the
 are part of the Keptn Release Lifecycle Management.
 
 A
-[KeptnTask](../reference/api-reference/lifecycle/v1alpha3/index.md#keptntask)
+[KeptnTask](../reference/api-reference/lifecycle/v1beta1/index.md#keptntask)
 executes as a runner in an application
 [container](https://kubernetes.io/docs/concepts/containers/),
 which runs as part of a Kubernetes

--- a/docs/docs/reference/crd-reference/app.md
+++ b/docs/docs/reference/crd-reference/app.md
@@ -13,7 +13,7 @@ and to work with the corresponding
 ## Synopsis
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnApp
 metadata:
   name: <app-name>

--- a/docs/docs/reference/crd-reference/config.md
+++ b/docs/docs/reference/crd-reference/config.md
@@ -69,7 +69,7 @@ spec:
 
 API Reference:
 
-* [KeptnTaskDefinition](../api-reference/lifecycle/v1alpha3/index.md#keptntaskdefinition)
+* [KeptnTaskDefinition](../api-reference/lifecycle/v1beta1/index.md#keptntaskdefinition)
 
 ## Differences between versions
 

--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -13,7 +13,7 @@ as part of pre- and post-analysis phases of a [workload](https://kubernetes.io/d
 ## Yaml Synopsis
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnEvaluationDefinition
 metadata:
   name: <evaluation-name>
@@ -29,7 +29,7 @@ spec:
 <!-- markdownlint-disable MD007 -->
 
 * **apiVersion** -- API version being used.
-  Must be `v1alpha3` or later for this syntax.
+  Must be `v1beta1` or later for this syntax.
 * **kind** -- Resource type.
    Must be set to `KeptnEvaluationDefinition`
 
@@ -85,7 +85,7 @@ on all namespaces in the cluster.
 ## Example
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnEvaluationDefinition
 metadata:
   name: my-prometheus-evaluation
@@ -132,7 +132,7 @@ spec:
       evaluationTarget: >4
 ```
 
-Beginning with `v1alpha3` API version,
+Beginning with `v1beta1` API version,
 `KeptnEvaluationDefinition` references a `keptnMetricRef`
 that points to a [KeptnMetric](metric.md) CR,
 that defines the data source, the query and the namespace to use.

--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -117,7 +117,7 @@ that are now taken from the specified [KeptnMetric](metric.md) CRD.
 The synopsis was:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha2
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnEvaluationDefinition
 metadata:
   name: <evaluation-name>

--- a/docs/docs/reference/crd-reference/task.md
+++ b/docs/docs/reference/crd-reference/task.md
@@ -138,7 +138,7 @@ to use for a deployment being done outside of Kubernetes, see
 
 ## Files
 
-[API reference](../api-reference/lifecycle/v1alpha3/index.md#keptntaskspec)
+[API reference](../api-reference/lifecycle/v1beta1/index.md#keptntaskspec)
 
 ## Differences between versions
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -483,7 +483,7 @@ spec:
 This example illustrates the use of both a `ConfigMapRef` and a `ConfigMap`:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha2
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -7,7 +7,7 @@ comments: true
 A `KeptnTaskDefinition` defines tasks
 that Keptn runs as part of the pre- and post-deployment phases of a
 [KeptnApp](./app.md) or
-[KeptnWorkload](../api-reference/lifecycle/v1alpha3/index.md#keptnworkload).
+[KeptnWorkload](../api-reference/lifecycle/v1beta1/index.md#keptnworkload).
 
 A Keptn task executes as a
 [runner](https://docs.gitlab.com/runner/executors/kubernetes.html#how-the-runner-creates-kubernetes-pods)
@@ -156,7 +156,7 @@ spec:
       [image concepts](https://kubernetes.io/docs/concepts/containers/images/)
       and pushed to a registry
     * **other fields** -- The full list of valid fields is available at
-      [ContainerSpec](../api-reference/lifecycle/v1alpha3/index.md#containerspec),
+      [ContainerSpec](../api-reference/lifecycle/v1beta1/index.md#containerspec),
       with additional information in the Kubernetes
       [Container](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
       spec documentation.
@@ -334,7 +334,7 @@ spec:
 
 A Task executes the TaskDefinition of a
 [KeptnApp](app.md) or a
-[KeptnWorkload](../api-reference/lifecycle/v1alpha3/index.md#keptnworkload).
+[KeptnWorkload](../api-reference/lifecycle/v1beta1/index.md#keptnworkload).
 The execution is done by spawning a Kubernetes
 [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
 to handle a single Task.
@@ -399,7 +399,7 @@ This example defines a full-fledged Deno script
 within the `KeptnTaskDefinition` YAML file:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-inline
@@ -421,7 +421,7 @@ spec:
 This example fetches the Deno script from a remote webserver at runtime:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: hello-keptn-http
@@ -447,7 +447,7 @@ In this case, it calls `slack-notification-dev`,
 passing `parameters` and `secureParameters` to that other task:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: slack-notification-dev
@@ -468,7 +468,7 @@ This example references a `ConfigMap` by the name of `dev-configmap`
 that contains the code for the function to be executed.
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: keptntaskdefinition-sample
@@ -596,14 +596,14 @@ directory for more example `KeptnTaskDefinition` YAML files.
 
 API Reference:
 
-* [KeptnTaskDefinition](../api-reference/lifecycle/v1alpha3/index.md#keptntaskdefinition)
-* [KeptnTaskDefinitionList](../api-reference/lifecycle/v1alpha3/index.md#keptntaskdefinitionlist)
-* [KeptnTaskDefinitionSpec](../api-reference/lifecycle/v1alpha3/index.md#keptntaskdefinitionspec)
-* [FunctionReference](../api-reference/lifecycle/v1alpha3/index.md#functionreference)
-* [FunctionSpec](../api-reference/lifecycle/v1alpha3/index.md#runtimespec)
-* [FunctionStatus](../api-reference/lifecycle/v1alpha3/index.md#functionstatus)
-* [HttpReference](../api-reference/lifecycle/v1alpha3/index.md#httpreference)
-* [Inline](../api-reference/lifecycle/v1alpha3/index.md#inline)
+* [KeptnTaskDefinition](../api-reference/lifecycle/v1beta1/index.md#keptntaskdefinition)
+* [KeptnTaskDefinitionList](../api-reference/lifecycle/v1beta1/index.md#keptntaskdefinitionlist)
+* [KeptnTaskDefinitionSpec](../api-reference/lifecycle/v1beta1/index.md#keptntaskdefinitionspec)
+* [FunctionReference](../api-reference/lifecycle/v1beta1/index.md#functionreference)
+* [FunctionSpec](../api-reference/lifecycle/v1beta1/index.md#runtimespec)
+* [FunctionStatus](../api-reference/lifecycle/v1beta1/index.md#functionstatus)
+* [HttpReference](../api-reference/lifecycle/v1beta1/index.md#httpreference)
+* [Inline](../api-reference/lifecycle/v1beta1/index.md#inline)
 
 ## Differences between versions
 

--- a/docs/docs/use-cases/non-k8s.md
+++ b/docs/docs/use-cases/non-k8s.md
@@ -58,7 +58,7 @@ For example, you might create a `test-task-definition.yaml` file
 with the following content:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: helloworldtask
@@ -98,7 +98,7 @@ For example, you might create a `test-task.yaml` file
 with the following content:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTask
 metadata:
   name: runhelloworld1
@@ -141,7 +141,7 @@ For example, you could create a `test-task-2.yaml` file
 with the `metadata.name` field set to `runhelloworld2`:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1alpha3
+apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTask
 metadata:
   name: runhelloworld2


### PR DESCRIPTION
Synce our lifecycle  api  is at v1beta1 all links in the docs should refer to that api