### PR TITLE
ci: log cosign attest verification to file to release pipeline remove hangs

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -565,6 +565,7 @@ spanhandler
 spanid
 spanitem
 spdx
+spdxjson
 spf
 squidfunk
 sre

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,6 @@ jobs:
             --output-file ./cosign-attest-output.json
             ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
           echo "Result of verification:"
-          cat ./cosign-attest-output.json
 
       - name: Upload verification log as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,22 @@ jobs:
         env:
           IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
         run: |
-          cosign attest --yes --type spdx --predicate ./sbom-${{ matrix.config.name }}.spdx.json ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
+          echo "Attesting SBOM for this releaseand image..."
+          cosign attest --yes --type spdxjson --predicate ./sbom-${{ matrix.config.name }}.spdx.json ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
+          echo "Verifying that the attestation worked..."
+          cosign verify-attestation --type spdx \
+            --certificate-identity-regexp="https://github.com/keptn/lifecycle-toolkit/.*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            --output-file ./cosign-attest-output.json
+            ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
+          echo "Result of verification:"
+          cat ./cosign-attest-output.json
+
+      - name: Upload verification log as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cosign-attest-verification-log
+          path: ./cosign-attest-output.json
 
   update-examples:
     name: Update examples

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,10 +208,6 @@ jobs:
           IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
         run: |
           cosign attest --yes --type spdx --predicate ./sbom-${{ matrix.config.name }}.spdx.json ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
-          cosign verify-attestation --type spdx \
-            --certificate-identity-regexp="https://github.com/keptn/lifecycle-toolkit/.*" \
-            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-            ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
 
   update-examples:
     name: Update examples

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
         env:
           IMAGE_DIGEST: ${{ steps.docker_build_image.outputs.digest }}
         run: |
-          echo "Attesting SBOM for this releaseand image..."
+          echo "Attesting SBOM for this release and image..."
           cosign attest --yes --type spdxjson --predicate ./sbom-${{ matrix.config.name }}.spdx.json ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
           echo "Verifying that the attestation worked..."
           cosign verify-attestation --type spdx \


### PR DESCRIPTION
### This PR
- move the log for `cosign verify-attestation` to an output file since several megabytes of text will come in that block/hang the pipeline
- the log file is uploaded as an artifact to the release pipeline