### PR TITLE
feat: change operator base images to cgr.dev/chainguard/static

### DIFF
--- a/keptn-cert-manager/Dockerfile
+++ b/keptn-cert-manager/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the go source
 COPY ./ ./
-cgr.dev/chainguard/static
+
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 ARG CONTROLLER_TOOLS_VERSION=v0.14.0
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_TOOLS_VERSION

--- a/keptn-cert-manager/Dockerfile
+++ b/keptn-cert-manager/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the go source
 COPY ./ ./
-
+cgr.dev/chainguard/static
 # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
 ARG CONTROLLER_TOOLS_VERSION=v0.14.0
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@$CONTROLLER_TOOLS_VERSION
@@ -45,7 +45,7 @@ COPY --from=builder /workspace/manager .
 
 ENTRYPOINT ["/manager"]
 
-FROM gcr.io/distroless/static-debian11:nonroot AS production
+FROM cgr.dev/chainguard/static AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit/keptn-cert-manager" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/lifecycle-operator/Dockerfile
+++ b/lifecycle-operator/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=builder /workspace/bin/manager .
 
 ENTRYPOINT ["/manager"]
 
-FROM gcr.io/distroless/static-debian11:nonroot AS production
+FROM cgr.dev/chainguard/static AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder /scheduler/bin/kube-scheduler /bin/kube-scheduler
 WORKDIR /bin
 CMD ["kube-scheduler"]
 
-FROM gcr.io/distroless/static-debian11:nonroot AS production
+FROM cgr.dev/chainguard/static AS production
 
 LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolkit" \
     org.opencontainers.image.url="https://keptn.sh" \


### PR DESCRIPTION
Moving to use `cgr.dev/chainguard/static` as Base images for the Production build stages in the Dockerfiles

Fixes #1591 

# Checklist

- [ ] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [ ] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [ ] New and existing unit and integration tests pass locally with my changes