### PR TITLE
chore: introduce resource limts to mockserver integration tests

### DIFF
--- a/test/chainsaw/testanalysis/analysis-controller-existing-status/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller-existing-status/mock-server.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 64Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller-existing-status/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller-existing-status/mock-server.yaml
@@ -30,6 +30,7 @@ spec:
         app: mockserver
       name: mockserver
     spec:
+      automountServiceAccountToken: false
       containers:
         - env:
             - name: MOCKSERVER_LOG_LEVEL
@@ -38,6 +39,13 @@ spec:
               value: "1080"
           image: mockserver/mockserver:mockserver-5.13.0
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller-multiple-providers/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller-multiple-providers/mock-server.yaml
@@ -44,10 +44,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 64Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller-multiple-providers/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller-multiple-providers/mock-server.yaml
@@ -32,6 +32,7 @@ spec:
         app: mockserver
       name: mockserver
     spec:
+      automountServiceAccountToken: false
       containers:
         - env:
             - name: MOCKSERVER_LOG_LEVEL
@@ -40,6 +41,13 @@ spec:
               value: "1080"
           image: mockserver/mockserver:mockserver-5.13.0
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller-with-duration-timeframe/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller-with-duration-timeframe/mock-server.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 64Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller-with-duration-timeframe/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller-with-duration-timeframe/mock-server.yaml
@@ -30,6 +30,7 @@ spec:
         app: mockserver
       name: mockserver
     spec:
+      automountServiceAccountToken: false
       containers:
         - env:
             - name: MOCKSERVER_LOG_LEVEL
@@ -38,6 +39,13 @@ spec:
               value: "1080"
           image: mockserver/mockserver:mockserver-5.13.0
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller/mock-server.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 64Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testanalysis/analysis-controller/mock-server.yaml
+++ b/test/chainsaw/testanalysis/analysis-controller/mock-server.yaml
@@ -30,6 +30,7 @@ spec:
         app: mockserver
       name: mockserver
     spec:
+      automountServiceAccountToken: false
       containers:
         - env:
             - name: MOCKSERVER_LOG_LEVEL
@@ -38,6 +39,13 @@ spec:
               value: "1080"
           image: mockserver/mockserver:mockserver-5.13.0
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testmetrics/metrics-hpa/mock-server.yaml
+++ b/test/chainsaw/testmetrics/metrics-hpa/mock-server.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 10m
-              memory: 32Mi
+              memory: 64Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10

--- a/test/chainsaw/testmetrics/metrics-hpa/mock-server.yaml
+++ b/test/chainsaw/testmetrics/metrics-hpa/mock-server.yaml
@@ -30,6 +30,7 @@ spec:
         app: mockserver
       name: mockserver
     spec:
+      automountServiceAccountToken: false
       containers:
         - env:
             - name: MOCKSERVER_LOG_LEVEL
@@ -38,6 +39,13 @@ spec:
               value: "1080"
           image: mockserver/mockserver:mockserver-5.13.0
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
           livenessProbe:
             failureThreshold: 10
             initialDelaySeconds: 10


### PR DESCRIPTION
Fixes: #2955 