### PR TITLE
docs: move all keptn.sh links to /stable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,21 +40,21 @@ on Slack and a mentor will surely guide you!
 ### Prerequisites
 
 See
-[Set up the development environment](https://keptn.sh/latest/docs/contribute/software/dev-environ/)
+[Set up the development environment](https://keptn.sh/stable/docs/contribute/software/dev-environ/)
 for information about how to set up an environment
 in which you can develop and test software for Keptn.
 
 ## Related Technologies
 
-Please check [Related Technologies](https://keptn.sh/latest/docs/contribute/general/technologies/).
+Please check [Related Technologies](https://keptn.sh/stable/docs/contribute/general/technologies/).
 
 ## Linter Requirements
 
-Please check [Linter Requirements](https://keptn.sh/latest/docs/contribute/docs/linter-requirements/).
+Please check [Linter Requirements](https://keptn.sh/stable/docs/contribute/docs/linter-requirements/).
 
 ## Working with git
 
-See [Working with Git](https://keptn.sh/latest/docs/contribute/general/git/)
+See [Working with Git](https://keptn.sh/stable/docs/contribute/general/git/)
 
 Your PR will usually be reviewed by the Keptn team within a
 couple of days, but feel free to let us know about your PR
@@ -64,5 +64,5 @@ couple of days, but feel free to let us know about your PR
 
 All commits must be accompanied by a DCO sign-off.
 See
-[DCO](https://keptn.sh/latest/docs/contribute/general/dco/)
+[DCO](https://keptn.sh/stable/docs/contribute/general/dco/)
 for more information.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,18 +18,18 @@ You can make modifications in various ways:
   this works well for small modifications.
 - Use GitHub Codespaces.
    See
-  [Codespaces](https://keptn.sh/latest/docs/contribute/general/codespace/)
+  [Codespaces](https://keptn.sh/stable/docs/contribute/general/codespace/)
 - If you are making significant changes,
   you may find it better to fork and clone the repository
   and make changes using the text editor or IDE of your choice.
-  See [Working with Git](https://keptn.sh/latest/docs/contribute/general/git/)
+  See [Working with Git](https://keptn.sh/stable/docs/contribute/general/git/)
 
   You can run the website locally
   to check the rendered documentation.
   and then push your changes to the repository as a pull request.
 
 See the
-[Contributing guide](https://keptn.sh/latest/docs/contribute/)
+[Contributing guide](https://keptn.sh/stable/docs/contribute/)
 for more information about tools and practices to use
 when contributing to the Keptn project.
 
@@ -53,9 +53,9 @@ is displayed in the logs.
 By default this should be `http://0.0.0.0:8000/`
 
 For more details, see
-[Build documentation locally](https://keptn.sh/latest/docs/contribute/docs/local-building/)
+[Build documentation locally](https://keptn.sh/stable/docs/contribute/docs/local-building/)
 
 For information about previewing `.md` files
 that are outside the documentation NAV path
 (such as `README.md` and `CONTRIBUTING.md` files), see
-[Building markdown files without Hugo](https://keptn.sh/latest/docs/contribute/docs/local-building/#building-markdown-files-without-hugo).
+[Building markdown files without Hugo](https://keptn.sh/stable/docs/contribute/docs/local-building/#building-markdown-files-without-hugo).

--- a/docs/blog/posts/2023-keptn-year-in-review.md
+++ b/docs/blog/posts/2023-keptn-year-in-review.md
@@ -29,7 +29,7 @@ of Keptn, or migrating, we recommend the following articles:
 
 - [September 2023: Keptn Lifecycle Toolkit is now Keptn!](https://medium.com/keptn/keptn-lifecycle-toolkit-is-now-keptn-e0812217bf46)
 - [July 2022: Keptn reaches incubating status in CNCF!](https://medium.com/keptn/keptn-reaches-the-incubating-status-in-the-cncf-67291e2dda7)
-- [Migrating to Keptn](https://keptn.sh/latest/docs/migrate/keptn/)
+- [Migrating to Keptn](https://keptn.sh/stable/docs/migrate/keptn/)
 
 ## Latest Release
 
@@ -92,7 +92,7 @@ At the end of 2023 we transitioned away from our own Keptn Slack workspace to
 [CNCF Slack](http://cloud-native.slack.com/)
 utilizing the [#keptn channel](https://cloud-native.slack.com/messages/keptn/) to
 better align with the Cloud Native ecosystem & other CNCF projects.
-We also saw a [new website](https://keptn.sh/) and [docs](https://keptn.sh/latest/docs/)
+We also saw a [new website](https://keptn.sh/) and [docs](https://keptn.sh/stable/docs/)
 (the new [docs folder in GitHub](https://github.com/keptn/lifecycle-toolkit/tree/main/docs)
 has been updated as well) and look forward to major improvements to both in 2024.
 

--- a/docs/docs/use-cases/non-k8s.md
+++ b/docs/docs/use-cases/non-k8s.md
@@ -206,6 +206,6 @@ To implement a Keptn analysis for your deployment:
 See the
 [Analysis](../guides/slo.md)
 guide and the
-[Analyzing Application Performance with Keptn](https://keptn.sh/latest/blog/2023/12/19/analyzing-application-performance-with-keptn/)
+[Analyzing Application Performance with Keptn](https://keptn.sh/stable/blog/2023/12/19/analyzing-application-performance-with-keptn/)
 blog
 for more details and examples for the Keptn analysis feature.


### PR DESCRIPTION
Fixes #3015 

# Description

Changed all links in the repo to keptn.sh/stable instead of keptn.sh/latest.



