### PR TITLE
docs: fix formatting for KeptnTaskDefinition fields

### DIFF
--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -109,6 +109,7 @@ spec:
             and code the functionality to match the container you define.
             See
             [Synopsis for container-runtime container](#synopsis-for-container-runtime).
+
      * **retries** -- specifies the number of times
        a job executing the `KeptnTaskDefinition`
        should be restarted if an attempt is unsuccessful.
@@ -145,23 +146,25 @@ spec:
     <other fields>
 ```
 
-### Spec used only for container-runtime
+### Fields used only for container-runtime
+<!-- markdownlint-disable MD007 -->
 
 * **spec**
-  * **container** -- Container definition.
-    * **name** -- Name of the container that will run,
-      which is not the same as the `metadata.name` field
-      that is used in the `KeptnTaskDefinition` resource.
-    * **image** -- name of the image you defined according to
-      [image reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image)
-      and
-      [image concepts](https://kubernetes.io/docs/concepts/containers/images/)
-      and pushed to a registry
-    * **other fields** -- The full list of valid fields is available at
-      [ContainerSpec](../api-reference/lifecycle/v1beta1/index.md#containerspec),
-      with additional information in the Kubernetes
-      [Container](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
-      spec documentation.
+     * **container** -- Container definition.
+          * **name** -- Name of the container that will run,
+            which is not the same as the `metadata.name` field
+            that is used in the `KeptnTaskDefinition` resource.
+          * **image** -- name of the image you defined according to
+            [image reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image)
+            and
+            [image concepts](https://kubernetes.io/docs/concepts/containers/images/)
+            and pushed to a registry
+          * **other fields** -- The full list of valid fields is available at
+            [ContainerSpec](../api-reference/lifecycle/v1beta1/index.md#containerspec),
+            with additional information in the Kubernetes
+            [Container](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
+            spec documentation.
+<!-- markdownlint-enable MD007 -->
 
 ## Synopsis for predefined containers
 
@@ -219,118 +222,120 @@ spec:
 ```
 
 ### Fields for predefined containers
+<!-- markdownlint-disable MD007 -->
 
 * **spec** -- choose either `deno` or `python`
-  * **deno** -- Specify that the task uses the `deno-runtime`
-    and is expressed as a [Deno](https://deno.com/) script.
-    Refer to [deno runtime](https://github.com/keptn/lifecycle-toolkit/tree/main/runtimes/deno-runtime)
-    for more information about this runner.
-  * **python** -- Identifies this as a Python runner.
+     * **deno | python**
+        * **deno** -- Specify that the task uses the `deno-runtime`
+          and is expressed as a [Deno](https://deno.com/) script.
+          Refer to [deno runtime](https://github.com/keptn/lifecycle-toolkit/tree/main/runtimes/deno-runtime)
+          for more information about this runner.
+        * **python** -- Identifies this as a Python runner.
 
-* **inline | httpRef | functionRef | ConfigMapRef** -- choose the syntax
-  used to call the executables.
-  Only one of these can be specified per `KeptnTaskDefinition` resource:
+            * **inline | httpRef | functionRef | ConfigMapRef** -- choose the syntax
+              used to call the executables.
+              Only one of these can be specified per `KeptnTaskDefinition` resource:
 
-  * **inline** - Include the actual executable code to execute.
-    You can code a sequence of executables here
-    that need to be run in order
-    as long as they are executables that are part of the lifecycle workflow.
-    Task sequences that are not part of the lifecycle workflow
-    should be handled by the pipeline engine tools being used
-    such as Jenkins, Argo Workflows, Flux, and Tekton.
+                 * **inline** - Include the actual executable code to execute.
+                   You can code a sequence of executables here
+                   that need to be run in order
+                   as long as they are executables that are part of the lifecycle workflow.
+                   Task sequences that are not part of the lifecycle workflow
+                   should be handled by the pipeline engine tools being used
+                   such as Jenkins, Argo Workflows, Flux, and Tekton.
 
-    * **deno example:**
-        [Example 1: inline script for a Deno script](#example-1-inline-script-for-a-deno-script)
+                   * **deno example:**
+                       [Example 1: inline script for a Deno script](#example-1-inline-script-for-a-deno-script)
 
-    * **python example:**
-        [Example 1: inline code for a python-runtime runner](#example-1-inline-code-for-a-python-runtime-runner)
+                   * **python example:**
+                       [Example 1: inline code for a python-runtime runner](#example-1-inline-code-for-a-python-runtime-runner)
 
-  * **httpRef** - Specify a script to be executed at runtime
-      from the remote webserver that is specified.
+                   * **httpRef** - Specify a script to be executed at runtime
+                     from the remote webserver that is specified.
 
-      This syntax allows you to call a general function
-      that is used in multiple places,
-      possibly with different parameters
-      that are provided in the calling `KeptnTaskDefinition` resource.
-      Another `KeptnTaskDefinition` resource could call this same script
-      but with different parameters.
+                     This syntax allows you to call a general function
+                     that is used in multiple places,
+                     possibly with different parameters
+                     that are provided in the calling `KeptnTaskDefinition` resource.
+                     Another `KeptnTaskDefinition` resource could call this same script
+                     but with different parameters.
 
-      Only one script can be executed.
-      Any other scripts listed here are silently ignored.
+                     Only one script can be executed.
+                     Any other scripts listed here are silently ignored.
 
-    * **deno example:**
-        [Example 2: httpRef script for a Deno script](#example-2-httpref-script-for-a-deno-script)
-    * **python example:**
-        [Example 2: httpRef for a python-runtime runner](#example-2-httpref-for-a-python-runtime-runner)
+                     * **deno example:**
+                       [Example 2: httpRef script for a Deno script](#example-2-httpref-script-for-a-deno-script)
+                     * **python example:**
+                       [Example 2: httpRef for a python-runtime runner](#example-2-httpref-for-a-python-runtime-runner)
 
-  * **functionRef** -- Execute another `KeptnTaskDefinition` resources.
-      Populate this field with the value(s) of the `metadata.name` field
-      for each `KeptnDefinitionTask` to be called.
+                 * **functionRef** -- Execute another `KeptnTaskDefinition` resources.
+                     Populate this field with the value(s) of the `metadata.name` field
+                     for each `KeptnDefinitionTask` to be called.
 
-      Like the `httpRef` syntax,this is commonly used
-      to call a general function that is used in multiple places,
-      possibly with different parameters
-      that are set in the calling `KeptnTaskDefinition` resource.
+                     Like the `httpRef` syntax,this is commonly used
+                     to call a general function that is used in multiple places,
+                     possibly with different parameters
+                     that are set in the calling `KeptnTaskDefinition` resource.
 
-      To be able to run the pre/post-deployment task, you must create
-      the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
-      in the pre/post-deployment section of `KeptnAppContext`.
+                     To be able to run the pre/post-deployment task, you must create
+                     the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
+                     in the pre/post-deployment section of `KeptnAppContext`.
 
-      The `KeptnTaskDefinition` called with `functionref`
-      is the `parent task` whose runner is used for the execution
-      even if it is not the same runner defined in the
-      calling `KeptnTaskDefinition`.
+                     The `KeptnTaskDefinition` called with `functionref`
+                     is the `parent task` whose runner is used for the execution
+                     even if it is not the same runner defined in the
+                     calling `KeptnTaskDefinition`.
 
-      Only one `KeptnTaskDefinition` resources can be listed
-      with the `functionRef` syntax
-      although that `KeptnTaskDefinition` can call multipe
-      executables (programs, functions, and scripts)..
-      Any calls to additional `KeptnTaskDefinition` resources
-      are silently ignored.
+                     Only one `KeptnTaskDefinition` resources can be listed
+                     with the `functionRef` syntax
+                     although that `KeptnTaskDefinition` can call multipe
+                     executables (programs, functions, and scripts)..
+                     Any calls to additional `KeptnTaskDefinition` resources
+                     are silently ignored.
 
-    * **deno example:**
-        [Example 3: functionRef for a Deno script](#example-3-functionref-for-a-deno-script)
-    * **python example:**
-        [Example 3: functionRef for a python-runtime runner](#example-3-functionref-for-a-python-runtime-runner)
+                     * **deno example:**
+                       [Example 3: functionRef for a Deno script](#example-3-functionref-for-a-deno-script)
+                     * **python example:**
+                       [Example 3: functionRef for a python-runtime runner](#example-3-functionref-for-a-python-runtime-runner)
 
-  * **ConfigMapRef** - Specify the name of a
-      [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
-      resource that contains the function to be executed.
+                 * **ConfigMapRef** - Specify the name of a
+                       [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
+                       resource that contains the function to be executed.
 
-    * **deno example:**
-        [Example 5: ConfigMap for a Deno script](#example-5-configmap-for-a-deno-script)
-    * **python example:**
-        [Example 4: ConfigMapRef for a python-runtime runner](#example-4-configmapref-for-a-python-runtime-runner)
+                     * **deno example:**
+                         [Example 5: ConfigMap for a Deno script](#example-5-configmap-for-a-deno-script)
+                     * **python example:**
+                         [Example 4: ConfigMapRef for a python-runtime runner](#example-4-configmapref-for-a-python-runtime-runner)
 
-  * **parameters** - An optional field to supply input parameters to a function.
-    Keptn passes the values defined inside the `map` field
-    as a JSON object.
-    See
-    [Passing secrets, environment variables, and modifying the python command](#passing-secrets-environment-variables-and-modifying-the-python-command)
-    and
-    [Parameterized functions](../../guides/tasks.md#parameterized-functions)
-    for more information.
+            * **parameters** - An optional field to supply input parameters to a function.
+              Keptn passes the values defined inside the `map` field
+              as a JSON object.
+              See
+              [Passing secrets, environment variables, and modifying the python command](#passing-secrets-environment-variables-and-modifying-the-python-command)
+              and
+              [Parameterized functions](../../guides/tasks.md#parameterized-functions)
+              for more information.
 
-    * **deno example:**
-      [Example 3: functionRef for a Deno script](#example-3-functionref-for-a-deno-script)
-    * **python example:**
-      [Example 3: functionRef for a python-runner runner](#example-3-functionref-for-a-python-runtime-runner)
+                 * **deno example:**
+                   [Example 3: functionRef for a Deno script](#example-3-functionref-for-a-deno-script)
+                 * **python example:**
+                   [Example 3: functionRef for a python-runner runner](#example-3-functionref-for-a-python-runtime-runner)
 
-  * **secureParameters** -- An optional field used to pass a Kubernetes secret.
-    The `secret` value is the Kubernetes secret name
-    that is mounted into the runtime and made available to functions
-    using the `SECURE_DATA` environment variable.
+            * **secureParameters** -- An optional field used to pass a Kubernetes secret.
+              The `secret` value is the Kubernetes secret name
+              that is mounted into the runtime and made available to functions
+              using the `SECURE_DATA` environment variable.
 
-    Note that, currently, only one secret can be passed
-    per `KeptnTaskDefinition` resource.
+              Note that, currently, only one secret can be passed
+              per `KeptnTaskDefinition` resource.
 
-    See [Create secret text](../../guides/tasks.md#create-secret-text)
-    for details.
+              See [Create secret text](../../guides/tasks.md#create-secret-text)
+              for details.
 
-    * **deno example:**
-      [Example 3: functionRef for a Deno script](#example-3-functionref-for-a-deno-script)
-    * **python example:**
-      [Example 3: functionRef for a python-runner runner](#example-3-functionref-for-a-python-runtime-runner)
+              * **deno example:**
+                [Example 3: functionRef for a Deno script](#example-3-functionref-for-a-deno-script)
+              * **python example:**
+                [Example 3: functionRef for a python-runner runner](#example-3-functionref-for-a-python-runtime-runner)
 <!-- markdownlint-enable MD007 -->
 
 ## Usage


### PR DESCRIPTION
This PR fixes the formatting of the "Fields for pre-defined containers" section of the KeptnTaskDefinition crd-ref page