### PR TITLE
chore: bump elastic/crd-ref-docs to 0.0.11 to enable validation field in docs

### DIFF
--- a/.github/scripts/generate-crd-docs/generate-crd-docs.sh
+++ b/.github/scripts/generate-crd-docs/generate-crd-docs.sh
@@ -8,7 +8,7 @@
 # Inputs: None
 
 # renovate: datasource=github-releases depName=elastic/crd-ref-docs
-GENERATOR_VERSION=v0.0.10
+GENERATOR_VERSION=v0.0.11
 API_DOMAIN="keptn.sh"
 OPERATOR_API_ROOT='lifecycle-operator/apis/'
 METRICS_API_ROOT='metrics-operator/api/'

--- a/.github/scripts/generate-crd-docs/templates/type.tpl
+++ b/.github/scripts/generate-crd-docs/templates/type.tpl
@@ -8,6 +8,13 @@
 
 {{ $type.Doc }}
 
+{{ if $type.Validation -}}
+_Validation:_
+{{- range $type.Validation }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
 {{ if $type.References -}}
 _Appears in:_
 {{- range $type.SortedReferences }}
@@ -16,21 +23,21 @@ _Appears in:_
 {{- end }}
 
 {{ if $type.Members -}}
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
 {{ if $type.GVK -}}
-| `apiVersion` _string_ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}` | | |
-| `kind` _string_ | `{{ $type.GVK.Kind }}` | | |
+| `apiVersion` _string_ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}` | | | |
+| `kind` _string_ | `{{ $type.GVK.Kind }}` | | | |
 {{ end -}}
 
 {{ range $type.Members -}}
-| `{{ .Name }}` _{{ markdownRenderType .Type }}_ | {{ template "type_members" . }} |
+| `{{ .Name }}` {{ if .Type.IsAlias }}_{{  markdownRenderTypeLink .Type.UnderlyingType  }}_{{else}}_{{ markdownRenderType .Type }}_{{ end }} | {{ template "type_members" . }} |
 {{- if index .Markers "kubebuilder:default" -}}
 {{- with index (index .Markers "kubebuilder:default") 0 -}}
  {{ .Value -}}
 {{ end -}}
 {{ end -}}
-| {{ if index .Markers "optional" }}✓{{ else }}x{{ end }} |
+| {{ if index .Markers "optional" }}✓{{ else }}x{{ end }} | {{ range .Validation -}} {{ . }} <br />{{ end }} |
 {{ end }}
 
 {{- end -}}

--- a/docs/docs/reference/api-reference/lifecycle/v1alpha1/index.md
+++ b/docs/docs/reference/api-reference/lifecycle/v1alpha1/index.md
@@ -38,6 +38,8 @@ _Underlying type:_ _string_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationSpec](#keptnevaluationspec)
 - [KeptnTaskSpec](#keptntaskspec)
@@ -50,12 +52,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || ✓ |  |
 
 
 
@@ -66,17 +70,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 - [KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `evaluationDefinitionName` _string_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `evaluationName` _string_ |  || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `evaluationDefinitionName` _string_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `evaluationName` _string_ |  || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### EvaluationStatusItem
@@ -85,14 +91,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationStatus](#keptnevaluationstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ |  || x |
-| `status` _[KeptnState](#keptnstate)_ |  || x |
-| `message` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ |  || x |  |
+| `status` _string_ |  || x |  |
+| `message` _string_ |  || ✓ |  |
 
 
 #### FunctionReference
@@ -101,12 +109,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || ✓ |  |
 
 
 #### FunctionSpec
@@ -115,17 +125,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `functionRef` _[FunctionReference](#functionreference)_ |  || ✓ |
-| `inline` _[Inline](#inline)_ |  || ✓ |
-| `httpRef` _[HttpReference](#httpreference)_ |  || ✓ |
-| `configMapRef` _[ConfigMapReference](#configmapreference)_ |  || ✓ |
-| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `functionRef` _[FunctionReference](#functionreference)_ |  || ✓ |  |
+| `inline` _[Inline](#inline)_ |  || ✓ |  |
+| `httpRef` _[HttpReference](#httpreference)_ |  || ✓ |  |
+| `configMapRef` _[ConfigMapReference](#configmapreference)_ |  || ✓ |  |
+| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |  |
 
 
 #### FunctionStatus
@@ -134,12 +146,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `configMap` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `configMap` _string_ |  || ✓ |  |
 
 
 
@@ -152,12 +166,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `url` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `url` _string_ |  || ✓ |  |
 
 
 #### Inline
@@ -166,12 +182,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `code` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `code` _string_ |  || ✓ |  |
 
 
 #### KeptnApp
@@ -180,16 +198,18 @@ _Appears in:_
 
 KeptnApp is the Schema for the keptnapps API
 
+
+
 _Appears in:_
 - [KeptnAppList](#keptnapplist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnApp` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppSpec](#keptnappspec)_ |  || ✓ |
-| `status` _[KeptnAppStatus](#keptnappstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnApp` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppSpec](#keptnappspec)_ |  || ✓ |  |
+| `status` _[KeptnAppStatus](#keptnappstatus)_ |  || ✓ |  |
 
 
 #### KeptnAppList
@@ -200,12 +220,14 @@ KeptnAppList contains a list of KeptnApp
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnAppList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnApp](#keptnapp) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnAppList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnApp](#keptnapp) array_ |  || x |  |
 
 
 #### KeptnAppSpec
@@ -214,18 +236,20 @@ KeptnAppList contains a list of KeptnApp
 
 KeptnAppSpec defines the desired state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ |  || x |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ |  || x |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
 
 
 #### KeptnAppStatus
@@ -234,12 +258,14 @@ _Appears in:_
 
 KeptnAppStatus defines the observed state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ |  || ✓ |  |
 
 
 #### KeptnAppVersion
@@ -248,16 +274,18 @@ _Appears in:_
 
 KeptnAppVersion is the Schema for the keptnappversions API
 
+
+
 _Appears in:_
 - [KeptnAppVersionList](#keptnappversionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnAppVersion` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ |  || ✓ |
-| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnAppVersion` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ |  || ✓ |  |
+| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ |  || ✓ |  |
 
 
 #### KeptnAppVersionList
@@ -268,12 +296,14 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnAppVersionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnAppVersionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |  |
 
 
 #### KeptnAppVersionSpec
@@ -282,20 +312,22 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 KeptnAppVersionSpec defines the desired state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ |  || x |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
-| `appName` _string_ |  || x |
-| `previousVersion` _string_ |  || ✓ |
-| `traceId` _object (keys:string, values:string)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ |  || x |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `appName` _string_ |  || x |  |
+| `previousVersion` _string_ |  || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ |  || ✓ |  |
 
 
 #### KeptnAppVersionStatus
@@ -304,26 +336,28 @@ _Appears in:_
 
 KeptnAppVersionStatus defines the observed state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `workloadOverallStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ |  || ✓ |
-| `currentPhase` _string_ |  || ✓ |
-| `preDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |
-| `postDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `workloadOverallStatus` _string_ |  |Pending| ✓ |  |
+| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ |  || ✓ |  |
+| `currentPhase` _string_ |  || ✓ |  |
+| `preDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |  |
+| `postDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### KeptnEvaluation
@@ -332,16 +366,18 @@ _Appears in:_
 
 KeptnEvaluation is the Schema for the keptnevaluations API
 
+
+
 _Appears in:_
 - [KeptnEvaluationList](#keptnevaluationlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnEvaluation` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ |  || ✓ |
-| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnEvaluation` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ |  || ✓ |  |
+| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ |  || ✓ |  |
 
 
 #### KeptnEvaluationDefinition
@@ -350,16 +386,18 @@ _Appears in:_
 
 KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions API
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionList](#keptnevaluationdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnEvaluationDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnEvaluationDefinitionList
@@ -370,12 +408,14 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnEvaluationDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |  |
 
 
 #### KeptnEvaluationDefinitionSpec
@@ -384,13 +424,15 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 KeptnEvaluationDefinitionSpec defines the desired state of KeptnEvaluationDefinition
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinition](#keptnevaluationdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `source` _string_ |  || x |
-| `objectives` _[Objective](#objective) array_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `source` _string_ |  || x |  |
+| `objectives` _[Objective](#objective) array_ |  || x |  |
 
 
 #### KeptnEvaluationList
@@ -401,12 +443,14 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnEvaluationList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnEvaluationList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |  |
 
 
 
@@ -417,20 +461,22 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 KeptnEvaluationSpec defines the desired state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _string_ |  || ✓ |
-| `workloadVersion` _string_ |  || x |
-| `appName` _string_ |  || ✓ |
-| `appVersion` _string_ |  || ✓ |
-| `evaluationDefinition` _string_ |  || x |
-| `retries` _integer_ |  |10| ✓ |
-| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ |  |5s| ✓ |
-| `failAction` _string_ |  || ✓ |
-| `checkType` _[CheckType](#checktype)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _string_ |  || ✓ |  |
+| `workloadVersion` _string_ |  || x |  |
+| `appName` _string_ |  || ✓ |  |
+| `appVersion` _string_ |  || ✓ |  |
+| `evaluationDefinition` _string_ |  || x |  |
+| `retries` _integer_ |  |10| ✓ |  |
+| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ |  |5s| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
+| `failAction` _string_ |  || ✓ |  |
+| `checkType` _string_ |  || ✓ |  |
 
 
 #### KeptnEvaluationStatus
@@ -439,16 +485,18 @@ _Appears in:_
 
 KeptnEvaluationStatus defines the observed state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `retryCount` _integer_ |  |0| x |
-| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ |  || x |
-| `overallStatus` _[KeptnState](#keptnstate)_ |  |Pending| x |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `retryCount` _integer_ |  |0| x |  |
+| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ |  || x |  |
+| `overallStatus` _string_ |  |Pending| x |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 
@@ -460,6 +508,8 @@ _Appears in:_
 _Underlying type:_ _string_
 
 KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+
+
 
 _Appears in:_
 - [EvaluationStatus](#evaluationstatus)
@@ -479,16 +529,18 @@ _Appears in:_
 
 KeptnTask is the Schema for the keptntasks API
 
+
+
 _Appears in:_
 - [KeptnTaskList](#keptntasklist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnTask` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskSpec](#keptntaskspec)_ |  || ✓ |
-| `status` _[KeptnTaskStatus](#keptntaskstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnTask` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskSpec](#keptntaskspec)_ |  || ✓ |  |
+| `status` _[KeptnTaskStatus](#keptntaskstatus)_ |  || ✓ |  |
 
 
 #### KeptnTaskDefinition
@@ -497,16 +549,18 @@ _Appears in:_
 
 KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionList](#keptntaskdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnTaskDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ |  || ✓ |
-| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnTaskDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ |  || ✓ |  |
+| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ |  || ✓ |  |
 
 
 #### KeptnTaskDefinitionList
@@ -517,12 +571,14 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnTaskDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnTaskDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |  |
 
 
 #### KeptnTaskDefinitionSpec
@@ -531,12 +587,14 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[FunctionSpec](#functionspec)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[FunctionSpec](#functionspec)_ |  || ✓ |  |
 
 
 #### KeptnTaskDefinitionStatus
@@ -545,12 +603,14 @@ _Appears in:_
 
 KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[FunctionStatus](#functionstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[FunctionStatus](#functionstatus)_ |  || ✓ |  |
 
 
 #### KeptnTaskList
@@ -561,12 +621,14 @@ KeptnTaskList contains a list of KeptnTask
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnTaskList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTask](#keptntask) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnTaskList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTask](#keptntask) array_ |  || x |  |
 
 
 #### KeptnTaskSpec
@@ -575,20 +637,22 @@ KeptnTaskList contains a list of KeptnTask
 
 KeptnTaskSpec defines the desired state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _string_ |  || x |
-| `workloadVersion` _string_ |  || x |
-| `app` _string_ |  || x |
-| `appVersion` _string_ |  || x |
-| `taskDefinition` _string_ |  || x |
-| `context` _[TaskContext](#taskcontext)_ |  || x |
-| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |
-| `checkType` _[CheckType](#checktype)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _string_ |  || x |  |
+| `workloadVersion` _string_ |  || x |  |
+| `app` _string_ |  || x |  |
+| `appVersion` _string_ |  || x |  |
+| `taskDefinition` _string_ |  || x |  |
+| `context` _[TaskContext](#taskcontext)_ |  || x |  |
+| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |  |
+| `checkType` _string_ |  || ✓ |  |
 
 
 #### KeptnTaskStatus
@@ -597,16 +661,18 @@ _Appears in:_
 
 KeptnTaskStatus defines the observed state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `jobName` _string_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `message` _string_ |  || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `jobName` _string_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `message` _string_ |  || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### KeptnWorkload
@@ -615,16 +681,18 @@ _Appears in:_
 
 KeptnWorkload is the Schema for the keptnworkloads API
 
+
+
 _Appears in:_
 - [KeptnWorkloadList](#keptnworkloadlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnWorkload` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ |  || ✓ |
-| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnWorkload` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ |  || ✓ |  |
+| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ |  || ✓ |  |
 
 
 #### KeptnWorkloadInstance
@@ -633,16 +701,18 @@ _Appears in:_
 
 KeptnWorkloadInstance is the Schema for the keptnworkloadinstances API
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstanceList](#keptnworkloadinstancelist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnWorkloadInstance` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)_ |  || ✓ |
-| `status` _[KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnWorkloadInstance` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)_ |  || ✓ |  |
+| `status` _[KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)_ |  || ✓ |  |
 
 
 #### KeptnWorkloadInstanceList
@@ -653,12 +723,14 @@ KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnWorkloadInstanceList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkloadInstance](#keptnworkloadinstance) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnWorkloadInstanceList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkloadInstance](#keptnworkloadinstance) array_ |  || x |  |
 
 
 #### KeptnWorkloadInstanceSpec
@@ -667,21 +739,23 @@ KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 
 KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstance](#keptnworkloadinstance)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ |  || x |
-| `version` _string_ |  || x |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |
-| `workloadName` _string_ |  || x |
-| `previousVersion` _string_ |  || ✓ |
-| `traceId` _object (keys:string, values:string)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ |  || x |  |
+| `version` _string_ |  || x |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |  |
+| `workloadName` _string_ |  || x |  |
+| `previousVersion` _string_ |  || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ |  || ✓ |  |
 
 
 #### KeptnWorkloadInstanceStatus
@@ -690,25 +764,27 @@ _Appears in:_
 
 KeptnWorkloadInstanceStatus defines the observed state of KeptnWorkloadInstance
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstance](#keptnworkloadinstance)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `deploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `preDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |
-| `postDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `currentPhase` _string_ |  || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `deploymentStatus` _string_ |  |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `preDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |  |
+| `postDeploymentTaskStatus` _[TaskStatus](#taskstatus) array_ |  || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[EvaluationStatus](#evaluationstatus) array_ |  || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `currentPhase` _string_ |  || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
 
 
 #### KeptnWorkloadList
@@ -719,15 +795,19 @@ KeptnWorkloadList contains a list of KeptnWorkload
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnWorkloadList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnWorkloadList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |  |
 
 
 #### KeptnWorkloadRef
+
+
 
 
 
@@ -738,10 +818,10 @@ _Appears in:_
 - [KeptnAppVersionSpec](#keptnappversionspec)
 - [WorkloadStatus](#workloadstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || x |
-| `version` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || x |  |
+| `version` _string_ |  || x |  |
 
 
 #### KeptnWorkloadSpec
@@ -750,19 +830,21 @@ _Appears in:_
 
 KeptnWorkloadSpec defines the desired state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 - [KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ |  || x |
-| `version` _string_ |  || x |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ |  || x |  |
+| `version` _string_ |  || x |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |  |
 
 
 #### KeptnWorkloadStatus
@@ -771,12 +853,14 @@ _Appears in:_
 
 KeptnWorkloadStatus defines the observed state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ |  || ✓ |  |
 
 
 #### Objective
@@ -785,14 +869,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || x |
-| `query` _string_ |  || x |
-| `evaluationTarget` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || x |  |
+| `query` _string_ |  || x |  |
+| `evaluationTarget` _string_ |  || x |  |
 
 
 #### PhaseTraceID
@@ -800,6 +886,8 @@ _Appears in:_
 _Underlying type:_ _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_
 
 PhaseTraceID is a map storing TraceIDs of OpenTelemetry spans in lifecycle phases
+
+
 
 _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
@@ -813,18 +901,22 @@ _Appears in:_
 
 ResourceReference represents the parent resource of Workload
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)
 - [KeptnWorkloadSpec](#keptnworkloadspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `uid` _[UID](https://pkg.go.dev/k8s.io/apimachinery@v0.29.2/pkg/types#UID)_ |  || x |
-| `kind` _string_ |  || x |
-| `name` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `uid` _string_ |  || x |  |
+| `kind` _string_ |  || x |  |
+| `name` _string_ |  || x |  |
 
 
 #### SecureParameters
+
+
 
 
 
@@ -834,9 +926,9 @@ _Appears in:_
 - [FunctionSpec](#functionspec)
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `secret` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `secret` _string_ |  || ✓ |  |
 
 
 
@@ -847,20 +939,24 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workloadName` _string_ |  || x |
-| `appName` _string_ |  || x |
-| `appVersion` _string_ |  || x |
-| `workloadVersion` _string_ |  || x |
-| `taskType` _string_ |  || x |
-| `objectType` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workloadName` _string_ |  || x |  |
+| `appName` _string_ |  || x |  |
+| `appVersion` _string_ |  || x |  |
+| `workloadVersion` _string_ |  || x |  |
+| `taskType` _string_ |  || x |  |
+| `objectType` _string_ |  || x |  |
 
 
 #### TaskParameters
+
+
 
 
 
@@ -870,12 +966,14 @@ _Appears in:_
 - [FunctionSpec](#functionspec)
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `map` _object (keys:string, values:string)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `map` _object (keys:string, values:string)_ |  || ✓ |  |
 
 
 #### TaskStatus
+
+
 
 
 
@@ -885,13 +983,13 @@ _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 - [KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `taskDefinitionName` _string_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `taskName` _string_ |  || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `taskDefinitionName` _string_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `taskName` _string_ |  || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### WorkloadStatus
@@ -900,12 +998,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
 
 

--- a/docs/docs/reference/api-reference/lifecycle/v1alpha2/index.md
+++ b/docs/docs/reference/api-reference/lifecycle/v1alpha2/index.md
@@ -38,6 +38,8 @@ _Underlying type:_ _string_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationSpec](#keptnevaluationspec)
 - [KeptnTaskSpec](#keptntaskspec)
@@ -50,12 +52,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || ✓ |  |
 
 
 
@@ -66,14 +70,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationStatus](#keptnevaluationstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ |  || x |
-| `status` _[KeptnState](#keptnstate)_ |  || x |
-| `message` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ |  || x |  |
+| `status` _string_ |  || x |  |
+| `message` _string_ |  || ✓ |  |
 
 
 #### FunctionReference
@@ -82,12 +88,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || ✓ |  |
 
 
 #### FunctionSpec
@@ -96,17 +104,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `functionRef` _[FunctionReference](#functionreference)_ |  || ✓ |
-| `inline` _[Inline](#inline)_ |  || ✓ |
-| `httpRef` _[HttpReference](#httpreference)_ |  || ✓ |
-| `configMapRef` _[ConfigMapReference](#configmapreference)_ |  || ✓ |
-| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `functionRef` _[FunctionReference](#functionreference)_ |  || ✓ |  |
+| `inline` _[Inline](#inline)_ |  || ✓ |  |
+| `httpRef` _[HttpReference](#httpreference)_ |  || ✓ |  |
+| `configMapRef` _[ConfigMapReference](#configmapreference)_ |  || ✓ |  |
+| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |  |
 
 
 #### FunctionStatus
@@ -115,12 +125,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `configMap` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `configMap` _string_ |  || ✓ |  |
 
 
 #### HttpReference
@@ -129,12 +141,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `url` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `url` _string_ |  || ✓ |  |
 
 
 #### Inline
@@ -143,15 +157,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [FunctionSpec](#functionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `code` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `code` _string_ |  || ✓ |  |
 
 
 #### ItemStatus
+
+
 
 
 
@@ -161,13 +179,13 @@ _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 - [KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `name` _string_ | Name is the name of the Evaluation/Task || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `name` _string_ | Name is the name of the Evaluation/Task || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### KeptnApp
@@ -176,16 +194,18 @@ _Appears in:_
 
 KeptnApp is the Schema for the keptnapps API
 
+
+
 _Appears in:_
 - [KeptnAppList](#keptnapplist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnApp` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppSpec](#keptnappspec)_ |  || ✓ |
-| `status` _[KeptnAppStatus](#keptnappstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnApp` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppSpec](#keptnappspec)_ |  || ✓ |  |
+| `status` _[KeptnAppStatus](#keptnappstatus)_ |  || ✓ |  |
 
 
 #### KeptnAppList
@@ -196,12 +216,14 @@ KeptnAppList contains a list of KeptnApp
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnAppList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnApp](#keptnapp) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnAppList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnApp](#keptnapp) array_ |  || x |  |
 
 
 #### KeptnAppSpec
@@ -210,19 +232,21 @@ KeptnAppList contains a list of KeptnApp
 
 KeptnAppSpec defines the desired state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ |  || x |
-| `revision` _integer_ |  |1| ✓ |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ |  || x |  |
+| `revision` _integer_ |  |1| ✓ |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
 
 
 #### KeptnAppStatus
@@ -231,12 +255,14 @@ _Appears in:_
 
 KeptnAppStatus defines the observed state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ |  || ✓ |  |
 
 
 #### KeptnAppVersion
@@ -245,16 +271,18 @@ _Appears in:_
 
 KeptnAppVersion is the Schema for the keptnappversions API
 
+
+
 _Appears in:_
 - [KeptnAppVersionList](#keptnappversionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnAppVersion` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ |  || ✓ |
-| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnAppVersion` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ |  || ✓ |  |
+| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ |  || ✓ |  |
 
 
 #### KeptnAppVersionList
@@ -265,12 +293,14 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnAppVersionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnAppVersionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |  |
 
 
 #### KeptnAppVersionSpec
@@ -279,21 +309,23 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 KeptnAppVersionSpec defines the desired state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ |  || x |
-| `revision` _integer_ |  |1| ✓ |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
-| `appName` _string_ |  || x |
-| `previousVersion` _string_ |  || ✓ |
-| `traceId` _object (keys:string, values:string)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ |  || x |  |
+| `revision` _integer_ |  |1| ✓ |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ |  || ✓ |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `appName` _string_ |  || x |  |
+| `previousVersion` _string_ |  || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ |  || ✓ |  |
 
 
 #### KeptnAppVersionStatus
@@ -302,26 +334,28 @@ _Appears in:_
 
 KeptnAppVersionStatus defines the observed state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `workloadOverallStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ |  || ✓ |
-| `currentPhase` _string_ |  || ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `workloadOverallStatus` _string_ |  |Pending| ✓ |  |
+| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ |  || ✓ |  |
+| `currentPhase` _string_ |  || ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### KeptnEvaluation
@@ -330,16 +364,18 @@ _Appears in:_
 
 KeptnEvaluation is the Schema for the keptnevaluations API
 
+
+
 _Appears in:_
 - [KeptnEvaluationList](#keptnevaluationlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnEvaluation` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ |  || ✓ |
-| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnEvaluation` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ |  || ✓ |  |
+| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ |  || ✓ |  |
 
 
 #### KeptnEvaluationDefinition
@@ -348,16 +384,18 @@ _Appears in:_
 
 KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions API
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionList](#keptnevaluationdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnEvaluationDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnEvaluationDefinitionList
@@ -368,12 +406,14 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnEvaluationDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |  |
 
 
 #### KeptnEvaluationDefinitionSpec
@@ -382,13 +422,15 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 KeptnEvaluationDefinitionSpec defines the desired state of KeptnEvaluationDefinition
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinition](#keptnevaluationdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `source` _string_ |  || x |
-| `objectives` _[Objective](#objective) array_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `source` _string_ |  || x |  |
+| `objectives` _[Objective](#objective) array_ |  || x |  |
 
 
 #### KeptnEvaluationList
@@ -399,12 +441,14 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnEvaluationList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnEvaluationList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |  |
 
 
 
@@ -415,20 +459,22 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 KeptnEvaluationSpec defines the desired state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _string_ |  || ✓ |
-| `workloadVersion` _string_ |  || x |
-| `appName` _string_ |  || ✓ |
-| `appVersion` _string_ |  || ✓ |
-| `evaluationDefinition` _string_ |  || x |
-| `retries` _integer_ |  |10| ✓ |
-| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ |  |5s| ✓ |
-| `failAction` _string_ |  || ✓ |
-| `checkType` _[CheckType](#checktype)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _string_ |  || ✓ |  |
+| `workloadVersion` _string_ |  || x |  |
+| `appName` _string_ |  || ✓ |  |
+| `appVersion` _string_ |  || ✓ |  |
+| `evaluationDefinition` _string_ |  || x |  |
+| `retries` _integer_ |  |10| ✓ |  |
+| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ |  |5s| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
+| `failAction` _string_ |  || ✓ |  |
+| `checkType` _string_ |  || ✓ |  |
 
 
 #### KeptnEvaluationStatus
@@ -437,16 +483,18 @@ _Appears in:_
 
 KeptnEvaluationStatus defines the observed state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `retryCount` _integer_ |  |0| x |
-| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ |  || x |
-| `overallStatus` _[KeptnState](#keptnstate)_ |  |Pending| x |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `retryCount` _integer_ |  |0| x |  |
+| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ |  || x |  |
+| `overallStatus` _string_ |  |Pending| x |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 
@@ -458,6 +506,8 @@ _Appears in:_
 _Underlying type:_ _string_
 
 KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+
+
 
 _Appears in:_
 - [EvaluationStatusItem](#evaluationstatusitem)
@@ -476,16 +526,18 @@ _Appears in:_
 
 KeptnTask is the Schema for the keptntasks API
 
+
+
 _Appears in:_
 - [KeptnTaskList](#keptntasklist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnTask` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskSpec](#keptntaskspec)_ |  || ✓ |
-| `status` _[KeptnTaskStatus](#keptntaskstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnTask` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskSpec](#keptntaskspec)_ |  || ✓ |  |
+| `status` _[KeptnTaskStatus](#keptntaskstatus)_ |  || ✓ |  |
 
 
 #### KeptnTaskDefinition
@@ -494,16 +546,18 @@ _Appears in:_
 
 KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionList](#keptntaskdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnTaskDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ |  || ✓ |
-| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnTaskDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ |  || ✓ |  |
+| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ |  || ✓ |  |
 
 
 #### KeptnTaskDefinitionList
@@ -514,12 +568,14 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnTaskDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnTaskDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |  |
 
 
 #### KeptnTaskDefinitionSpec
@@ -528,12 +584,14 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[FunctionSpec](#functionspec)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[FunctionSpec](#functionspec)_ |  || ✓ |  |
 
 
 #### KeptnTaskDefinitionStatus
@@ -542,12 +600,14 @@ _Appears in:_
 
 KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[FunctionStatus](#functionstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[FunctionStatus](#functionstatus)_ |  || ✓ |  |
 
 
 #### KeptnTaskList
@@ -558,12 +618,14 @@ KeptnTaskList contains a list of KeptnTask
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnTaskList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTask](#keptntask) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnTaskList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTask](#keptntask) array_ |  || x |  |
 
 
 #### KeptnTaskSpec
@@ -572,20 +634,22 @@ KeptnTaskList contains a list of KeptnTask
 
 KeptnTaskSpec defines the desired state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _string_ |  || x |
-| `workloadVersion` _string_ |  || x |
-| `app` _string_ |  || x |
-| `appVersion` _string_ |  || x |
-| `taskDefinition` _string_ |  || x |
-| `context` _[TaskContext](#taskcontext)_ |  || x |
-| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |
-| `checkType` _[CheckType](#checktype)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _string_ |  || x |  |
+| `workloadVersion` _string_ |  || x |  |
+| `app` _string_ |  || x |  |
+| `appVersion` _string_ |  || x |  |
+| `taskDefinition` _string_ |  || x |  |
+| `context` _[TaskContext](#taskcontext)_ |  || x |  |
+| `parameters` _[TaskParameters](#taskparameters)_ |  || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ |  || ✓ |  |
+| `checkType` _string_ |  || ✓ |  |
 
 
 #### KeptnTaskStatus
@@ -594,16 +658,18 @@ _Appears in:_
 
 KeptnTaskStatus defines the observed state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `jobName` _string_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `message` _string_ |  || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `jobName` _string_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `message` _string_ |  || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
 
 
 #### KeptnWorkload
@@ -612,16 +678,18 @@ _Appears in:_
 
 KeptnWorkload is the Schema for the keptnworkloads API
 
+
+
 _Appears in:_
 - [KeptnWorkloadList](#keptnworkloadlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnWorkload` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ |  || ✓ |
-| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnWorkload` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ |  || ✓ |  |
+| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ |  || ✓ |  |
 
 
 #### KeptnWorkloadInstance
@@ -630,16 +698,18 @@ _Appears in:_
 
 KeptnWorkloadInstance is the Schema for the keptnworkloadinstances API
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstanceList](#keptnworkloadinstancelist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnWorkloadInstance` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)_ |  || ✓ |
-| `status` _[KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnWorkloadInstance` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)_ |  || ✓ |  |
+| `status` _[KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)_ |  || ✓ |  |
 
 
 #### KeptnWorkloadInstanceList
@@ -650,12 +720,14 @@ KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnWorkloadInstanceList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkloadInstance](#keptnworkloadinstance) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnWorkloadInstanceList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkloadInstance](#keptnworkloadinstance) array_ |  || x |  |
 
 
 #### KeptnWorkloadInstanceSpec
@@ -664,21 +736,23 @@ KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 
 KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstance](#keptnworkloadinstance)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ |  || x |
-| `version` _string_ |  || x |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |
-| `workloadName` _string_ |  || x |
-| `previousVersion` _string_ |  || ✓ |
-| `traceId` _object (keys:string, values:string)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ |  || x |  |
+| `version` _string_ |  || x |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |  |
+| `workloadName` _string_ |  || x |  |
+| `previousVersion` _string_ |  || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ |  || ✓ |  |
 
 
 #### KeptnWorkloadInstanceStatus
@@ -687,25 +761,27 @@ _Appears in:_
 
 KeptnWorkloadInstanceStatus defines the observed state of KeptnWorkloadInstance
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstance](#keptnworkloadinstance)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `deploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |
-| `currentPhase` _string_ |  || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `deploymentStatus` _string_ |  |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ |  |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ |  |Pending| ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ |  || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ |  || ✓ |  |
+| `currentPhase` _string_ |  || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
 
 
 #### KeptnWorkloadList
@@ -716,15 +792,19 @@ KeptnWorkloadList contains a list of KeptnWorkload
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnWorkloadList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnWorkloadList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |  |
 
 
 #### KeptnWorkloadRef
+
+
 
 
 
@@ -735,10 +815,10 @@ _Appears in:_
 - [KeptnAppVersionSpec](#keptnappversionspec)
 - [WorkloadStatus](#workloadstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || x |
-| `version` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || x |  |
+| `version` _string_ |  || x |  |
 
 
 #### KeptnWorkloadSpec
@@ -747,19 +827,21 @@ _Appears in:_
 
 KeptnWorkloadSpec defines the desired state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 - [KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ |  || x |
-| `version` _string_ |  || x |
-| `preDeploymentTasks` _string array_ |  || ✓ |
-| `postDeploymentTasks` _string array_ |  || ✓ |
-| `preDeploymentEvaluations` _string array_ |  || ✓ |
-| `postDeploymentEvaluations` _string array_ |  || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ |  || x |  |
+| `version` _string_ |  || x |  |
+| `preDeploymentTasks` _string array_ |  || ✓ |  |
+| `postDeploymentTasks` _string array_ |  || ✓ |  |
+| `preDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `postDeploymentEvaluations` _string array_ |  || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ |  || x |  |
 
 
 #### KeptnWorkloadStatus
@@ -768,12 +850,14 @@ _Appears in:_
 
 KeptnWorkloadStatus defines the observed state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ |  || ✓ |  |
 
 
 #### Objective
@@ -782,19 +866,23 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || x |
-| `query` _string_ |  || x |
-| `evaluationTarget` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || x |  |
+| `query` _string_ |  || x |  |
+| `evaluationTarget` _string_ |  || x |  |
 
 
 #### PhaseTraceID
 
 _Underlying type:_ _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_
+
+
 
 
 
@@ -810,18 +898,22 @@ _Appears in:_
 
 ResourceReference represents the parent resource of Workload
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)
 - [KeptnWorkloadSpec](#keptnworkloadspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `uid` _[UID](https://pkg.go.dev/k8s.io/apimachinery@v0.29.2/pkg/types#UID)_ |  || x |
-| `kind` _string_ |  || x |
-| `name` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `uid` _string_ |  || x |  |
+| `kind` _string_ |  || x |  |
+| `name` _string_ |  || x |  |
 
 
 #### SecureParameters
+
+
 
 
 
@@ -831,9 +923,9 @@ _Appears in:_
 - [FunctionSpec](#functionspec)
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `secret` _string_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `secret` _string_ |  || ✓ |  |
 
 
 
@@ -844,20 +936,24 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workloadName` _string_ |  || x |
-| `appName` _string_ |  || x |
-| `appVersion` _string_ |  || x |
-| `workloadVersion` _string_ |  || x |
-| `taskType` _string_ |  || x |
-| `objectType` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workloadName` _string_ |  || x |  |
+| `appName` _string_ |  || x |  |
+| `appVersion` _string_ |  || x |  |
+| `workloadVersion` _string_ |  || x |  |
+| `taskType` _string_ |  || x |  |
+| `objectType` _string_ |  || x |  |
 
 
 #### TaskParameters
+
+
 
 
 
@@ -867,9 +963,9 @@ _Appears in:_
 - [FunctionSpec](#functionspec)
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `map` _object (keys:string, values:string)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `map` _object (keys:string, values:string)_ |  || ✓ |  |
 
 
 #### WorkloadStatus
@@ -878,12 +974,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ |  || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ |  || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
 
 

--- a/docs/docs/reference/api-reference/lifecycle/v1alpha3/index.md
+++ b/docs/docs/reference/api-reference/lifecycle/v1alpha3/index.md
@@ -42,17 +42,21 @@ Package v1alpha3 contains API Schema definitions for the lifecycle v1alpha3 API 
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `type` _boolean_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `type` _boolean_ |  || x |  |
 
 
 #### CheckType
 
 _Underlying type:_ _string_
+
+
 
 
 
@@ -68,15 +72,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the referenced ConfigMap. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the referenced ConfigMap. || ✓ |  |
 
 
 #### ContainerSpec
+
+
 
 
 
@@ -93,14 +101,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationStatus](#keptnevaluationstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the value of the KeptnMetric being evaluated. || x |
-| `status` _[KeptnState](#keptnstate)_ | Status indicates the status of the objective being evaluated. || x |
-| `message` _string_ | Message contains additional information about the evaluation of an objective. This can include explanations about why an evaluation has failed (e.g. due to a missed objective), or if there was any error during the evaluation of the objective. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the value of the KeptnMetric being evaluated. || x |  |
+| `status` _string_ | Status indicates the status of the objective being evaluated. || x |  |
+| `message` _string_ | Message contains additional information about the evaluation of an objective.<br />This can include explanations about why an evaluation has failed (e.g. due to a missed objective),<br />or if there was any error during the evaluation of the objective. || ✓ |  |
 
 
 #### FunctionReference
@@ -109,12 +119,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the referenced KeptnTaskDefinition. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the referenced KeptnTaskDefinition. || ✓ |  |
 
 
 #### FunctionStatus
@@ -123,12 +135,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `configMap` _string_ | ConfigMap indicates the ConfigMap in which the function code is stored. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `configMap` _string_ | ConfigMap indicates the ConfigMap in which the function code is stored. || ✓ |  |
 
 
 #### HttpReference
@@ -137,12 +151,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `url` _string_ | Url is the URL containing the code of the function. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `url` _string_ | Url is the URL containing the code of the function. || ✓ |  |
 
 
 #### Inline
@@ -151,15 +167,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `code` _string_ | Code contains the code of the function. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `code` _string_ | Code contains the code of the function. || ✓ |  |
 
 
 #### ItemStatus
+
+
 
 
 
@@ -169,13 +189,13 @@ _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 - [KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `name` _string_ | Name is the name of the Evaluation/Task || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the Item (Evaluation/Task) started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the Item (Evaluation/Task) started. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `name` _string_ | Name is the name of the Evaluation/Task || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the Item (Evaluation/Task) started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the Item (Evaluation/Task) started. || ✓ |  |
 
 
 #### KeptnApp
@@ -184,16 +204,18 @@ _Appears in:_
 
 KeptnApp is the Schema for the keptnapps API
 
+
+
 _Appears in:_
 - [KeptnAppList](#keptnapplist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnApp` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppSpec](#keptnappspec)_ | Spec describes the desired state of the KeptnApp. || ✓ |
-| `status` _[KeptnAppStatus](#keptnappstatus)_ | Status describes the current state of the KeptnApp. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnApp` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppSpec](#keptnappspec)_ | Spec describes the desired state of the KeptnApp. || ✓ |  |
+| `status` _[KeptnAppStatus](#keptnappstatus)_ | Status describes the current state of the KeptnApp. || ✓ |  |
 
 
 #### KeptnAppCreationRequest
@@ -202,16 +224,18 @@ _Appears in:_
 
 KeptnAppCreationRequest is the Schema for the keptnappcreationrequests API
 
+
+
 _Appears in:_
 - [KeptnAppCreationRequestList](#keptnappcreationrequestlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnAppCreationRequest` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppCreationRequestSpec](#keptnappcreationrequestspec)_ | Spec describes the desired state of the KeptnAppCreationRequest. || ✓ |
-| `status` _string_ | Status describes the current state of the KeptnAppCreationRequest. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnAppCreationRequest` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppCreationRequestSpec](#keptnappcreationrequestspec)_ | Spec describes the desired state of the KeptnAppCreationRequest. || ✓ |  |
+| `status` _string_ | Status describes the current state of the KeptnAppCreationRequest. || ✓ |  |
 
 
 #### KeptnAppCreationRequestList
@@ -222,12 +246,14 @@ KeptnAppCreationRequestList contains a list of KeptnAppCreationRequest
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnAppCreationRequestList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnAppCreationRequest](#keptnappcreationrequest) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnAppCreationRequestList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnAppCreationRequest](#keptnappcreationrequest) array_ |  || x |  |
 
 
 #### KeptnAppCreationRequestSpec
@@ -236,12 +262,14 @@ KeptnAppCreationRequestList contains a list of KeptnAppCreationRequest
 
 KeptnAppCreationRequestSpec defines the desired state of KeptnAppCreationRequest
 
+
+
 _Appears in:_
 - [KeptnAppCreationRequest](#keptnappcreationrequest)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `appName` _string_ | AppName is the name of the KeptnApp the KeptnAppCreationRequest should create if no user-defined object with that name is found. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `appName` _string_ | AppName is the name of the KeptnApp the KeptnAppCreationRequest should create if no user-defined object with that name is found. || x |  |
 
 
 #### KeptnAppList
@@ -252,12 +280,14 @@ KeptnAppList contains a list of KeptnApp
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnAppList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnApp](#keptnapp) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnAppList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnApp](#keptnapp) array_ |  || x |  |
 
 
 #### KeptnAppSpec
@@ -266,19 +296,21 @@ KeptnAppList contains a list of KeptnApp
 
 KeptnAppSpec defines the desired state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps, the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |
-| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version. This can be used for restarting a KeptnApp which failed to deploy, e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps,<br />the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |  |
+| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version.<br />This can be used for restarting a KeptnApp which failed to deploy,<br />e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
 
 
 #### KeptnAppStatus
@@ -287,12 +319,14 @@ _Appears in:_
 
 KeptnAppStatus defines the observed state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |  |
 
 
 #### KeptnAppVersion
@@ -301,16 +335,18 @@ _Appears in:_
 
 KeptnAppVersion is the Schema for the keptnappversions API
 
+
+
 _Appears in:_
 - [KeptnAppVersionList](#keptnappversionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnAppVersion` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ | Spec describes the desired state of the KeptnAppVersion. || ✓ |
-| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ | Status describes the current state of the KeptnAppVersion. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnAppVersion` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ | Spec describes the desired state of the KeptnAppVersion. || ✓ |  |
+| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ | Status describes the current state of the KeptnAppVersion. || ✓ |  |
 
 
 #### KeptnAppVersionList
@@ -321,12 +357,14 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnAppVersionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnAppVersionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |  |
 
 
 #### KeptnAppVersionSpec
@@ -335,21 +373,23 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 KeptnAppVersionSpec defines the desired state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps, the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |
-| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version. This can be used for restarting a KeptnApp which failed to deploy, e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `appName` _string_ | AppName is the name of the KeptnApp. || x |
-| `previousVersion` _string_ | PreviousVersion is the version of the KeptnApp that has been deployed prior to this version. || ✓ |
-| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps,<br />the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |  |
+| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version.<br />This can be used for restarting a KeptnApp which failed to deploy,<br />e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `appName` _string_ | AppName is the name of the KeptnApp. || x |  |
+| `previousVersion` _string_ | PreviousVersion is the version of the KeptnApp that has been deployed prior to this version. || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |  |
 
 
 #### KeptnAppVersionStatus
@@ -358,26 +398,28 @@ _Appears in:_
 
 KeptnAppVersionStatus defines the observed state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ | PreDeploymentStatus indicates the current status of the KeptnAppVersion's PreDeployment phase. |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ | PostDeploymentStatus indicates the current status of the KeptnAppVersion's PostDeployment phase. |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PreDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PostDeploymentEvaluation phase. |Pending| ✓ |
-| `workloadOverallStatus` _[KeptnState](#keptnstate)_ | WorkloadOverallStatus indicates the current status of the KeptnAppVersion's Workload deployment phase. |Pending| ✓ |
-| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ | WorkloadStatus contains the current status of each KeptnWorkload that is part of the KeptnAppVersion. || ✓ |
-| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnAppVersion. || ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnAppVersion. || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnAppVersion. || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnAppVersion. || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnAppVersion. || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnAppVersion. || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status represents the overall status of the KeptnAppVersion. |Pending| ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnAppVersion started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnAppVersion finished. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ | PreDeploymentStatus indicates the current status of the KeptnAppVersion's PreDeployment phase. |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ | PostDeploymentStatus indicates the current status of the KeptnAppVersion's PostDeployment phase. |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PreDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PostDeploymentEvaluation phase. |Pending| ✓ |  |
+| `workloadOverallStatus` _string_ | WorkloadOverallStatus indicates the current status of the KeptnAppVersion's Workload deployment phase. |Pending| ✓ |  |
+| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ | WorkloadStatus contains the current status of each KeptnWorkload that is part of the KeptnAppVersion. || ✓ |  |
+| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnAppVersion. || ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnAppVersion. || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnAppVersion. || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnAppVersion. || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnAppVersion. || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnAppVersion. || ✓ |  |
+| `status` _string_ | Status represents the overall status of the KeptnAppVersion. |Pending| ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnAppVersion started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnAppVersion finished. || ✓ |  |
 
 
 #### KeptnEvaluation
@@ -386,16 +428,18 @@ _Appears in:_
 
 KeptnEvaluation is the Schema for the keptnevaluations API
 
+
+
 _Appears in:_
 - [KeptnEvaluationList](#keptnevaluationlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnEvaluation` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ | Spec describes the desired state of the KeptnEvaluation. || ✓ |
-| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ | Status describes the current state of the KeptnEvaluation. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnEvaluation` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ | Spec describes the desired state of the KeptnEvaluation. || ✓ |  |
+| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ | Status describes the current state of the KeptnEvaluation. || ✓ |  |
 
 
 #### KeptnEvaluationDefinition
@@ -404,16 +448,18 @@ _Appears in:_
 
 KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions API
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionList](#keptnevaluationdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnEvaluationDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ | Spec describes the desired state of the KeptnEvaluationDefinition. || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ | Spec describes the desired state of the KeptnEvaluationDefinition. || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnEvaluationDefinitionList
@@ -424,12 +470,14 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnEvaluationDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |  |
 
 
 #### KeptnEvaluationDefinitionSpec
@@ -438,12 +486,14 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 KeptnEvaluationDefinitionSpec defines the desired state of KeptnEvaluationDefinition
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinition](#keptnevaluationdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `objectives` _[Objective](#objective) array_ | Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this KeptnEvaluationDefinition to be successful. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `objectives` _[Objective](#objective) array_ | Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this<br />KeptnEvaluationDefinition to be successful. || x |  |
 
 
 #### KeptnEvaluationList
@@ -454,12 +504,14 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnEvaluationList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnEvaluationList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |  |
 
 
 
@@ -470,20 +522,22 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 KeptnEvaluationSpec defines the desired state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _string_ | Workload defines the KeptnWorkload for which the KeptnEvaluation is done. || ✓ |
-| `workloadVersion` _string_ | WorkloadVersion defines the version of the KeptnWorkload for which the KeptnEvaluation is done. || x |
-| `appName` _string_ | AppName defines the KeptnApp for which the KeptnEvaluation is done. || ✓ |
-| `appVersion` _string_ | AppVersion defines the version of the KeptnApp for which the KeptnEvaluation is done. || ✓ |
-| `evaluationDefinition` _string_ | EvaluationDefinition refers to the name of the KeptnEvaluationDefinition which includes the objectives for the KeptnEvaluation. The KeptnEvaluationDefinition can be located in the same namespace as the KeptnEvaluation, or in the Keptn namespace. || x |
-| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |
-| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error or a missed objective. |5s| ✓ |
-| `failAction` _string_ |  || ✓ |
-| `checkType` _[CheckType](#checktype)_ | Type indicates whether the KeptnEvaluation is part of the pre- or postDeployment phase. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _string_ | Workload defines the KeptnWorkload for which the KeptnEvaluation is done. || ✓ |  |
+| `workloadVersion` _string_ | WorkloadVersion defines the version of the KeptnWorkload for which the KeptnEvaluation is done. || x |  |
+| `appName` _string_ | AppName defines the KeptnApp for which the KeptnEvaluation is done. || ✓ |  |
+| `appVersion` _string_ | AppVersion defines the version of the KeptnApp for which the KeptnEvaluation is done. || ✓ |  |
+| `evaluationDefinition` _string_ | EvaluationDefinition refers to the name of the KeptnEvaluationDefinition<br />which includes the objectives for the KeptnEvaluation.<br />The KeptnEvaluationDefinition can be<br />located in the same namespace as the KeptnEvaluation, or in the Keptn namespace. || x |  |
+| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or<br />missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |  |
+| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error<br />or a missed objective. |5s| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
+| `failAction` _string_ |  || ✓ |  |
+| `checkType` _string_ | Type indicates whether the KeptnEvaluation is part of the pre- or postDeployment phase. || ✓ |  |
 
 
 #### KeptnEvaluationStatus
@@ -492,16 +546,18 @@ _Appears in:_
 
 KeptnEvaluationStatus defines the observed state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `retryCount` _integer_ | RetryCount indicates how many times the KeptnEvaluation has been attempted already. |0| x |
-| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ | EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition referenced by the KeptnEvaluation. || x |
-| `overallStatus` _[KeptnState](#keptnstate)_ | OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived from the status of the individual objectives of the KeptnEvaluationDefinition referenced by the KeptnEvaluation. |Pending| x |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnEvaluation started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnEvaluation finished. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `retryCount` _integer_ | RetryCount indicates how many times the KeptnEvaluation has been attempted already. |0| x |  |
+| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ | EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition<br />referenced by the KeptnEvaluation. || x |  |
+| `overallStatus` _string_ | OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived<br />from the status of the individual objectives of the KeptnEvaluationDefinition<br />referenced by the KeptnEvaluation. |Pending| x |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnEvaluation started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnEvaluation finished. || ✓ |  |
 
 
 
@@ -512,13 +568,15 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [Objective](#objective)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the referenced KeptnMetric. || x |
-| `namespace` _string_ | Namespace is the namespace where the referenced KeptnMetric is located. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the referenced KeptnMetric. || x |  |
+| `namespace` _string_ | Namespace is the namespace where the referenced KeptnMetric is located. || ✓ |  |
 
 
 
@@ -528,6 +586,8 @@ _Appears in:_
 _Underlying type:_ _string_
 
 KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+
+
 
 _Appears in:_
 - [EvaluationStatusItem](#evaluationstatusitem)
@@ -546,16 +606,18 @@ _Appears in:_
 
 KeptnTask is the Schema for the keptntasks API
 
+
+
 _Appears in:_
 - [KeptnTaskList](#keptntasklist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnTask` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskSpec](#keptntaskspec)_ | Spec describes the desired state of the KeptnTask. || ✓ |
-| `status` _[KeptnTaskStatus](#keptntaskstatus)_ | Status describes the current state of the KeptnTask. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnTask` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskSpec](#keptntaskspec)_ | Spec describes the desired state of the KeptnTask. || ✓ |  |
+| `status` _[KeptnTaskStatus](#keptntaskstatus)_ | Status describes the current state of the KeptnTask. || ✓ |  |
 
 
 #### KeptnTaskDefinition
@@ -564,16 +626,18 @@ _Appears in:_
 
 KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionList](#keptntaskdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnTaskDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ | Spec describes the desired state of the KeptnTaskDefinition. || ✓ |
-| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ | Status describes the current state of the KeptnTaskDefinition. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnTaskDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ | Spec describes the desired state of the KeptnTaskDefinition. || ✓ |  |
+| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ | Status describes the current state of the KeptnTaskDefinition. || ✓ |  |
 
 
 #### KeptnTaskDefinitionList
@@ -584,12 +648,14 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnTaskDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnTaskDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |  |
 
 
 #### KeptnTaskDefinitionSpec
@@ -598,21 +664,23 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[RuntimeSpec](#runtimespec)_ | Deprecated Function contains the definition for the function that is to be executed in KeptnTasks. || ✓ |
-| `python` _[RuntimeSpec](#runtimespec)_ | Python contains the definition for the python function that is to be executed in KeptnTasks. || ✓ |
-| `deno` _[RuntimeSpec](#runtimespec)_ | Deno contains the definition for the Deno function that is to be executed in KeptnTasks. || ✓ |
-| `container` _[ContainerSpec](#containerspec)_ | Container contains the definition for the container that is to be used in Job. || ✓ |
-| `retries` _integer_ | Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case of an unsuccessful attempt. |10| ✓ |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully. If the task does not complete successfully within this time frame, it will be considered to be failed. |5m| ✓ |
-| `serviceAccount` _[ServiceAccountSpec](#serviceaccountspec)_ | ServiceAccount specifies the service account to be used in jobs to authenticate with the Kubernetes API and access cluster resources. || ✓ |
-| `automountServiceAccountToken` _[AutomountServiceAccountTokenSpec](#automountserviceaccounttokenspec)_ | AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false the pod will decline the service account || ✓ |
-| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished. The timer starts when the status shows up to be Complete or Failed. |300| ✓ |
-| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets is an optional field to specify the names of secrets to use for pulling container images || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[RuntimeSpec](#runtimespec)_ | Deprecated<br />Function contains the definition for the function that is to be executed in KeptnTasks. || ✓ |  |
+| `python` _[RuntimeSpec](#runtimespec)_ | Python contains the definition for the python function that is to be executed in KeptnTasks. || ✓ |  |
+| `deno` _[RuntimeSpec](#runtimespec)_ | Deno contains the definition for the Deno function that is to be executed in KeptnTasks. || ✓ |  |
+| `container` _[ContainerSpec](#containerspec)_ | Container contains the definition for the container that is to be used in Job. || ✓ |  |
+| `retries` _integer_ | Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case<br />of an unsuccessful attempt. |10| ✓ |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully.<br />If the task does not complete successfully within this time frame, it will be<br />considered to be failed. |5m| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
+| `serviceAccount` _[ServiceAccountSpec](#serviceaccountspec)_ | ServiceAccount specifies the service account to be used in jobs to authenticate with the Kubernetes API and access cluster resources. || ✓ |  |
+| `automountServiceAccountToken` _[AutomountServiceAccountTokenSpec](#automountserviceaccounttokenspec)_ | AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false<br />the pod will decline the service account || ✓ |  |
+| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.<br />The timer starts when the status shows up to be Complete or Failed. |300| ✓ |  |
+| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets is an optional field to specify the names of secrets to use for pulling container images || ✓ |  |
 
 
 #### KeptnTaskDefinitionStatus
@@ -621,12 +689,14 @@ _Appears in:_
 
 KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[FunctionStatus](#functionstatus)_ | Function contains status information of the function definition for the task. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[FunctionStatus](#functionstatus)_ | Function contains status information of the function definition for the task. || ✓ |  |
 
 
 #### KeptnTaskList
@@ -637,12 +707,14 @@ KeptnTaskList contains a list of KeptnTask
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnTaskList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTask](#keptntask) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnTaskList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTask](#keptntask) array_ |  || x |  |
 
 
 #### KeptnTaskSpec
@@ -651,18 +723,20 @@ KeptnTaskList contains a list of KeptnTask
 
 KeptnTaskSpec defines the desired state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `taskDefinition` _string_ | TaskDefinition refers to the name of the KeptnTaskDefinition which includes the specification for the task to be performed. The KeptnTaskDefinition can be located in the same namespace as the KeptnTask, or in the Keptn namespace. || x |
-| `context` _[TaskContext](#taskcontext)_ | Context contains contextual information about the task execution. || ✓ |
-| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task. || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task. These will be stored and accessed as secrets in the cluster. || ✓ |
-| `checkType` _[CheckType](#checktype)_ | Type indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |
-| `retries` _integer_ | Retries indicates how many times the KeptnTask can be attempted in the case of an error before considering the KeptnTask to be failed. |10| ✓ |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully. If the task does not complete successfully within this time frame, it will be considered to be failed. |5m| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `taskDefinition` _string_ | TaskDefinition refers to the name of the KeptnTaskDefinition<br />which includes the specification for the task to be performed.<br />The KeptnTaskDefinition can be<br />located in the same namespace as the KeptnTask, or in the Keptn namespace. || x |  |
+| `context` _[TaskContext](#taskcontext)_ | Context contains contextual information about the task execution. || ✓ |  |
+| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task. || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task.<br />These will be stored and accessed as secrets in the cluster. || ✓ |  |
+| `checkType` _string_ | Type indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |  |
+| `retries` _integer_ | Retries indicates how many times the KeptnTask can be attempted in the case of an error<br />before considering the KeptnTask to be failed. |10| ✓ |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully.<br />If the task does not complete successfully within this time frame, it will be<br />considered to be failed. |5m| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### KeptnTaskStatus
@@ -671,17 +745,19 @@ _Appears in:_
 
 KeptnTaskStatus defines the observed state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `jobName` _string_ | JobName is the name of the Job executing the Task. || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status represents the overall state of the KeptnTask. |Pending| ✓ |
-| `message` _string_ | Message contains information about unexpected errors encountered during the execution of the KeptnTask. || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnTask started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnTask finished. || ✓ |
-| `reason` _string_ | Reason contains more information about the reason for the last transition of the Job executing the KeptnTask. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `jobName` _string_ | JobName is the name of the Job executing the Task. || ✓ |  |
+| `status` _string_ | Status represents the overall state of the KeptnTask. |Pending| ✓ |  |
+| `message` _string_ | Message contains information about unexpected errors encountered during the execution of the KeptnTask. || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnTask started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnTask finished. || ✓ |  |
+| `reason` _string_ | Reason contains more information about the reason for the last transition of the Job executing the KeptnTask. || ✓ |  |
 
 
 #### KeptnWorkload
@@ -690,16 +766,18 @@ _Appears in:_
 
 KeptnWorkload is the Schema for the keptnworkloads API
 
+
+
 _Appears in:_
 - [KeptnWorkloadList](#keptnworkloadlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnWorkload` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ | Spec describes the desired state of the KeptnWorkload. || ✓ |
-| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ | Status describes the current state of the KeptnWorkload. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnWorkload` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ | Spec describes the desired state of the KeptnWorkload. || ✓ |  |
+| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ | Status describes the current state of the KeptnWorkload. || ✓ |  |
 
 
 #### KeptnWorkloadInstance
@@ -708,16 +786,18 @@ _Appears in:_
 
 KeptnWorkloadInstance is the Schema for the keptnworkloadinstances API
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstanceList](#keptnworkloadinstancelist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnWorkloadInstance` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)_ | Spec describes the desired state of the KeptnWorkloadInstance. || ✓ |
-| `status` _[KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)_ | Status describes the current state of the KeptnWorkloadInstance. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnWorkloadInstance` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)_ | Spec describes the desired state of the KeptnWorkloadInstance. || ✓ |  |
+| `status` _[KeptnWorkloadInstanceStatus](#keptnworkloadinstancestatus)_ | Status describes the current state of the KeptnWorkloadInstance. || ✓ |  |
 
 
 #### KeptnWorkloadInstanceList
@@ -728,12 +808,14 @@ KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnWorkloadInstanceList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkloadInstance](#keptnworkloadinstance) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnWorkloadInstanceList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkloadInstance](#keptnworkloadinstance) array_ |  || x |  |
 
 
 #### KeptnWorkloadInstanceSpec
@@ -742,21 +824,23 @@ KeptnWorkloadInstanceList contains a list of KeptnWorkloadInstance
 
 KeptnWorkloadInstanceSpec defines the desired state of KeptnWorkloadInstance
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstance](#keptnworkloadinstance)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |
-| `version` _string_ | Version defines the version of the KeptnWorkload. || x |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |
-| `workloadName` _string_ | WorkloadName is the name of the KeptnWorkload. || x |
-| `previousVersion` _string_ | PreviousVersion is the version of the KeptnWorkload that has been deployed prior to this version. || ✓ |
-| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |  |
+| `version` _string_ | Version defines the version of the KeptnWorkload. || x |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource<br />(Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |  |
+| `workloadName` _string_ | WorkloadName is the name of the KeptnWorkload. || x |  |
+| `previousVersion` _string_ | PreviousVersion is the version of the KeptnWorkload that has been deployed prior to this version. || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |  |
 
 
 #### KeptnWorkloadInstanceStatus
@@ -765,25 +849,27 @@ _Appears in:_
 
 KeptnWorkloadInstanceStatus defines the observed state of KeptnWorkloadInstance
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstance](#keptnworkloadinstance)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ | PreDeploymentStatus indicates the current status of the KeptnWorkloadInstance's PreDeployment phase. |Pending| ✓ |
-| `deploymentStatus` _[KeptnState](#keptnstate)_ | DeploymentStatus indicates the current status of the KeptnWorkloadInstance's Deployment phase. |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadInstance's PreDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadInstance's PostDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ | PostDeploymentStatus indicates the current status of the KeptnWorkloadInstance's PostDeployment phase. |Pending| ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnWorkloadInstance. || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnWorkloadInstance. || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnWorkloadInstance. || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnWorkloadInstance. || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnWorkloadInstance started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnWorkloadInstance finished. || ✓ |
-| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnWorkloadInstance. This can be: - PreDeploymentTasks - PreDeploymentEvaluations - Deployment - PostDeploymentTasks - PostDeploymentEvaluations || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnWorkloadInstance || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status represents the overall status of the KeptnWorkloadInstance. |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ | PreDeploymentStatus indicates the current status of the KeptnWorkloadInstance's PreDeployment phase. |Pending| ✓ |  |
+| `deploymentStatus` _string_ | DeploymentStatus indicates the current status of the KeptnWorkloadInstance's Deployment phase. |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadInstance's PreDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadInstance's PostDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ | PostDeploymentStatus indicates the current status of the KeptnWorkloadInstance's PostDeployment phase. |Pending| ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnWorkloadInstance. || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnWorkloadInstance. || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnWorkloadInstance. || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnWorkloadInstance. || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnWorkloadInstance started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnWorkloadInstance finished. || ✓ |  |
+| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnWorkloadInstance. This can be:<br />- PreDeploymentTasks<br />- PreDeploymentEvaluations<br />- Deployment<br />- PostDeploymentTasks<br />- PostDeploymentEvaluations || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnWorkloadInstance || ✓ |  |
+| `status` _string_ | Status represents the overall status of the KeptnWorkloadInstance. |Pending| ✓ |  |
 
 
 #### KeptnWorkloadList
@@ -794,12 +880,14 @@ KeptnWorkloadList contains a list of KeptnWorkload
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnWorkloadList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnWorkloadList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |  |
 
 
 #### KeptnWorkloadRef
@@ -808,15 +896,17 @@ KeptnWorkloadList contains a list of KeptnWorkload
 
 KeptnWorkloadRef refers to a KeptnWorkload that is part of a KeptnApp
 
+
+
 _Appears in:_
 - [KeptnAppSpec](#keptnappspec)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 - [WorkloadStatus](#workloadstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the KeptnWorkload. || x |
-| `version` _string_ | Version is the version of the KeptnWorkload. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the KeptnWorkload. || x |  |
+| `version` _string_ | Version is the version of the KeptnWorkload. || x |  |
 
 
 #### KeptnWorkloadSpec
@@ -825,19 +915,21 @@ _Appears in:_
 
 KeptnWorkloadSpec defines the desired state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 - [KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |
-| `version` _string_ | Version defines the version of the KeptnWorkload. || x |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |  |
+| `version` _string_ | Version defines the version of the KeptnWorkload. || x |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource<br />(Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |  |
 
 
 #### KeptnWorkloadStatus
@@ -846,12 +938,14 @@ _Appears in:_
 
 KeptnWorkloadStatus defines the observed state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |  |
 
 
 #### Objective
@@ -860,18 +954,22 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `keptnMetricRef` _[KeptnMetricReference](#keptnmetricreference)_ | KeptnMetricRef references the KeptnMetric that should be evaluated. || x |
-| `evaluationTarget` _string_ | EvaluationTarget specifies the target value for the references KeptnMetric. Needs to start with either '<' or '>', followed by the target value (e.g. '<10'). || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `keptnMetricRef` _[KeptnMetricReference](#keptnmetricreference)_ | KeptnMetricRef references the KeptnMetric that should be evaluated. || x |  |
+| `evaluationTarget` _string_ | EvaluationTarget specifies the target value for the references KeptnMetric.<br />Needs to start with either '<' or '>', followed by the target value (e.g. '<10'). || x |  |
 
 
 #### PhaseTraceID
 
 _Underlying type:_ _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_
+
+
 
 
 
@@ -887,15 +985,17 @@ _Appears in:_
 
 ResourceReference represents the parent resource of Workload
 
+
+
 _Appears in:_
 - [KeptnWorkloadInstanceSpec](#keptnworkloadinstancespec)
 - [KeptnWorkloadSpec](#keptnworkloadspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `uid` _[UID](https://pkg.go.dev/k8s.io/apimachinery@v0.29.2/pkg/types#UID)_ |  || x |
-| `kind` _string_ |  || x |
-| `name` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `uid` _string_ |  || x |  |
+| `kind` _string_ |  || x |  |
+| `name` _string_ |  || x |  |
 
 
 #### RuntimeSpec
@@ -904,21 +1004,25 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `functionRef` _[FunctionReference](#functionreference)_ | FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters. || ✓ |
-| `inline` _[Inline](#inline)_ | Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line string. || ✓ |
-| `httpRef` _[HttpReference](#httpreference)_ | HttpReference allows to point to an HTTP URL containing the code of the function. || ✓ |
-| `configMapRef` _[ConfigMapReference](#configmapreference)_ | ConfigMapReference allows to reference a ConfigMap containing the code of the function. When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key of the referenced ConfigMap. || ✓ |
-| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task as env variables. || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task. These will be stored and accessed as secrets in the cluster. || ✓ |
-| `cmdParameters` _string_ | CmdParameters contains parameters that will be passed to the command || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `functionRef` _[FunctionReference](#functionreference)_ | FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the<br />function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have<br />multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters. || ✓ |  |
+| `inline` _[Inline](#inline)_ | Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line<br />string. || ✓ |  |
+| `httpRef` _[HttpReference](#httpreference)_ | HttpReference allows to point to an HTTP URL containing the code of the function. || ✓ |  |
+| `configMapRef` _[ConfigMapReference](#configmapreference)_ | ConfigMapReference allows to reference a ConfigMap containing the code of the function.<br />When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key<br />of the referenced ConfigMap. || ✓ |  |
+| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task as env variables. || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task.<br />These will be stored and accessed as secrets in the cluster. || ✓ |  |
+| `cmdParameters` _string_ | CmdParameters contains parameters that will be passed to the command || ✓ |  |
 
 
 #### SecureParameters
+
+
 
 
 
@@ -928,9 +1032,9 @@ _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `secret` _string_ | Secret contains the parameters that will be made available to the job executing the KeptnTask via the 'SECRET_DATA' environment variable. The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA' key of the referenced secret. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `secret` _string_ | Secret contains the parameters that will be made available to the job<br />executing the KeptnTask via the 'SECRET_DATA' environment variable.<br />The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'<br />key of the referenced secret. || ✓ |  |
 
 
 #### ServiceAccountSpec
@@ -939,12 +1043,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || x |  |
 
 
 
@@ -955,20 +1061,24 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workloadName` _string_ | WorkloadName the name of the KeptnWorkload the KeptnTask is being executed for. || ✓ |
-| `appName` _string_ | AppName the name of the KeptnApp the KeptnTask is being executed for. || ✓ |
-| `appVersion` _string_ | AppVersion the version of the KeptnApp the KeptnTask is being executed for. || ✓ |
-| `workloadVersion` _string_ | WorkloadVersion the version of the KeptnWorkload the KeptnTask is being executed for. || ✓ |
-| `taskType` _string_ | TaskType indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |
-| `objectType` _string_ | ObjectType indicates whether the KeptnTask is being executed for a KeptnApp or KeptnWorkload. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workloadName` _string_ | WorkloadName the name of the KeptnWorkload the KeptnTask is being executed for. || ✓ |  |
+| `appName` _string_ | AppName the name of the KeptnApp the KeptnTask is being executed for. || ✓ |  |
+| `appVersion` _string_ | AppVersion the version of the KeptnApp the KeptnTask is being executed for. || ✓ |  |
+| `workloadVersion` _string_ | WorkloadVersion the version of the KeptnWorkload the KeptnTask is being executed for. || ✓ |  |
+| `taskType` _string_ | TaskType indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |  |
+| `objectType` _string_ | ObjectType indicates whether the KeptnTask is being executed for a KeptnApp or KeptnWorkload. || ✓ |  |
 
 
 #### TaskParameters
+
+
 
 
 
@@ -978,9 +1088,9 @@ _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `map` _object (keys:string, values:string)_ | Inline contains the parameters that will be made available to the job executing the KeptnTask via the 'DATA' environment variable. The 'DATA'  environment variable's content will be a json encoded string containing all properties of the map provided. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `map` _object (keys:string, values:string)_ | Inline contains the parameters that will be made available to the job<br />executing the KeptnTask via the 'DATA' environment variable.<br />The 'DATA'  environment variable's content will be a json<br />encoded string containing all properties of the map provided. || ✓ |  |
 
 
 #### WorkloadStatus
@@ -989,12 +1099,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ | Workload refers to a KeptnWorkload that is part of the KeptnAppVersion. || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status indicates the current status of the KeptnWorkload. |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ | Workload refers to a KeptnWorkload that is part of the KeptnAppVersion. || ✓ |  |
+| `status` _string_ | Status indicates the current status of the KeptnWorkload. |Pending| ✓ |  |
 
 

--- a/docs/docs/reference/api-reference/lifecycle/v1alpha4/index.md
+++ b/docs/docs/reference/api-reference/lifecycle/v1alpha4/index.md
@@ -24,16 +24,18 @@ Package v1alpha4 contains API Schema definitions for the lifecycle v1alpha4 API 
 
 KeptnWorkloadVersion is the Schema for the keptnworkloadversions API
 
+
+
 _Appears in:_
 - [KeptnWorkloadVersionList](#keptnworkloadversionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha4` | | |
-| `kind` _string_ | `KeptnWorkloadVersion` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadVersionSpec](#keptnworkloadversionspec)_ | Spec describes the desired state of the KeptnWorkloadVersion. || ✓ |
-| `status` _[KeptnWorkloadVersionStatus](#keptnworkloadversionstatus)_ | Status describes the current state of the KeptnWorkloadVersion. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha4` | | | |
+| `kind` _string_ | `KeptnWorkloadVersion` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadVersionSpec](#keptnworkloadversionspec)_ | Spec describes the desired state of the KeptnWorkloadVersion. || ✓ |  |
+| `status` _[KeptnWorkloadVersionStatus](#keptnworkloadversionstatus)_ | Status describes the current state of the KeptnWorkloadVersion. || ✓ |  |
 
 
 #### KeptnWorkloadVersionList
@@ -44,12 +46,14 @@ KeptnWorkloadVersionList contains a list of KeptnWorkloadVersion
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha4` | | |
-| `kind` _string_ | `KeptnWorkloadVersionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkloadVersion](#keptnworkloadversion) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1alpha4` | | | |
+| `kind` _string_ | `KeptnWorkloadVersionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkloadVersion](#keptnworkloadversion) array_ |  || x |  |
 
 
 #### KeptnWorkloadVersionSpec
@@ -58,21 +62,23 @@ KeptnWorkloadVersionList contains a list of KeptnWorkloadVersion
 
 KeptnWorkloadVersionSpec defines the desired state of KeptnWorkloadVersion
 
+
+
 _Appears in:_
 - [KeptnWorkloadVersion](#keptnworkloadversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |
-| `version` _string_ | Version defines the version of the KeptnWorkload. || x |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `resourceReference` _[ResourceReference](../v1alpha3/index.md#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |
-| `workloadName` _string_ | WorkloadName is the name of the KeptnWorkload. || x |
-| `previousVersion` _string_ | PreviousVersion is the version of the KeptnWorkload that has been deployed prior to this version. || ✓ |
-| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |  |
+| `version` _string_ | Version defines the version of the KeptnWorkload. || x |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `resourceReference` _[ResourceReference](../v1alpha3/index.md#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource<br />(Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |  |
+| `workloadName` _string_ | WorkloadName is the name of the KeptnWorkload. || x |  |
+| `previousVersion` _string_ | PreviousVersion is the version of the KeptnWorkload that has been deployed prior to this version. || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |  |
 
 
 #### KeptnWorkloadVersionStatus
@@ -81,24 +87,26 @@ _Appears in:_
 
 KeptnWorkloadVersionStatus defines the observed state of KeptnWorkloadVersion
 
+
+
 _Appears in:_
 - [KeptnWorkloadVersion](#keptnworkloadversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](../v1alpha3/index.md#keptnstate)_ | PreDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PreDeployment phase. |Pending| ✓ |
-| `deploymentStatus` _[KeptnState](../v1alpha3/index.md#keptnstate)_ | DeploymentStatus indicates the current status of the KeptnWorkloadVersion's Deployment phase. |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](../v1alpha3/index.md#keptnstate)_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PreDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](../v1alpha3/index.md#keptnstate)_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](../v1alpha3/index.md#keptnstate)_ | PostDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PostDeployment phase. |Pending| ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnWorkloadVersion. || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnWorkloadVersion. || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnWorkloadVersion started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnWorkloadVersion finished. || ✓ |
-| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be: - PreDeploymentTasks - PreDeploymentEvaluations - Deployment - PostDeploymentTasks - PostDeploymentEvaluations || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](../v1alpha3/index.md#phasetraceid)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnWorkloadVersion || ✓ |
-| `status` _[KeptnState](../v1alpha3/index.md#keptnstate)_ | Status represents the overall status of the KeptnWorkloadVersion. |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ | PreDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PreDeployment phase. |Pending| ✓ |  |
+| `deploymentStatus` _string_ | DeploymentStatus indicates the current status of the KeptnWorkloadVersion's Deployment phase. |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PreDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ | PostDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PostDeployment phase. |Pending| ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnWorkloadVersion. || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnWorkloadVersion. || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](../v1alpha3/index.md#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnWorkloadVersion started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnWorkloadVersion finished. || ✓ |  |
+| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:<br />- PreDeploymentTasks<br />- PreDeploymentEvaluations<br />- Deployment<br />- PostDeploymentTasks<br />- PostDeploymentEvaluations || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnWorkloadVersion || ✓ |  |
+| `status` _string_ | Status represents the overall status of the KeptnWorkloadVersion. |Pending| ✓ |  |
 
 

--- a/docs/docs/reference/api-reference/lifecycle/v1beta1/index.md
+++ b/docs/docs/reference/api-reference/lifecycle/v1beta1/index.md
@@ -44,17 +44,21 @@ Package v1beta1 contains API Schema definitions for the lifecycle v1beta1 API gr
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `type` _boolean_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `type` _boolean_ |  || x |  |
 
 
 #### CheckType
 
 _Underlying type:_ _string_
+
+
 
 
 
@@ -70,15 +74,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the referenced ConfigMap. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the referenced ConfigMap. || ✓ |  |
 
 
 #### ContainerSpec
+
+
 
 
 
@@ -95,17 +103,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnAppContextSpec](#keptnappcontextspec)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `promotionTasks` _string array_ | PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `promotionTasks` _string array_ | PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
 
 
 #### EvaluationStatusItem
@@ -114,14 +124,16 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationStatus](#keptnevaluationstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the value of the KeptnMetric being evaluated. || x |
-| `status` _[KeptnState](#keptnstate)_ | Status indicates the status of the objective being evaluated. || x |
-| `message` _string_ | Message contains additional information about the evaluation of an objective. This can include explanations about why an evaluation has failed (e.g. due to a missed objective), or if there was any error during the evaluation of the objective. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the value of the KeptnMetric being evaluated. || x |  |
+| `status` _string_ | Status indicates the status of the objective being evaluated. || x |  |
+| `message` _string_ | Message contains additional information about the evaluation of an objective.<br />This can include explanations about why an evaluation has failed (e.g. due to a missed objective),<br />or if there was any error during the evaluation of the objective. || ✓ |  |
 
 
 #### FailureConditions
@@ -131,14 +143,16 @@ _Appears in:_
 FailureConditions represent the failure conditions (number of retries and retry interval)
 for the evaluation to be considered as failed
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)
 - [KeptnEvaluationSpec](#keptnevaluationspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |
-| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error or a missed objective. |5s| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or<br />missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |  |
+| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error<br />or a missed objective. |5s| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### FunctionReference
@@ -147,12 +161,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the referenced KeptnTaskDefinition. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the referenced KeptnTaskDefinition. || ✓ |  |
 
 
 #### FunctionStatus
@@ -161,12 +177,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `configMap` _string_ | ConfigMap indicates the ConfigMap in which the function code is stored. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `configMap` _string_ | ConfigMap indicates the ConfigMap in which the function code is stored. || ✓ |  |
 
 
 #### HttpReference
@@ -175,12 +193,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `url` _string_ | Url is the URL containing the code of the function. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `url` _string_ | Url is the URL containing the code of the function. || ✓ |  |
 
 
 #### Inline
@@ -189,15 +209,19 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `code` _string_ | Code contains the code of the function. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `code` _string_ | Code contains the code of the function. || ✓ |  |
 
 
 #### ItemStatus
+
+
 
 
 
@@ -207,13 +231,13 @@ _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 - [KeptnWorkloadVersionStatus](#keptnworkloadversionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition || ✓ |
-| `status` _[KeptnState](#keptnstate)_ |  |Pending| ✓ |
-| `name` _string_ | Name is the name of the Evaluation/Task || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the Item (Evaluation/Task) started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the Item (Evaluation/Task) started. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `definitionName` _string_ | DefinitionName is the name of the EvaluationDefinition/TaskDefinition || ✓ |  |
+| `status` _string_ |  |Pending| ✓ |  |
+| `name` _string_ | Name is the name of the Evaluation/Task || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the Item (Evaluation/Task) started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the Item (Evaluation/Task) started. || ✓ |  |
 
 
 #### KeptnApp
@@ -222,16 +246,18 @@ _Appears in:_
 
 KeptnApp is the Schema for the keptnapps API
 
+
+
 _Appears in:_
 - [KeptnAppList](#keptnapplist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnApp` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppSpec](#keptnappspec)_ | Spec describes the desired state of the KeptnApp. || ✓ |
-| `status` _[KeptnAppStatus](#keptnappstatus)_ | Status describes the current state of the KeptnApp. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnApp` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppSpec](#keptnappspec)_ | Spec describes the desired state of the KeptnApp. || ✓ |  |
+| `status` _[KeptnAppStatus](#keptnappstatus)_ | Status describes the current state of the KeptnApp. || ✓ |  |
 
 
 #### KeptnAppContext
@@ -240,16 +266,18 @@ _Appears in:_
 
 KeptnAppContext is the Schema for the keptnappcontexts API
 
+
+
 _Appears in:_
 - [KeptnAppContextList](#keptnappcontextlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppContext` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || x |
-| `spec` _[KeptnAppContextSpec](#keptnappcontextspec)_ |  || x |
-| `status` _[KeptnAppContextStatus](#keptnappcontextstatus)_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppContext` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || x |  |
+| `spec` _[KeptnAppContextSpec](#keptnappcontextspec)_ |  || x |  |
+| `status` _[KeptnAppContextStatus](#keptnappcontextstatus)_ |  || x |  |
 
 
 #### KeptnAppContextList
@@ -260,12 +288,14 @@ KeptnAppContextList contains a list of KeptnAppContext
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppContextList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || x |
-| `items` _[KeptnAppContext](#keptnappcontext) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppContextList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || x |  |
+| `items` _[KeptnAppContext](#keptnappcontext) array_ |  || x |  |
 
 
 #### KeptnAppContextSpec
@@ -274,19 +304,21 @@ KeptnAppContextList contains a list of KeptnAppContext
 
 KeptnAppContextSpec defines the desired state of KeptnAppContext
 
+
+
 _Appears in:_
 - [KeptnAppContext](#keptnappcontext)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `promotionTasks` _string array_ | PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |
-| `spanLinks` _string array_ | SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing. For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `promotionTasks` _string array_ | PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |  |
+| `spanLinks` _string array_ | SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.<br />For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links || ✓ |  |
 
 
 #### KeptnAppContextStatus
@@ -295,12 +327,14 @@ _Appears in:_
 
 KeptnAppContextStatus defines the observed state of KeptnAppContext
 
+
+
 _Appears in:_
 - [KeptnAppContext](#keptnappcontext)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnAppCreationRequest
@@ -309,16 +343,18 @@ _Appears in:_
 
 KeptnAppCreationRequest is the Schema for the keptnappcreationrequests API
 
+
+
 _Appears in:_
 - [KeptnAppCreationRequestList](#keptnappcreationrequestlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppCreationRequest` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppCreationRequestSpec](#keptnappcreationrequestspec)_ | Spec describes the desired state of the KeptnAppCreationRequest. || ✓ |
-| `status` _string_ | Status describes the current state of the KeptnAppCreationRequest. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppCreationRequest` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppCreationRequestSpec](#keptnappcreationrequestspec)_ | Spec describes the desired state of the KeptnAppCreationRequest. || ✓ |  |
+| `status` _string_ | Status describes the current state of the KeptnAppCreationRequest. || ✓ |  |
 
 
 #### KeptnAppCreationRequestList
@@ -329,12 +365,14 @@ KeptnAppCreationRequestList contains a list of KeptnAppCreationRequest
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppCreationRequestList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnAppCreationRequest](#keptnappcreationrequest) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppCreationRequestList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnAppCreationRequest](#keptnappcreationrequest) array_ |  || x |  |
 
 
 #### KeptnAppCreationRequestSpec
@@ -343,12 +381,14 @@ KeptnAppCreationRequestList contains a list of KeptnAppCreationRequest
 
 KeptnAppCreationRequestSpec defines the desired state of KeptnAppCreationRequest
 
+
+
 _Appears in:_
 - [KeptnAppCreationRequest](#keptnappcreationrequest)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `appName` _string_ | AppName is the name of the KeptnApp the KeptnAppCreationRequest should create if no user-defined object with that name is found. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `appName` _string_ | AppName is the name of the KeptnApp the KeptnAppCreationRequest should create if no user-defined object with that name is found. || x |  |
 
 
 #### KeptnAppList
@@ -359,12 +399,14 @@ KeptnAppList contains a list of KeptnApp
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnApp](#keptnapp) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnApp](#keptnapp) array_ |  || x |  |
 
 
 #### KeptnAppSpec
@@ -373,15 +415,17 @@ KeptnAppList contains a list of KeptnApp
 
 KeptnAppSpec defines the desired state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps, the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |
-| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version. This can be used for restarting a KeptnApp which failed to deploy, e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps,<br />the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |  |
+| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version.<br />This can be used for restarting a KeptnApp which failed to deploy,<br />e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |  |
 
 
 #### KeptnAppStatus
@@ -390,12 +434,14 @@ _Appears in:_
 
 KeptnAppStatus defines the observed state of KeptnApp
 
+
+
 _Appears in:_
 - [KeptnApp](#keptnapp)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |  |
 
 
 #### KeptnAppVersion
@@ -404,16 +450,18 @@ _Appears in:_
 
 KeptnAppVersion is the Schema for the keptnappversions API
 
+
+
 _Appears in:_
 - [KeptnAppVersionList](#keptnappversionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppVersion` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ | Spec describes the desired state of the KeptnAppVersion. || ✓ |
-| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ | Status describes the current state of the KeptnAppVersion. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppVersion` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnAppVersionSpec](#keptnappversionspec)_ | Spec describes the desired state of the KeptnAppVersion. || ✓ |  |
+| `status` _[KeptnAppVersionStatus](#keptnappversionstatus)_ | Status describes the current state of the KeptnAppVersion. || ✓ |  |
 
 
 #### KeptnAppVersionList
@@ -424,12 +472,14 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnAppVersionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnAppVersionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnAppVersion](#keptnappversion) array_ |  || x |  |
 
 
 #### KeptnAppVersionSpec
@@ -438,24 +488,26 @@ KeptnAppVersionList contains a list of KeptnAppVersion
 
 KeptnAppVersionSpec defines the desired state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnApp. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `promotionTasks` _string array_ | PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |
-| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |
-| `spanLinks` _string array_ | SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing. For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links || ✓ |
-| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps, the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |
-| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version. This can be used for restarting a KeptnApp which failed to deploy, e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |
-| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |
-| `appName` _string_ | AppName is the name of the KeptnApp. || x |
-| `previousVersion` _string_ | PreviousVersion is the version of the KeptnApp that has been deployed prior to this version. || ✓ |
-| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnApp.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `promotionTasks` _string array_ | PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || x |  |
+| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |  |
+| `spanLinks` _string array_ | SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.<br />For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links || ✓ |  |
+| `version` _string_ | Version defines the version of the application. For automatically created KeptnApps,<br />the version is a function of all KeptnWorkloads that are part of the KeptnApp. || x |  |
+| `revision` _integer_ | Revision can be modified to trigger another deployment of a KeptnApp of the same version.<br />This can be used for restarting a KeptnApp which failed to deploy,<br />e.g. due to a failed preDeploymentEvaluation/preDeploymentTask. |1| ✓ |  |
+| `workloads` _[KeptnWorkloadRef](#keptnworkloadref) array_ | Workloads is a list of all KeptnWorkloads that are part of the KeptnApp. || ✓ |  |
+| `appName` _string_ | AppName is the name of the KeptnApp. || x |  |
+| `previousVersion` _string_ | PreviousVersion is the version of the KeptnApp that has been deployed prior to this version. || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |  |
 
 
 #### KeptnAppVersionStatus
@@ -464,28 +516,30 @@ _Appears in:_
 
 KeptnAppVersionStatus defines the observed state of KeptnAppVersion
 
+
+
 _Appears in:_
 - [KeptnAppVersion](#keptnappversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ | PreDeploymentStatus indicates the current status of the KeptnAppVersion's PreDeployment phase. |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ | PostDeploymentStatus indicates the current status of the KeptnAppVersion's PostDeployment phase. |Pending| ✓ |
-| `promotionStatus` _[KeptnState](#keptnstate)_ | PromotionStatus indicates the current status of the KeptnAppVersion's Promotion phase. |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PreDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PostDeploymentEvaluation phase. |Pending| ✓ |
-| `workloadOverallStatus` _[KeptnState](#keptnstate)_ | WorkloadOverallStatus indicates the current status of the KeptnAppVersion's Workload deployment phase. |Pending| ✓ |
-| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ | WorkloadStatus contains the current status of each KeptnWorkload that is part of the KeptnAppVersion. || ✓ |
-| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnAppVersion. || ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnAppVersion. || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnAppVersion. || ✓ |
-| `promotionTaskStatus` _[ItemStatus](#itemstatus) array_ | PromotionTaskStatus indicates the current state of each promotionTask of the KeptnAppVersion. || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnAppVersion. || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnAppVersion. || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnAppVersion. || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status represents the overall status of the KeptnAppVersion. |Pending| ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnAppVersion started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnAppVersion finished. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ | PreDeploymentStatus indicates the current status of the KeptnAppVersion's PreDeployment phase. |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ | PostDeploymentStatus indicates the current status of the KeptnAppVersion's PostDeployment phase. |Pending| ✓ |  |
+| `promotionStatus` _string_ | PromotionStatus indicates the current status of the KeptnAppVersion's Promotion phase. |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PreDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnAppVersion's PostDeploymentEvaluation phase. |Pending| ✓ |  |
+| `workloadOverallStatus` _string_ | WorkloadOverallStatus indicates the current status of the KeptnAppVersion's Workload deployment phase. |Pending| ✓ |  |
+| `workloadStatus` _[WorkloadStatus](#workloadstatus) array_ | WorkloadStatus contains the current status of each KeptnWorkload that is part of the KeptnAppVersion. || ✓ |  |
+| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnAppVersion. || ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnAppVersion. || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnAppVersion. || ✓ |  |
+| `promotionTaskStatus` _[ItemStatus](#itemstatus) array_ | PromotionTaskStatus indicates the current state of each promotionTask of the KeptnAppVersion. || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnAppVersion. || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnAppVersion. || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnAppVersion. || ✓ |  |
+| `status` _string_ | Status represents the overall status of the KeptnAppVersion. |Pending| ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnAppVersion started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnAppVersion finished. || ✓ |  |
 
 
 #### KeptnEvaluation
@@ -494,16 +548,18 @@ _Appears in:_
 
 KeptnEvaluation is the Schema for the keptnevaluations API
 
+
+
 _Appears in:_
 - [KeptnEvaluationList](#keptnevaluationlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnEvaluation` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ | Spec describes the desired state of the KeptnEvaluation. || ✓ |
-| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ | Status describes the current state of the KeptnEvaluation. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnEvaluation` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationSpec](#keptnevaluationspec)_ | Spec describes the desired state of the KeptnEvaluation. || ✓ |  |
+| `status` _[KeptnEvaluationStatus](#keptnevaluationstatus)_ | Status describes the current state of the KeptnEvaluation. || ✓ |  |
 
 
 #### KeptnEvaluationDefinition
@@ -512,16 +568,18 @@ _Appears in:_
 
 KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions API
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionList](#keptnevaluationdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnEvaluationDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ | Spec describes the desired state of the KeptnEvaluationDefinition. || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)_ | Spec describes the desired state of the KeptnEvaluationDefinition. || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnEvaluationDefinitionList
@@ -532,12 +590,14 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnEvaluationDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnEvaluationDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluationDefinition](#keptnevaluationdefinition) array_ |  || x |  |
 
 
 #### KeptnEvaluationDefinitionSpec
@@ -546,14 +606,16 @@ KeptnEvaluationDefinitionList contains a list of KeptnEvaluationDefinition
 
 KeptnEvaluationDefinitionSpec defines the desired state of KeptnEvaluationDefinition
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinition](#keptnevaluationdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `objectives` _[Objective](#objective) array_ | Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this KeptnEvaluationDefinition to be successful. || x |
-| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |
-| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error or a missed objective. |5s| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `objectives` _[Objective](#objective) array_ | Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this<br />KeptnEvaluationDefinition to be successful. || x |  |
+| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or<br />missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |  |
+| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error<br />or a missed objective. |5s| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### KeptnEvaluationList
@@ -564,12 +626,14 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnEvaluationList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnEvaluationList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnEvaluation](#keptnevaluation) array_ |  || x |  |
 
 
 #### KeptnEvaluationSpec
@@ -578,19 +642,21 @@ KeptnEvaluationList contains a list of KeptnEvaluation
 
 KeptnEvaluationSpec defines the desired state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _string_ | Workload defines the KeptnWorkload for which the KeptnEvaluation is done. || ✓ |
-| `workloadVersion` _string_ | WorkloadVersion defines the version of the KeptnWorkload for which the KeptnEvaluation is done. || x |
-| `appName` _string_ | AppName defines the KeptnApp for which the KeptnEvaluation is done. || ✓ |
-| `appVersion` _string_ | AppVersion defines the version of the KeptnApp for which the KeptnEvaluation is done. || ✓ |
-| `evaluationDefinition` _string_ | EvaluationDefinition refers to the name of the KeptnEvaluationDefinition which includes the objectives for the KeptnEvaluation. The KeptnEvaluationDefinition can be located in the same namespace as the KeptnEvaluation, or in the Keptn namespace. || x |
-| `checkType` _[CheckType](#checktype)_ | Type indicates whether the KeptnEvaluation is part of the pre- or postDeployment phase. || ✓ |
-| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |
-| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error or a missed objective. |5s| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _string_ | Workload defines the KeptnWorkload for which the KeptnEvaluation is done. || ✓ |  |
+| `workloadVersion` _string_ | WorkloadVersion defines the version of the KeptnWorkload for which the KeptnEvaluation is done. || x |  |
+| `appName` _string_ | AppName defines the KeptnApp for which the KeptnEvaluation is done. || ✓ |  |
+| `appVersion` _string_ | AppVersion defines the version of the KeptnApp for which the KeptnEvaluation is done. || ✓ |  |
+| `evaluationDefinition` _string_ | EvaluationDefinition refers to the name of the KeptnEvaluationDefinition<br />which includes the objectives for the KeptnEvaluation.<br />The KeptnEvaluationDefinition can be<br />located in the same namespace as the KeptnEvaluation, or in the Keptn namespace. || x |  |
+| `checkType` _string_ | Type indicates whether the KeptnEvaluation is part of the pre- or postDeployment phase. || ✓ |  |
+| `retries` _integer_ | Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or<br />missed evaluation objective, before considering the KeptnEvaluation to be failed. |10| ✓ |  |
+| `retryInterval` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error<br />or a missed objective. |5s| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### KeptnEvaluationStatus
@@ -599,16 +665,18 @@ _Appears in:_
 
 KeptnEvaluationStatus defines the observed state of KeptnEvaluation
 
+
+
 _Appears in:_
 - [KeptnEvaluation](#keptnevaluation)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `retryCount` _integer_ | RetryCount indicates how many times the KeptnEvaluation has been attempted already. |0| x |
-| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ | EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition referenced by the KeptnEvaluation. || x |
-| `overallStatus` _[KeptnState](#keptnstate)_ | OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived from the status of the individual objectives of the KeptnEvaluationDefinition referenced by the KeptnEvaluation. |Pending| x |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnEvaluation started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnEvaluation finished. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `retryCount` _integer_ | RetryCount indicates how many times the KeptnEvaluation has been attempted already. |0| x |  |
+| `evaluationStatus` _object (keys:string, values:[EvaluationStatusItem](#evaluationstatusitem))_ | EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition<br />referenced by the KeptnEvaluation. || x |  |
+| `overallStatus` _string_ | OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived<br />from the status of the individual objectives of the KeptnEvaluationDefinition<br />referenced by the KeptnEvaluation. |Pending| x |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnEvaluation started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnEvaluation finished. || ✓ |  |
 
 
 
@@ -619,13 +687,15 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [Objective](#objective)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the referenced KeptnMetric. || x |
-| `namespace` _string_ | Namespace is the namespace where the referenced KeptnMetric is located. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the referenced KeptnMetric. || x |  |
+| `namespace` _string_ | Namespace is the namespace where the referenced KeptnMetric is located. || ✓ |  |
 
 
 
@@ -635,6 +705,8 @@ _Appears in:_
 _Underlying type:_ _string_
 
 KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+
+
 
 _Appears in:_
 - [EvaluationStatusItem](#evaluationstatusitem)
@@ -653,16 +725,18 @@ _Appears in:_
 
 KeptnTask is the Schema for the keptntasks API
 
+
+
 _Appears in:_
 - [KeptnTaskList](#keptntasklist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnTask` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskSpec](#keptntaskspec)_ | Spec describes the desired state of the KeptnTask. || ✓ |
-| `status` _[KeptnTaskStatus](#keptntaskstatus)_ | Status describes the current state of the KeptnTask. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnTask` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskSpec](#keptntaskspec)_ | Spec describes the desired state of the KeptnTask. || ✓ |  |
+| `status` _[KeptnTaskStatus](#keptntaskstatus)_ | Status describes the current state of the KeptnTask. || ✓ |  |
 
 
 #### KeptnTaskDefinition
@@ -671,16 +745,18 @@ _Appears in:_
 
 KeptnTaskDefinition is the Schema for the keptntaskdefinitions API
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionList](#keptntaskdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnTaskDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ | Spec describes the desired state of the KeptnTaskDefinition. || ✓ |
-| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ | Status describes the current state of the KeptnTaskDefinition. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnTaskDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)_ | Spec describes the desired state of the KeptnTaskDefinition. || ✓ |  |
+| `status` _[KeptnTaskDefinitionStatus](#keptntaskdefinitionstatus)_ | Status describes the current state of the KeptnTaskDefinition. || ✓ |  |
 
 
 #### KeptnTaskDefinitionList
@@ -691,12 +767,14 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnTaskDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnTaskDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTaskDefinition](#keptntaskdefinition) array_ |  || x |  |
 
 
 #### KeptnTaskDefinitionSpec
@@ -705,21 +783,23 @@ KeptnTaskDefinitionList contains a list of KeptnTaskDefinition
 
 KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[RuntimeSpec](#runtimespec)_ | Deprecated Function contains the definition for the function that is to be executed in KeptnTasks. || ✓ |
-| `python` _[RuntimeSpec](#runtimespec)_ | Python contains the definition for the python function that is to be executed in KeptnTasks. || ✓ |
-| `deno` _[RuntimeSpec](#runtimespec)_ | Deno contains the definition for the Deno function that is to be executed in KeptnTasks. || ✓ |
-| `container` _[ContainerSpec](#containerspec)_ | Container contains the definition for the container that is to be used in Job. || ✓ |
-| `retries` _integer_ | Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case of an unsuccessful attempt. |10| ✓ |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully. If the task does not complete successfully within this time frame, it will be considered to be failed. |5m| ✓ |
-| `serviceAccount` _[ServiceAccountSpec](#serviceaccountspec)_ | ServiceAccount specifies the service account to be used in jobs to authenticate with the Kubernetes API and access cluster resources. || ✓ |
-| `automountServiceAccountToken` _[AutomountServiceAccountTokenSpec](#automountserviceaccounttokenspec)_ | AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false the pod will decline the service account || ✓ |
-| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished. The timer starts when the status shows up to be Complete or Failed. |300| ✓ |
-| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets is an optional field to specify the names of secrets to use for pulling container images || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[RuntimeSpec](#runtimespec)_ | Deprecated<br />Function contains the definition for the function that is to be executed in KeptnTasks. || ✓ |  |
+| `python` _[RuntimeSpec](#runtimespec)_ | Python contains the definition for the python function that is to be executed in KeptnTasks. || ✓ |  |
+| `deno` _[RuntimeSpec](#runtimespec)_ | Deno contains the definition for the Deno function that is to be executed in KeptnTasks. || ✓ |  |
+| `container` _[ContainerSpec](#containerspec)_ | Container contains the definition for the container that is to be used in Job. || ✓ |  |
+| `retries` _integer_ | Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case<br />of an unsuccessful attempt. |10| ✓ |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully.<br />If the task does not complete successfully within this time frame, it will be<br />considered to be failed. |5m| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
+| `serviceAccount` _[ServiceAccountSpec](#serviceaccountspec)_ | ServiceAccount specifies the service account to be used in jobs to authenticate with the Kubernetes API and access cluster resources. || ✓ |  |
+| `automountServiceAccountToken` _[AutomountServiceAccountTokenSpec](#automountserviceaccounttokenspec)_ | AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false<br />the pod will decline the service account || ✓ |  |
+| `ttlSecondsAfterFinished` _integer_ | TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.<br />The timer starts when the status shows up to be Complete or Failed. |300| ✓ |  |
+| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | ImagePullSecrets is an optional field to specify the names of secrets to use for pulling container images || ✓ |  |
 
 
 #### KeptnTaskDefinitionStatus
@@ -728,12 +808,14 @@ _Appears in:_
 
 KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
 
+
+
 _Appears in:_
 - [KeptnTaskDefinition](#keptntaskdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `function` _[FunctionStatus](#functionstatus)_ | Function contains status information of the function definition for the task. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `function` _[FunctionStatus](#functionstatus)_ | Function contains status information of the function definition for the task. || ✓ |  |
 
 
 #### KeptnTaskList
@@ -744,12 +826,14 @@ KeptnTaskList contains a list of KeptnTask
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnTaskList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnTask](#keptntask) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnTaskList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnTask](#keptntask) array_ |  || x |  |
 
 
 #### KeptnTaskSpec
@@ -758,18 +842,20 @@ KeptnTaskList contains a list of KeptnTask
 
 KeptnTaskSpec defines the desired state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `taskDefinition` _string_ | TaskDefinition refers to the name of the KeptnTaskDefinition which includes the specification for the task to be performed. The KeptnTaskDefinition can be located in the same namespace as the KeptnTask, or in the Keptn namespace. || x |
-| `context` _[TaskContext](#taskcontext)_ | Context contains contextual information about the task execution. || ✓ |
-| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task. || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task. These will be stored and accessed as secrets in the cluster. || ✓ |
-| `checkType` _[CheckType](#checktype)_ | Type indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |
-| `retries` _integer_ | Retries indicates how many times the KeptnTask can be attempted in the case of an error before considering the KeptnTask to be failed. |10| ✓ |
-| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully. If the task does not complete successfully within this time frame, it will be considered to be failed. |5m| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `taskDefinition` _string_ | TaskDefinition refers to the name of the KeptnTaskDefinition<br />which includes the specification for the task to be performed.<br />The KeptnTaskDefinition can be<br />located in the same namespace as the KeptnTask, or in the Keptn namespace. || x |  |
+| `context` _[TaskContext](#taskcontext)_ | Context contains contextual information about the task execution. || ✓ |  |
+| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task. || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task.<br />These will be stored and accessed as secrets in the cluster. || ✓ |  |
+| `checkType` _string_ | Type indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |  |
+| `retries` _integer_ | Retries indicates how many times the KeptnTask can be attempted in the case of an error<br />before considering the KeptnTask to be failed. |10| ✓ |  |
+| `timeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Timeout specifies the maximum time to wait for the task to be completed successfully.<br />If the task does not complete successfully within this time frame, it will be<br />considered to be failed. |5m| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### KeptnTaskStatus
@@ -778,17 +864,19 @@ _Appears in:_
 
 KeptnTaskStatus defines the observed state of KeptnTask
 
+
+
 _Appears in:_
 - [KeptnTask](#keptntask)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `jobName` _string_ | JobName is the name of the Job executing the Task. || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status represents the overall state of the KeptnTask. |Pending| ✓ |
-| `message` _string_ | Message contains information about unexpected errors encountered during the execution of the KeptnTask. || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnTask started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnTask finished. || ✓ |
-| `reason` _string_ | Reason contains more information about the reason for the last transition of the Job executing the KeptnTask. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `jobName` _string_ | JobName is the name of the Job executing the Task. || ✓ |  |
+| `status` _string_ | Status represents the overall state of the KeptnTask. |Pending| ✓ |  |
+| `message` _string_ | Message contains information about unexpected errors encountered during the execution of the KeptnTask. || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the KeptnTask started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the KeptnTask finished. || ✓ |  |
+| `reason` _string_ | Reason contains more information about the reason for the last transition of the Job executing the KeptnTask. || ✓ |  |
 
 
 #### KeptnWorkload
@@ -797,16 +885,18 @@ _Appears in:_
 
 KeptnWorkload is the Schema for the keptnworkloads API
 
+
+
 _Appears in:_
 - [KeptnWorkloadList](#keptnworkloadlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnWorkload` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ | Spec describes the desired state of the KeptnWorkload. || ✓ |
-| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ | Status describes the current state of the KeptnWorkload. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnWorkload` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadSpec](#keptnworkloadspec)_ | Spec describes the desired state of the KeptnWorkload. || ✓ |  |
+| `status` _[KeptnWorkloadStatus](#keptnworkloadstatus)_ | Status describes the current state of the KeptnWorkload. || ✓ |  |
 
 
 #### KeptnWorkloadList
@@ -817,12 +907,14 @@ KeptnWorkloadList contains a list of KeptnWorkload
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnWorkloadList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnWorkloadList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkload](#keptnworkload) array_ |  || x |  |
 
 
 #### KeptnWorkloadRef
@@ -831,15 +923,17 @@ KeptnWorkloadList contains a list of KeptnWorkload
 
 KeptnWorkloadRef refers to a KeptnWorkload that is part of a KeptnApp
 
+
+
 _Appears in:_
 - [KeptnAppSpec](#keptnappspec)
 - [KeptnAppVersionSpec](#keptnappversionspec)
 - [WorkloadStatus](#workloadstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name is the name of the KeptnWorkload. || x |
-| `version` _string_ | Version is the version of the KeptnWorkload. || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the KeptnWorkload. || x |  |
+| `version` _string_ | Version is the version of the KeptnWorkload. || x |  |
 
 
 #### KeptnWorkloadSpec
@@ -848,20 +942,22 @@ _Appears in:_
 
 KeptnWorkloadSpec defines the desired state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 - [KeptnWorkloadVersionSpec](#keptnworkloadversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |
-| `version` _string_ | Version defines the version of the KeptnWorkload. || x |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |
-| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |  |
+| `version` _string_ | Version defines the version of the KeptnWorkload. || x |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource<br />(Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |  |
+| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |  |
 
 
 #### KeptnWorkloadStatus
@@ -870,12 +966,14 @@ _Appears in:_
 
 KeptnWorkloadStatus defines the observed state of KeptnWorkload
 
+
+
 _Appears in:_
 - [KeptnWorkload](#keptnworkload)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `currentVersion` _string_ | CurrentVersion indicates the version that is currently deployed or being reconciled. || ✓ |  |
 
 
 #### KeptnWorkloadVersion
@@ -884,16 +982,18 @@ _Appears in:_
 
 KeptnWorkloadVersion is the Schema for the keptnworkloadversions API
 
+
+
 _Appears in:_
 - [KeptnWorkloadVersionList](#keptnworkloadversionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnWorkloadVersion` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnWorkloadVersionSpec](#keptnworkloadversionspec)_ | Spec describes the desired state of the KeptnWorkloadVersion. || ✓ |
-| `status` _[KeptnWorkloadVersionStatus](#keptnworkloadversionstatus)_ | Status describes the current state of the KeptnWorkloadVersion. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnWorkloadVersion` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnWorkloadVersionSpec](#keptnworkloadversionspec)_ | Spec describes the desired state of the KeptnWorkloadVersion. || ✓ |  |
+| `status` _[KeptnWorkloadVersionStatus](#keptnworkloadversionstatus)_ | Status describes the current state of the KeptnWorkloadVersion. || ✓ |  |
 
 
 #### KeptnWorkloadVersionList
@@ -904,12 +1004,14 @@ KeptnWorkloadVersionList contains a list of KeptnWorkloadVersion
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnWorkloadVersionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnWorkloadVersion](#keptnworkloadversion) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `lifecycle.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnWorkloadVersionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnWorkloadVersion](#keptnworkloadversion) array_ |  || x |  |
 
 
 #### KeptnWorkloadVersionSpec
@@ -918,22 +1020,24 @@ KeptnWorkloadVersionList contains a list of KeptnWorkloadVersion
 
 KeptnWorkloadVersionSpec defines the desired state of KeptnWorkloadVersion
 
+
+
 _Appears in:_
 - [KeptnWorkloadVersion](#keptnworkloadversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |
-| `version` _string_ | Version defines the version of the KeptnWorkload. || x |
-| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |
-| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnTaskDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed during the pre-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed during the post-deployment phase of the KeptnWorkload. The items of this list refer to the names of KeptnEvaluationDefinitions located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |
-| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |
-| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |
-| `workloadName` _string_ | WorkloadName is the name of the KeptnWorkload. || x |
-| `previousVersion` _string_ | PreviousVersion is the version of the KeptnWorkload that has been deployed prior to this version. || ✓ |
-| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `app` _string_ | AppName is the name of the KeptnApp containing the KeptnWorkload. || x |  |
+| `version` _string_ | Version defines the version of the KeptnWorkload. || x |  |
+| `preDeploymentTasks` _string array_ | PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnApp, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentTasks` _string array_ | PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnTaskDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `preDeploymentEvaluations` _string array_ | PreDeploymentEvaluations is a list of all evaluations to be performed<br />during the pre-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `postDeploymentEvaluations` _string array_ | PostDeploymentEvaluations is a list of all evaluations to be performed<br />during the post-deployment phase of the KeptnWorkload.<br />The items of this list refer to the names of KeptnEvaluationDefinitions<br />located in the same namespace as the KeptnWorkload, or in the Keptn namespace. || ✓ |  |
+| `resourceReference` _[ResourceReference](#resourcereference)_ | ResourceReference is a reference to the Kubernetes resource<br />(Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing. || x |  |
+| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |  |
+| `workloadName` _string_ | WorkloadName is the name of the KeptnWorkload. || x |  |
+| `previousVersion` _string_ | PreviousVersion is the version of the KeptnWorkload that has been deployed prior to this version. || ✓ |  |
+| `traceId` _object (keys:string, values:string)_ | TraceId contains the OpenTelemetry trace ID. || ✓ |  |
 
 
 #### KeptnWorkloadVersionStatus
@@ -942,27 +1046,29 @@ _Appears in:_
 
 KeptnWorkloadVersionStatus defines the observed state of KeptnWorkloadVersion
 
+
+
 _Appears in:_
 - [KeptnWorkloadVersion](#keptnworkloadversion)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `preDeploymentStatus` _[KeptnState](#keptnstate)_ | PreDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PreDeployment phase. |Pending| ✓ |
-| `deploymentStatus` _[KeptnState](#keptnstate)_ | DeploymentStatus indicates the current status of the KeptnWorkloadVersion's Deployment phase. |Pending| ✓ |
-| `preDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PreDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentEvaluationStatus` _[KeptnState](#keptnstate)_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase. |Pending| ✓ |
-| `postDeploymentStatus` _[KeptnState](#keptnstate)_ | PostDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PostDeployment phase. |Pending| ✓ |
-| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnWorkloadVersion. || ✓ |
-| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnWorkloadVersion. || ✓ |
-| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |
-| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |
-| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnWorkloadVersion started. || ✓ |
-| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnWorkloadVersion finished. || ✓ |
-| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be: - PreDeploymentTasks - PreDeploymentEvaluations - Deployment - PostDeploymentTasks - PostDeploymentEvaluations || ✓ |
-| `phaseTraceIDs` _[PhaseTraceID](#phasetraceid)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnWorkloadVersion || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status represents the overall status of the KeptnWorkloadVersion. |Pending| ✓ |
-| `appContextMetadata` _object (keys:string, values:string)_ | AppContextMetadata contains metadata from the related KeptnAppVersion. || ✓ |
-| `deploymentStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | DeploymentStartTime represents the start time of the deployment phase || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `preDeploymentStatus` _string_ | PreDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PreDeployment phase. |Pending| ✓ |  |
+| `deploymentStatus` _string_ | DeploymentStatus indicates the current status of the KeptnWorkloadVersion's Deployment phase. |Pending| ✓ |  |
+| `preDeploymentEvaluationStatus` _string_ | PreDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PreDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentEvaluationStatus` _string_ | PostDeploymentEvaluationStatus indicates the current status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase. |Pending| ✓ |  |
+| `postDeploymentStatus` _string_ | PostDeploymentStatus indicates the current status of the KeptnWorkloadVersion's PostDeployment phase. |Pending| ✓ |  |
+| `preDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentTaskStatus indicates the current state of each preDeploymentTask of the KeptnWorkloadVersion. || ✓ |  |
+| `postDeploymentTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentTaskStatus indicates the current state of each postDeploymentTask of the KeptnWorkloadVersion. || ✓ |  |
+| `preDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PreDeploymentEvaluationTaskStatus indicates the current state of each preDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |  |
+| `postDeploymentEvaluationTaskStatus` _[ItemStatus](#itemstatus) array_ | PostDeploymentEvaluationTaskStatus indicates the current state of each postDeploymentEvaluation of the KeptnWorkloadVersion. || ✓ |  |
+| `startTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | StartTime represents the time at which the deployment of the KeptnWorkloadVersion started. || ✓ |  |
+| `endTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | EndTime represents the time at which the deployment of the KeptnWorkloadVersion finished. || ✓ |  |
+| `currentPhase` _string_ | CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:<br />- PreDeploymentTasks<br />- PreDeploymentEvaluations<br />- Deployment<br />- PostDeploymentTasks<br />- PostDeploymentEvaluations || ✓ |  |
+| `phaseTraceIDs` _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_ | PhaseTraceIDs contains the trace IDs of the OpenTelemetry spans of each phase of the KeptnWorkloadVersion || ✓ |  |
+| `status` _string_ | Status represents the overall status of the KeptnWorkloadVersion. |Pending| ✓ |  |
+| `appContextMetadata` _object (keys:string, values:string)_ | AppContextMetadata contains metadata from the related KeptnAppVersion. || ✓ |  |
+| `deploymentStartTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | DeploymentStartTime represents the start time of the deployment phase || ✓ |  |
 
 
 #### Objective
@@ -971,18 +1077,22 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnEvaluationDefinitionSpec](#keptnevaluationdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `keptnMetricRef` _[KeptnMetricReference](#keptnmetricreference)_ | KeptnMetricRef references the KeptnMetric that should be evaluated. || x |
-| `evaluationTarget` _string_ | EvaluationTarget specifies the target value for the references KeptnMetric. Needs to start with either '<' or '>', followed by the target value (e.g. '<10'). || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `keptnMetricRef` _[KeptnMetricReference](#keptnmetricreference)_ | KeptnMetricRef references the KeptnMetric that should be evaluated. || x |  |
+| `evaluationTarget` _string_ | EvaluationTarget specifies the target value for the references KeptnMetric.<br />Needs to start with either '<' or '>', followed by the target value (e.g. '<10'). || x |  |
 
 
 #### PhaseTraceID
 
 _Underlying type:_ _[MapCarrier](https://pkg.go.dev/go.opentelemetry.io/otel/propagation#MapCarrier)_
+
+
 
 
 
@@ -998,15 +1108,17 @@ _Appears in:_
 
 ResourceReference represents the parent resource of Workload
 
+
+
 _Appears in:_
 - [KeptnWorkloadSpec](#keptnworkloadspec)
 - [KeptnWorkloadVersionSpec](#keptnworkloadversionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `uid` _[UID](https://pkg.go.dev/k8s.io/apimachinery@v0.29.2/pkg/types#UID)_ |  || x |
-| `kind` _string_ |  || x |
-| `name` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `uid` _string_ |  || x |  |
+| `kind` _string_ |  || x |  |
+| `name` _string_ |  || x |  |
 
 
 #### RuntimeSpec
@@ -1015,21 +1127,25 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `functionRef` _[FunctionReference](#functionreference)_ | FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters. || ✓ |
-| `inline` _[Inline](#inline)_ | Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line string. || ✓ |
-| `httpRef` _[HttpReference](#httpreference)_ | HttpReference allows to point to an HTTP URL containing the code of the function. || ✓ |
-| `configMapRef` _[ConfigMapReference](#configmapreference)_ | ConfigMapReference allows to reference a ConfigMap containing the code of the function. When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key of the referenced ConfigMap. || ✓ |
-| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task as env variables. || ✓ |
-| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task. These will be stored and accessed as secrets in the cluster. || ✓ |
-| `cmdParameters` _string_ | CmdParameters contains parameters that will be passed to the command || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `functionRef` _[FunctionReference](#functionreference)_ | FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the<br />function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have<br />multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters. || ✓ |  |
+| `inline` _[Inline](#inline)_ | Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line<br />string. || ✓ |  |
+| `httpRef` _[HttpReference](#httpreference)_ | HttpReference allows to point to an HTTP URL containing the code of the function. || ✓ |  |
+| `configMapRef` _[ConfigMapReference](#configmapreference)_ | ConfigMapReference allows to reference a ConfigMap containing the code of the function.<br />When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key<br />of the referenced ConfigMap. || ✓ |  |
+| `parameters` _[TaskParameters](#taskparameters)_ | Parameters contains parameters that will be passed to the job that executes the task as env variables. || ✓ |  |
+| `secureParameters` _[SecureParameters](#secureparameters)_ | SecureParameters contains secure parameters that will be passed to the job that executes the task.<br />These will be stored and accessed as secrets in the cluster. || ✓ |  |
+| `cmdParameters` _string_ | CmdParameters contains parameters that will be passed to the command || ✓ |  |
 
 
 #### SecureParameters
+
+
 
 
 
@@ -1039,9 +1155,9 @@ _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `secret` _string_ | Secret contains the parameters that will be made available to the job executing the KeptnTask via the 'SECRET_DATA' environment variable. The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA' key of the referenced secret. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `secret` _string_ | Secret contains the parameters that will be made available to the job<br />executing the KeptnTask via the 'SECRET_DATA' environment variable.<br />The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'<br />key of the referenced secret. || ✓ |  |
 
 
 #### ServiceAccountSpec
@@ -1050,12 +1166,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskDefinitionSpec](#keptntaskdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ |  || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ |  || x |  |
 
 
 
@@ -1066,21 +1184,25 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workloadName` _string_ | WorkloadName the name of the KeptnWorkload the KeptnTask is being executed for. || ✓ |
-| `appName` _string_ | AppName the name of the KeptnApp the KeptnTask is being executed for. || ✓ |
-| `appVersion` _string_ | AppVersion the version of the KeptnApp the KeptnTask is being executed for. || ✓ |
-| `workloadVersion` _string_ | WorkloadVersion the version of the KeptnWorkload the KeptnTask is being executed for. || ✓ |
-| `taskType` _string_ | TaskType indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |
-| `objectType` _string_ | ObjectType indicates whether the KeptnTask is being executed for a KeptnApp or KeptnWorkload. || ✓ |
-| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workloadName` _string_ | WorkloadName the name of the KeptnWorkload the KeptnTask is being executed for. || ✓ |  |
+| `appName` _string_ | AppName the name of the KeptnApp the KeptnTask is being executed for. || ✓ |  |
+| `appVersion` _string_ | AppVersion the version of the KeptnApp the KeptnTask is being executed for. || ✓ |  |
+| `workloadVersion` _string_ | WorkloadVersion the version of the KeptnWorkload the KeptnTask is being executed for. || ✓ |  |
+| `taskType` _string_ | TaskType indicates whether the KeptnTask is part of the pre- or postDeployment phase. || ✓ |  |
+| `objectType` _string_ | ObjectType indicates whether the KeptnTask is being executed for a KeptnApp or KeptnWorkload. || ✓ |  |
+| `metadata` _object (keys:string, values:string)_ | Metadata contains additional key-value pairs for contextual information. || ✓ |  |
 
 
 #### TaskParameters
+
+
 
 
 
@@ -1090,9 +1212,9 @@ _Appears in:_
 - [KeptnTaskSpec](#keptntaskspec)
 - [RuntimeSpec](#runtimespec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `map` _object (keys:string, values:string)_ | Inline contains the parameters that will be made available to the job executing the KeptnTask via the 'DATA' environment variable. The 'DATA'  environment variable's content will be a json encoded string containing all properties of the map provided. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `map` _object (keys:string, values:string)_ | Inline contains the parameters that will be made available to the job<br />executing the KeptnTask via the 'DATA' environment variable.<br />The 'DATA'  environment variable's content will be a json<br />encoded string containing all properties of the map provided. || ✓ |  |
 
 
 #### WorkloadStatus
@@ -1101,12 +1223,14 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnAppVersionStatus](#keptnappversionstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ | Workload refers to a KeptnWorkload that is part of the KeptnAppVersion. || ✓ |
-| `status` _[KeptnState](#keptnstate)_ | Status indicates the current status of the KeptnWorkload. |Pending| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `workload` _[KeptnWorkloadRef](#keptnworkloadref)_ | Workload refers to a KeptnWorkload that is part of the KeptnAppVersion. || ✓ |  |
+| `status` _string_ | Status indicates the current status of the KeptnWorkload. |Pending| ✓ |  |
 
 

--- a/docs/docs/reference/api-reference/metrics/v1alpha1/index.md
+++ b/docs/docs/reference/api-reference/metrics/v1alpha1/index.md
@@ -24,16 +24,18 @@ Package v1alpha1 contains API Schema definitions for the metrics v1alpha1 API gr
 
 KeptnMetric is the Schema for the keptnmetrics API
 
+
+
 _Appears in:_
 - [KeptnMetricList](#keptnmetriclist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnMetric` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |
-| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnMetric` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |  |
+| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |  |
 
 
 #### KeptnMetricList
@@ -44,12 +46,14 @@ KeptnMetricList contains a list of KeptnMetric
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnMetricList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnMetricList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |  |
 
 
 #### KeptnMetricSpec
@@ -58,14 +62,16 @@ KeptnMetricList contains a list of KeptnMetric
 
 KeptnMetricSpec defines the desired state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |
-| `query` _string_ | Query represents the query to be run || x |
-| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |  |
+| `query` _string_ | Query represents the query to be run || x |  |
+| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |  |
 
 
 #### KeptnMetricStatus
@@ -74,14 +80,16 @@ _Appears in:_
 
 KeptnMetricStatus defines the observed state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the resulting value || x |
-| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || x |
-| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the resulting value || x |  |
+| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || x |  |
+| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |  |
 
 
 #### ProviderRef
@@ -90,11 +98,13 @@ _Appears in:_
 
 ProviderRef represents the provider object
 
+
+
 _Appears in:_
 - [KeptnMetricSpec](#keptnmetricspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the provider || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name of the provider || x |  |
 
 

--- a/docs/docs/reference/api-reference/metrics/v1alpha2/index.md
+++ b/docs/docs/reference/api-reference/metrics/v1alpha2/index.md
@@ -26,16 +26,18 @@ Package v1alpha2 contains API Schema definitions for the metrics v1alpha2 API gr
 
 KeptnMetric is the Schema for the keptnmetrics API
 
+
+
 _Appears in:_
 - [KeptnMetricList](#keptnmetriclist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnMetric` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |
-| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnMetric` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |  |
+| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |  |
 
 
 #### KeptnMetricList
@@ -46,12 +48,14 @@ KeptnMetricList contains a list of KeptnMetric
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnMetricList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnMetricList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |  |
 
 
 #### KeptnMetricSpec
@@ -60,14 +64,16 @@ KeptnMetricList contains a list of KeptnMetric
 
 KeptnMetricSpec defines the desired state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |
-| `query` _string_ | Query represents the query to be run || x |
-| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |  |
+| `query` _string_ | Query represents the query to be run || x |  |
+| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |  |
 
 
 #### KeptnMetricStatus
@@ -76,14 +82,16 @@ _Appears in:_
 
 KeptnMetricStatus defines the observed state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the resulting value || x |
-| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || x |
-| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the resulting value || x |  |
+| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || x |  |
+| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |  |
 
 
 #### KeptnMetricsProvider
@@ -92,16 +100,18 @@ _Appears in:_
 
 KeptnMetricsProvider is the Schema for the keptnmetricsproviders API
 
+
+
 _Appears in:_
 - [KeptnMetricsProviderList](#keptnmetricsproviderlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnMetricsProvider` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricsProviderSpec](#keptnmetricsproviderspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnMetricsProvider` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricsProviderSpec](#keptnmetricsproviderspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnMetricsProviderList
@@ -112,12 +122,14 @@ KeptnMetricsProviderList contains a list of KeptnMetricsProvider
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | |
-| `kind` _string_ | `KeptnMetricsProviderList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetricsProvider](#keptnmetricsprovider) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha2` | | | |
+| `kind` _string_ | `KeptnMetricsProviderList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetricsProvider](#keptnmetricsprovider) array_ |  || x |  |
 
 
 #### KeptnMetricsProviderSpec
@@ -126,13 +138,15 @@ KeptnMetricsProviderList contains a list of KeptnMetricsProvider
 
 KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
 
+
+
 _Appears in:_
 - [KeptnMetricsProvider](#keptnmetricsprovider)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `targetServer` _string_ |  || x |
-| `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `targetServer` _string_ |  || x |  |
+| `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ |  || ✓ |  |
 
 
 #### ProviderRef
@@ -141,11 +155,13 @@ _Appears in:_
 
 ProviderRef represents the provider object
 
+
+
 _Appears in:_
 - [KeptnMetricSpec](#keptnmetricspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the provider || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name of the provider || x |  |
 
 

--- a/docs/docs/reference/api-reference/metrics/v1alpha3/index.md
+++ b/docs/docs/reference/api-reference/metrics/v1alpha3/index.md
@@ -32,16 +32,18 @@ Package v1alpha3 contains API Schema definitions for the metrics v1alpha3 API gr
 
 Analysis is the Schema for the analyses API
 
+
+
 _Appears in:_
 - [AnalysisList](#analysislist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `Analysis` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[AnalysisSpec](#analysisspec)_ |  || ✓ |
-| `status` _[AnalysisStatus](#analysisstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `Analysis` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[AnalysisSpec](#analysisspec)_ |  || ✓ |  |
+| `status` _[AnalysisStatus](#analysisstatus)_ |  || ✓ |  |
 
 
 #### AnalysisDefinition
@@ -50,16 +52,18 @@ _Appears in:_
 
 AnalysisDefinition is the Schema for the analysisdefinitions APIs
 
+
+
 _Appears in:_
 - [AnalysisDefinitionList](#analysisdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `AnalysisDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[AnalysisDefinitionSpec](#analysisdefinitionspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `AnalysisDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[AnalysisDefinitionSpec](#analysisdefinitionspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### AnalysisDefinitionList
@@ -70,12 +74,14 @@ AnalysisDefinitionList contains a list of AnalysisDefinition
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `AnalysisDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[AnalysisDefinition](#analysisdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `AnalysisDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[AnalysisDefinition](#analysisdefinition) array_ |  || x |  |
 
 
 #### AnalysisDefinitionSpec
@@ -84,13 +90,15 @@ AnalysisDefinitionList contains a list of AnalysisDefinition
 
 AnalysisDefinitionSpec defines the desired state of AnalysisDefinition
 
+
+
 _Appears in:_
 - [AnalysisDefinition](#analysisdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `objectives` _[Objective](#objective) array_ | Objectives defines a list of objectives to evaluate for an analysis || ✓ |
-| `totalScore` _[TotalScore](#totalscore)_ | TotalScore defines the required score for an analysis to be successful || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `objectives` _[Objective](#objective) array_ | Objectives defines a list of objectives to evaluate for an analysis || ✓ |  |
+| `totalScore` _[TotalScore](#totalscore)_ | TotalScore defines the required score for an analysis to be successful || x |  |
 
 
 #### AnalysisList
@@ -101,12 +109,14 @@ AnalysisList contains a list of Analysis
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `AnalysisList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[Analysis](#analysis) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `AnalysisList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[Analysis](#analysis) array_ |  || x |  |
 
 
 #### AnalysisSpec
@@ -115,14 +125,16 @@ AnalysisList contains a list of Analysis
 
 AnalysisSpec defines the desired state of Analysis
 
+
+
 _Appears in:_
 - [Analysis](#analysis)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `timeframe` _[Timeframe](#timeframe)_ | Timeframe specifies the range for the corresponding query in the AnalysisValueTemplate. Please note that either a combination of 'from' and 'to' or the 'recent' property may be set. If neither is set, the Analysis can not be added to the cluster. || x |
-| `args` _object (keys:string, values:string)_ | Args corresponds to a map of key/value pairs that can be used to substitute placeholders in the AnalysisValueTemplate query. i.e. for args foo:bar the query could be "query:percentile(95)?scope=tag(my_foo_label:{{.foo}})". || ✓ |
-| `analysisDefinition` _[ObjectReference](#objectreference)_ | AnalysisDefinition refers to the AnalysisDefinition, a CRD that stores the AnalysisValuesTemplates || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `timeframe` _[Timeframe](#timeframe)_ | Timeframe specifies the range for the corresponding query in the AnalysisValueTemplate. Please note that either<br />a combination of 'from' and 'to' or the 'recent' property may be set. If neither is set, the Analysis can<br />not be added to the cluster. || x |  |
+| `args` _object (keys:string, values:string)_ | Args corresponds to a map of key/value pairs that can be used to substitute placeholders in the AnalysisValueTemplate query. i.e. for args foo:bar the query could be "query:percentile(95)?scope=tag(my_foo_label:{{.foo}})". || ✓ |  |
+| `analysisDefinition` _[ObjectReference](#objectreference)_ | AnalysisDefinition refers to the AnalysisDefinition, a CRD that stores the AnalysisValuesTemplates || x |  |
 
 
 #### AnalysisState
@@ -130,6 +142,8 @@ _Appears in:_
 _Underlying type:_ _string_
 
 AnalysisState represents the state of the analysis
+
+
 
 _Appears in:_
 - [AnalysisStatus](#analysisstatus)
@@ -142,17 +156,19 @@ _Appears in:_
 
 AnalysisStatus stores the status of the overall analysis returns also pass or warnings
 
+
+
 _Appears in:_
 - [Analysis](#analysis)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `timeframe` _[Timeframe](#timeframe)_ | Timeframe describes the time frame which is evaluated by the Analysis || x |
-| `raw` _string_ | Raw contains the raw result of the SLO computation || ✓ |
-| `pass` _boolean_ | Pass returns whether the SLO is satisfied || ✓ |
-| `warning` _boolean_ | Warning returns whether the analysis returned a warning || ✓ |
-| `state` _[AnalysisState](#analysisstate)_ | State describes the current state of the Analysis (Pending/Progressing/Completed) || x |
-| `storedValues` _object (keys:string, values:[ProviderResult](#providerresult))_ | StoredValues contains all analysis values that have already been retrieved successfully || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `timeframe` _[Timeframe](#timeframe)_ | Timeframe describes the time frame which is evaluated by the Analysis || x |  |
+| `raw` _string_ | Raw contains the raw result of the SLO computation || ✓ |  |
+| `pass` _boolean_ | Pass returns whether the SLO is satisfied || ✓ |  |
+| `warning` _boolean_ | Warning returns whether the analysis returned a warning || ✓ |  |
+| `state` _string_ | State describes the current state of the Analysis (Pending/Progressing/Completed) || x |  |
+| `storedValues` _object (keys:string, values:[ProviderResult](#providerresult))_ | StoredValues contains all analysis values that have already been retrieved successfully || ✓ |  |
 
 
 #### AnalysisValueTemplate
@@ -161,16 +177,18 @@ _Appears in:_
 
 AnalysisValueTemplate is the Schema for the analysisvaluetemplates API
 
+
+
 _Appears in:_
 - [AnalysisValueTemplateList](#analysisvaluetemplatelist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `AnalysisValueTemplate` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[AnalysisValueTemplateSpec](#analysisvaluetemplatespec)_ | Spec contains the specification for the AnalysisValueTemplate || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `AnalysisValueTemplate` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[AnalysisValueTemplateSpec](#analysisvaluetemplatespec)_ | Spec contains the specification for the AnalysisValueTemplate || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### AnalysisValueTemplateList
@@ -181,12 +199,14 @@ AnalysisValueTemplateList contains a list of AnalysisValueTemplate
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `AnalysisValueTemplateList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[AnalysisValueTemplate](#analysisvaluetemplate) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `AnalysisValueTemplateList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[AnalysisValueTemplate](#analysisvaluetemplate) array_ |  || x |  |
 
 
 #### AnalysisValueTemplateSpec
@@ -195,13 +215,15 @@ AnalysisValueTemplateList contains a list of AnalysisValueTemplate
 
 AnalysisValueTemplateSpec defines the desired state of AnalysisValueTemplate
 
+
+
 _Appears in:_
 - [AnalysisValueTemplate](#analysisvaluetemplate)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `provider` _[ObjectReference](#objectreference)_ | Provider refers to the KeptnMetricsProvider which should be used to retrieve the data || x |
-| `query` _string_ | Query represents the query to be run. It can include placeholders that are defined using the go template syntax. More info on go templating - https://pkg.go.dev/text/template || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `provider` _[ObjectReference](#objectreference)_ | Provider refers to the KeptnMetricsProvider which should be used to retrieve the data || x |  |
+| `query` _string_ | Query represents the query to be run. It can include placeholders that are defined using the go template<br />syntax. More info on go templating - https://pkg.go.dev/text/template || x |  |
 
 
 #### IntervalResult
@@ -210,15 +232,17 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnMetricStatus](#keptnmetricstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the resulting value || x |
-| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which this data was queried || x |
-| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |
-| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the resulting value || x |  |
+| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which this data was queried || x |  |
+| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |  |
+| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |  |
 
 
 #### KeptnMetric
@@ -227,16 +251,18 @@ _Appears in:_
 
 KeptnMetric is the Schema for the keptnmetrics API
 
+
+
 _Appears in:_
 - [KeptnMetricList](#keptnmetriclist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnMetric` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |
-| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnMetric` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |  |
+| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |  |
 
 
 #### KeptnMetricList
@@ -247,12 +273,14 @@ KeptnMetricList contains a list of KeptnMetric
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnMetricList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnMetricList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |  |
 
 
 #### KeptnMetricSpec
@@ -261,15 +289,17 @@ KeptnMetricList contains a list of KeptnMetric
 
 KeptnMetricSpec defines the desired state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |
-| `query` _string_ | Query represents the query to be run || x |
-| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |
-| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which data is to be queried || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |  |
+| `query` _string_ | Query represents the query to be run || x |  |
+| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |  |
+| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which data is to be queried || ✓ |  |
 
 
 #### KeptnMetricStatus
@@ -278,16 +308,18 @@ _Appears in:_
 
 KeptnMetricStatus defines the observed state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the resulting value || ✓ |
-| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || ✓ |
-| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || ✓ |
-| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |
-| `intervalResults` _[IntervalResult](#intervalresult) array_ | IntervalResults contain a slice of all the interval results || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the resulting value || ✓ |  |
+| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || ✓ |  |
+| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || ✓ |  |
+| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |  |
+| `intervalResults` _[IntervalResult](#intervalresult) array_ | IntervalResults contain a slice of all the interval results || ✓ |  |
 
 
 #### KeptnMetricsProvider
@@ -296,16 +328,18 @@ _Appears in:_
 
 KeptnMetricsProvider is the Schema for the keptnmetricsproviders API
 
+
+
 _Appears in:_
 - [KeptnMetricsProviderList](#keptnmetricsproviderlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnMetricsProvider` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricsProviderSpec](#keptnmetricsproviderspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnMetricsProvider` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricsProviderSpec](#keptnmetricsproviderspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnMetricsProviderList
@@ -316,12 +350,14 @@ KeptnMetricsProviderList contains a list of KeptnMetricsProvider
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | |
-| `kind` _string_ | `KeptnMetricsProviderList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetricsProvider](#keptnmetricsprovider) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1alpha3` | | | |
+| `kind` _string_ | `KeptnMetricsProviderList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetricsProvider](#keptnmetricsprovider) array_ |  || x |  |
 
 
 #### KeptnMetricsProviderSpec
@@ -330,17 +366,21 @@ KeptnMetricsProviderList contains a list of KeptnMetricsProvider
 
 KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
 
+
+
 _Appears in:_
 - [KeptnMetricsProvider](#keptnmetricsprovider)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `type` _string_ | Type represents the provider type. This can be one of prometheus, dynatrace, datadog, dql. || x |
-| `targetServer` _string_ | TargetServer defined the URL at which the metrics provider is reachable with included port and protocol. || x |
-| `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SecretKeyRef defines an optional secret for access credentials to the metrics provider. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `type` _string_ | Type represents the provider type. This can be one of prometheus, dynatrace, datadog, dql. || x | Optional: {} <br />Pattern: `prometheus|dynatrace|datadog|dql` <br /> |
+| `targetServer` _string_ | TargetServer defined the URL at which the metrics provider is reachable with included port and protocol. || x |  |
+| `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SecretKeyRef defines an optional secret for access credentials to the metrics provider. || ✓ | Optional: {} <br /> |
 
 
 #### ObjectReference
+
+
 
 
 
@@ -352,10 +392,10 @@ _Appears in:_
 - [Objective](#objective)
 - [ProviderResult](#providerresult)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name defines the name of the referenced object || x |
-| `namespace` _string_ | Namespace defines the namespace of the referenced object || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name defines the name of the referenced object || x |  |
+| `namespace` _string_ | Namespace defines the namespace of the referenced object || ✓ |  |
 
 
 #### Objective
@@ -364,15 +404,17 @@ _Appears in:_
 
 Objective defines an objective for analysis
 
+
+
 _Appears in:_
 - [AnalysisDefinitionSpec](#analysisdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `analysisValueTemplateRef` _[ObjectReference](#objectreference)_ | AnalysisValueTemplateRef refers to the appropriate AnalysisValueTemplate || x |
-| `target` _[Target](#target)_ | Target defines failure or warning criteria || ✓ |
-| `weight` _integer_ | Weight can be used to emphasize the importance of one Objective over the others |1| ✓ |
-| `keyObjective` _boolean_ | KeyObjective defines whether the whole analysis fails when this objective's target is not met |false| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `analysisValueTemplateRef` _[ObjectReference](#objectreference)_ | AnalysisValueTemplateRef refers to the appropriate AnalysisValueTemplate || x |  |
+| `target` _[Target](#target)_ | Target defines failure or warning criteria || ✓ |  |
+| `weight` _integer_ | Weight can be used to emphasize the importance of one Objective over the others |1| ✓ |  |
+| `keyObjective` _boolean_ | KeyObjective defines whether the whole analysis fails when this objective's target is not met |false| ✓ |  |
 
 
 #### Operator
@@ -381,18 +423,20 @@ _Appears in:_
 
 Operator specifies the supported operators for value comparisons
 
+
+
 _Appears in:_
 - [Target](#target)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `lessThanOrEqual` _[OperatorValue](#operatorvalue)_ | LessThanOrEqual represents '<=' operator || ✓ |
-| `lessThan` _[OperatorValue](#operatorvalue)_ | LessThan represents '<' operator || ✓ |
-| `greaterThan` _[OperatorValue](#operatorvalue)_ | GreaterThan represents '>' operator || ✓ |
-| `greaterThanOrEqual` _[OperatorValue](#operatorvalue)_ | GreaterThanOrEqual represents '>=' operator || ✓ |
-| `equalTo` _[OperatorValue](#operatorvalue)_ | EqualTo represents '==' operator || ✓ |
-| `inRange` _[RangeValue](#rangevalue)_ | InRange represents operator checking the value is inclusively in the defined range, e.g. 2 <= x <= 5 || ✓ |
-| `notInRange` _[RangeValue](#rangevalue)_ | NotInRange represents operator checking the value is exclusively out of the defined range, e.g. x < 2 AND x > 5 || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `lessThanOrEqual` _[OperatorValue](#operatorvalue)_ | LessThanOrEqual represents '<=' operator || ✓ |  |
+| `lessThan` _[OperatorValue](#operatorvalue)_ | LessThan represents '<' operator || ✓ |  |
+| `greaterThan` _[OperatorValue](#operatorvalue)_ | GreaterThan represents '>' operator || ✓ |  |
+| `greaterThanOrEqual` _[OperatorValue](#operatorvalue)_ | GreaterThanOrEqual represents '>=' operator || ✓ |  |
+| `equalTo` _[OperatorValue](#operatorvalue)_ | EqualTo represents '==' operator || ✓ |  |
+| `inRange` _[RangeValue](#rangevalue)_ | InRange represents operator checking the value is inclusively in the defined range, e.g. 2 <= x <= 5 || ✓ |  |
+| `notInRange` _[RangeValue](#rangevalue)_ | NotInRange represents operator checking the value is exclusively out of the defined range, e.g. x < 2 AND x > 5 || ✓ |  |
 
 
 #### OperatorValue
@@ -401,12 +445,14 @@ _Appears in:_
 
 OperatorValue represents the value to which the result is compared
 
+
+
 _Appears in:_
 - [Operator](#operator)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `fixedValue` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | FixedValue defines the value for comparison || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `fixedValue` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | FixedValue defines the value for comparison || x |  |
 
 
 #### ProviderRef
@@ -415,12 +461,14 @@ _Appears in:_
 
 ProviderRef represents the provider object
 
+
+
 _Appears in:_
 - [KeptnMetricSpec](#keptnmetricspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the provider || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name of the provider || x |  |
 
 
 #### ProviderResult
@@ -429,15 +477,17 @@ _Appears in:_
 
 ProviderResult stores reference of already collected provider query associated to its objective template
 
+
+
 _Appears in:_
 - [AnalysisStatus](#analysisstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `objectiveReference` _[ObjectReference](#objectreference)_ | Objective store reference to corresponding objective template || ✓ |
-| `query` _string_ | Query represents the executed query || ✓ |
-| `value` _string_ | Value is the value the provider returned || ✓ |
-| `errMsg` _string_ | ErrMsg stores any possible error at retrieval time || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `objectiveReference` _[ObjectReference](#objectreference)_ | Objective store reference to corresponding objective template || ✓ |  |
+| `query` _string_ | Query represents the executed query || ✓ |  |
+| `value` _string_ | Value is the value the provider returned || ✓ |  |
+| `errMsg` _string_ | ErrMsg stores any possible error at retrieval time || ✓ |  |
 
 
 #### RangeSpec
@@ -446,16 +496,18 @@ _Appears in:_
 
 RangeSpec defines the time range for which data is to be queried
 
+
+
 _Appears in:_
 - [IntervalResult](#intervalresult)
 - [KeptnMetricSpec](#keptnmetricspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `interval` _string_ | Interval specifies the duration of the time interval for the data query |5m| ✓ |
-| `step` _string_ | Step represents the query resolution step width for the data query || ✓ |
-| `aggregation` _string_ | Aggregation defines the type of aggregation function to be applied on the data. Accepted values: p90, p95, p99, max, min, avg, median || ✓ |
-| `storedResults` _integer_ | StoredResults indicates the upper limit of how many past results should be stored in the status of a KeptnMetric || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `interval` _string_ | Interval specifies the duration of the time interval for the data query |5m| ✓ |  |
+| `step` _string_ | Step represents the query resolution step width for the data query || ✓ |  |
+| `aggregation` _string_ | Aggregation defines the type of aggregation function to be applied on the data. Accepted values: p90, p95, p99, max, min, avg, median || ✓ | Enum: [p90 p95 p99 max min avg median] <br /> |
+| `storedResults` _integer_ | StoredResults indicates the upper limit of how many past results should be stored in the status of a KeptnMetric || ✓ | Maximum: 255 <br /> |
 
 
 #### RangeValue
@@ -464,13 +516,15 @@ _Appears in:_
 
 RangeValue represents a range which the value should fit
 
+
+
 _Appears in:_
 - [Operator](#operator)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `lowBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | LowBound defines the lower bound of the range || x |
-| `highBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | HighBound defines the higher bound of the range || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `lowBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | LowBound defines the lower bound of the range || x |  |
+| `highBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | HighBound defines the higher bound of the range || x |  |
 
 
 #### Target
@@ -479,16 +533,20 @@ _Appears in:_
 
 Target defines the failure and warning criteria
 
+
+
 _Appears in:_
 - [Objective](#objective)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `failure` _[Operator](#operator)_ | Failure defines limits up to which an analysis fails || ✓ |
-| `warning` _[Operator](#operator)_ | Warning defines limits where the result does not pass or fail || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `failure` _[Operator](#operator)_ | Failure defines limits up to which an analysis fails || ✓ |  |
+| `warning` _[Operator](#operator)_ | Warning defines limits where the result does not pass or fail || ✓ |  |
 
 
 #### Timeframe
+
+
 
 
 
@@ -498,11 +556,11 @@ _Appears in:_
 - [AnalysisSpec](#analysisspec)
 - [AnalysisStatus](#analysisstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `from` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | From is the time of start for the query. This field follows RFC3339 time format || ✓ |
-| `to` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | To is the time of end for the query. This field follows RFC3339 time format || ✓ |
-| `recent` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis for the last five minutes || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `from` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | From is the time of start for the query. This field follows RFC3339 time format || ✓ |  |
+| `to` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | To is the time of end for the query. This field follows RFC3339 time format || ✓ |  |
+| `recent` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis<br />for the last five minutes || ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### TotalScore
@@ -511,12 +569,14 @@ _Appears in:_
 
 TotalScore defines the required score for an analysis to be successful
 
+
+
 _Appears in:_
 - [AnalysisDefinitionSpec](#analysisdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `passPercentage` _integer_ | PassPercentage defines the threshold to reach for an analysis to pass || x |
-| `warningPercentage` _integer_ | WarningPercentage defines the threshold to reach for an analysis to pass with a 'warning' status || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `passPercentage` _integer_ | PassPercentage defines the threshold to reach for an analysis to pass || x | Maximum: 100 <br />Minimum: 0 <br /> |
+| `warningPercentage` _integer_ | WarningPercentage defines the threshold to reach for an analysis to pass with a 'warning' status || x | Maximum: 100 <br />Minimum: 0 <br /> |
 
 

--- a/docs/docs/reference/api-reference/metrics/v1beta1/index.md
+++ b/docs/docs/reference/api-reference/metrics/v1beta1/index.md
@@ -32,16 +32,18 @@ Package v1beta1 contains API Schema definitions for the metrics v1beta1 API grou
 
 Analysis is the Schema for the analyses API
 
+
+
 _Appears in:_
 - [AnalysisList](#analysislist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `Analysis` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[AnalysisSpec](#analysisspec)_ |  || ✓ |
-| `status` _[AnalysisStatus](#analysisstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `Analysis` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[AnalysisSpec](#analysisspec)_ |  || ✓ |  |
+| `status` _[AnalysisStatus](#analysisstatus)_ |  || ✓ |  |
 
 
 #### AnalysisDefinition
@@ -50,16 +52,18 @@ _Appears in:_
 
 AnalysisDefinition is the Schema for the analysisdefinitions APIs
 
+
+
 _Appears in:_
 - [AnalysisDefinitionList](#analysisdefinitionlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `AnalysisDefinition` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[AnalysisDefinitionSpec](#analysisdefinitionspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `AnalysisDefinition` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[AnalysisDefinitionSpec](#analysisdefinitionspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### AnalysisDefinitionList
@@ -70,12 +74,14 @@ AnalysisDefinitionList contains a list of AnalysisDefinition resources
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `AnalysisDefinitionList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[AnalysisDefinition](#analysisdefinition) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `AnalysisDefinitionList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[AnalysisDefinition](#analysisdefinition) array_ |  || x |  |
 
 
 #### AnalysisDefinitionSpec
@@ -84,13 +90,15 @@ AnalysisDefinitionList contains a list of AnalysisDefinition resources
 
 AnalysisDefinitionSpec defines the desired state of AnalysisDefinition
 
+
+
 _Appears in:_
 - [AnalysisDefinition](#analysisdefinition)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `objectives` _[Objective](#objective) array_ | Objectives defines a list of objectives to evaluate for an analysis || ✓ |
-| `totalScore` _[TotalScore](#totalscore)_ | TotalScore defines the required score for an analysis to be successful || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `objectives` _[Objective](#objective) array_ | Objectives defines a list of objectives to evaluate for an analysis || ✓ |  |
+| `totalScore` _[TotalScore](#totalscore)_ | TotalScore defines the required score for an analysis to be successful || x |  |
 
 
 #### AnalysisList
@@ -101,12 +109,14 @@ AnalysisList contains a list of Analysis resources
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `AnalysisList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[Analysis](#analysis) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `AnalysisList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[Analysis](#analysis) array_ |  || x |  |
 
 
 #### AnalysisSpec
@@ -115,14 +125,16 @@ AnalysisList contains a list of Analysis resources
 
 AnalysisSpec defines the desired state of Analysis
 
+
+
 _Appears in:_
 - [Analysis](#analysis)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `timeframe` _[Timeframe](#timeframe)_ | Timeframe specifies the range for the corresponding query in the AnalysisValueTemplate. Please note that either a combination of 'from' and 'to' or the 'recent' property may be set. If neither is set, the Analysis can not be added to the cluster. || x |
-| `args` _object (keys:string, values:string)_ | Args corresponds to a map of key/value pairs that can be used to substitute placeholders in the AnalysisValueTemplate query. i.e. for args foo:bar the query could be "query:percentile(95)?scope=tag(my_foo_label:{{.foo}})". || ✓ |
-| `analysisDefinition` _[ObjectReference](#objectreference)_ | AnalysisDefinition refers to the AnalysisDefinition, a CRD that stores the AnalysisValuesTemplates || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `timeframe` _[Timeframe](#timeframe)_ | Timeframe specifies the range for the corresponding query in the AnalysisValueTemplate. Please note that either<br />a combination of 'from' and 'to' or the 'recent' property may be set. If neither is set, the Analysis can<br />not be added to the cluster. || x |  |
+| `args` _object (keys:string, values:string)_ | Args corresponds to a map of key/value pairs that can be used to substitute placeholders in the AnalysisValueTemplate query. i.e. for args foo:bar the query could be "query:percentile(95)?scope=tag(my_foo_label:{{.foo}})". || ✓ |  |
+| `analysisDefinition` _[ObjectReference](#objectreference)_ | AnalysisDefinition refers to the AnalysisDefinition, a CRD that stores the AnalysisValuesTemplates || x |  |
 
 
 #### AnalysisState
@@ -130,6 +142,8 @@ _Appears in:_
 _Underlying type:_ _string_
 
 AnalysisState represents the state of the analysis
+
+
 
 _Appears in:_
 - [AnalysisStatus](#analysisstatus)
@@ -142,17 +156,19 @@ _Appears in:_
 
 AnalysisStatus stores the status of the overall analysis returns also pass or warnings
 
+
+
 _Appears in:_
 - [Analysis](#analysis)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `timeframe` _[Timeframe](#timeframe)_ | Timeframe describes the time frame which is evaluated by the Analysis || x |
-| `raw` _string_ | Raw contains the raw result of the SLO computation || ✓ |
-| `pass` _boolean_ | Pass returns whether the SLO is satisfied || ✓ |
-| `warning` _boolean_ | Warning returns whether the analysis returned a warning || ✓ |
-| `state` _[AnalysisState](#analysisstate)_ | State describes the current state of the Analysis (Pending/Progressing/Completed) || x |
-| `storedValues` _object (keys:string, values:[ProviderResult](#providerresult))_ | StoredValues contains all analysis values that have already been retrieved successfully || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `timeframe` _[Timeframe](#timeframe)_ | Timeframe describes the time frame which is evaluated by the Analysis || x |  |
+| `raw` _string_ | Raw contains the raw result of the SLO computation || ✓ |  |
+| `pass` _boolean_ | Pass returns whether the SLO is satisfied || ✓ |  |
+| `warning` _boolean_ | Warning returns whether the analysis returned a warning || ✓ |  |
+| `state` _string_ | State describes the current state of the Analysis (Pending/Progressing/Completed) || x |  |
+| `storedValues` _object (keys:string, values:[ProviderResult](#providerresult))_ | StoredValues contains all analysis values that have already been retrieved successfully || ✓ |  |
 
 
 #### AnalysisValueTemplate
@@ -161,16 +177,18 @@ _Appears in:_
 
 AnalysisValueTemplate is the Schema for the analysisvaluetemplates API
 
+
+
 _Appears in:_
 - [AnalysisValueTemplateList](#analysisvaluetemplatelist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `AnalysisValueTemplate` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[AnalysisValueTemplateSpec](#analysisvaluetemplatespec)_ | Spec contains the specification for the AnalysisValueTemplate || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `AnalysisValueTemplate` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[AnalysisValueTemplateSpec](#analysisvaluetemplatespec)_ | Spec contains the specification for the AnalysisValueTemplate || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### AnalysisValueTemplateList
@@ -181,12 +199,14 @@ AnalysisValueTemplateList contains a list of AnalysisValueTemplate resources
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `AnalysisValueTemplateList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[AnalysisValueTemplate](#analysisvaluetemplate) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `AnalysisValueTemplateList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[AnalysisValueTemplate](#analysisvaluetemplate) array_ |  || x |  |
 
 
 #### AnalysisValueTemplateSpec
@@ -195,13 +215,15 @@ AnalysisValueTemplateList contains a list of AnalysisValueTemplate resources
 
 AnalysisValueTemplateSpec defines the desired state of AnalysisValueTemplate
 
+
+
 _Appears in:_
 - [AnalysisValueTemplate](#analysisvaluetemplate)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `provider` _[ObjectReference](#objectreference)_ | Provider refers to the KeptnMetricsProvider which should be used to retrieve the data || x |
-| `query` _string_ | Query represents the query to be run. It can include placeholders that are defined using the go template syntax. More info on go templating - https://pkg.go.dev/text/template || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `provider` _[ObjectReference](#objectreference)_ | Provider refers to the KeptnMetricsProvider which should be used to retrieve the data || x |  |
+| `query` _string_ | Query represents the query to be run. It can include placeholders that are defined using the go template<br />syntax. More info on go templating - https://pkg.go.dev/text/template || x |  |
 
 
 #### IntervalResult
@@ -210,15 +232,17 @@ _Appears in:_
 
 
 
+
+
 _Appears in:_
 - [KeptnMetricStatus](#keptnmetricstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the resulting value || x |
-| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which this data was queried || x |
-| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |
-| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the resulting value || x |  |
+| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which this data was queried || x |  |
+| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || x |  |
+| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |  |
 
 
 #### KeptnMetric
@@ -227,16 +251,18 @@ _Appears in:_
 
 KeptnMetric is the Schema for the keptnmetrics API
 
+
+
 _Appears in:_
 - [KeptnMetricList](#keptnmetriclist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnMetric` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |
-| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnMetric` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricSpec](#keptnmetricspec)_ |  || ✓ |  |
+| `status` _[KeptnMetricStatus](#keptnmetricstatus)_ |  || ✓ |  |
 
 
 #### KeptnMetricList
@@ -247,12 +273,14 @@ KeptnMetricList contains a list of KeptnMetric resources
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnMetricList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnMetricList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetric](#keptnmetric) array_ |  || x |  |
 
 
 #### KeptnMetricSpec
@@ -261,15 +289,17 @@ KeptnMetricList contains a list of KeptnMetric resources
 
 KeptnMetricSpec defines the desired state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |
-| `query` _string_ | Query represents the query to be run || x |
-| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |
-| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which data is to be queried || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `provider` _[ProviderRef](#providerref)_ | Provider represents the provider object || x |  |
+| `query` _string_ | Query represents the query to be run || x |  |
+| `fetchIntervalSeconds` _integer_ | FetchIntervalSeconds represents the update frequency in seconds that is used to update the metric || x |  |
+| `range` _[RangeSpec](#rangespec)_ | Range represents the time range for which data is to be queried || ✓ |  |
 
 
 #### KeptnMetricStatus
@@ -278,16 +308,18 @@ _Appears in:_
 
 KeptnMetricStatus defines the observed state of KeptnMetric
 
+
+
 _Appears in:_
 - [KeptnMetric](#keptnmetric)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `value` _string_ | Value represents the resulting value || ✓ |
-| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || ✓ |
-| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || ✓ |
-| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |
-| `intervalResults` _[IntervalResult](#intervalresult) array_ | IntervalResults contain a slice of all the interval results || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `value` _string_ | Value represents the resulting value || ✓ |  |
+| `rawValue` _integer array_ | RawValue represents the resulting value in raw format || ✓ |  |
+| `lastUpdated` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | LastUpdated represents the time when the status data was last updated || ✓ |  |
+| `errMsg` _string_ | ErrMsg represents the error details when the query could not be evaluated || ✓ |  |
+| `intervalResults` _[IntervalResult](#intervalresult) array_ | IntervalResults contain a slice of all the interval results || ✓ |  |
 
 
 #### KeptnMetricsProvider
@@ -296,16 +328,18 @@ _Appears in:_
 
 KeptnMetricsProvider is the Schema for the keptnmetricsproviders API
 
+
+
 _Appears in:_
 - [KeptnMetricsProviderList](#keptnmetricsproviderlist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnMetricsProvider` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnMetricsProviderSpec](#keptnmetricsproviderspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnMetricsProvider` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnMetricsProviderSpec](#keptnmetricsproviderspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnMetricsProviderList
@@ -316,12 +350,14 @@ KeptnMetricsProviderList contains a list of KeptnMetricsProvider resources
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | |
-| `kind` _string_ | `KeptnMetricsProviderList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnMetricsProvider](#keptnmetricsprovider) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `metrics.keptn.sh/v1beta1` | | | |
+| `kind` _string_ | `KeptnMetricsProviderList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnMetricsProvider](#keptnmetricsprovider) array_ |  || x |  |
 
 
 #### KeptnMetricsProviderSpec
@@ -330,17 +366,21 @@ KeptnMetricsProviderList contains a list of KeptnMetricsProvider resources
 
 KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
 
+
+
 _Appears in:_
 - [KeptnMetricsProvider](#keptnmetricsprovider)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `type` _string_ | Type represents the provider type. This can be one of prometheus, dynatrace, datadog, dql. || x |
-| `targetServer` _string_ | TargetServer defines URL (including port and protocol) at which the metrics provider is reachable. || x |
-| `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SecretKeyRef defines an optional secret for access credentials to the metrics provider. || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `type` _string_ | Type represents the provider type. This can be one of prometheus, dynatrace, datadog, dql. || x | Optional: {} <br />Pattern: `prometheus|dynatrace|datadog|dql` <br /> |
+| `targetServer` _string_ | TargetServer defines URL (including port and protocol) at which the metrics provider is reachable. || x |  |
+| `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SecretKeyRef defines an optional secret for access credentials to the metrics provider. || ✓ | Optional: {} <br /> |
 
 
 #### ObjectReference
+
+
 
 
 
@@ -352,10 +392,10 @@ _Appears in:_
 - [Objective](#objective)
 - [ProviderResult](#providerresult)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name defines the name of the referenced object || x |
-| `namespace` _string_ | Namespace defines the namespace of the referenced object || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name defines the name of the referenced object || x |  |
+| `namespace` _string_ | Namespace defines the namespace of the referenced object || ✓ |  |
 
 
 #### Objective
@@ -364,15 +404,17 @@ _Appears in:_
 
 Objective defines an objective for analysis
 
+
+
 _Appears in:_
 - [AnalysisDefinitionSpec](#analysisdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `analysisValueTemplateRef` _[ObjectReference](#objectreference)_ | AnalysisValueTemplateRef refers to the appropriate AnalysisValueTemplate || x |
-| `target` _[Target](#target)_ | Target defines failure or warning criteria || ✓ |
-| `weight` _integer_ | Weight can be used to emphasize the importance of one Objective over the others |1| ✓ |
-| `keyObjective` _boolean_ | KeyObjective defines whether the whole analysis fails when this objective's target is not met |false| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `analysisValueTemplateRef` _[ObjectReference](#objectreference)_ | AnalysisValueTemplateRef refers to the appropriate AnalysisValueTemplate || x |  |
+| `target` _[Target](#target)_ | Target defines failure or warning criteria || ✓ |  |
+| `weight` _integer_ | Weight can be used to emphasize the importance of one Objective over the others |1| ✓ |  |
+| `keyObjective` _boolean_ | KeyObjective defines whether the whole analysis fails when this objective's target is not met |false| ✓ |  |
 
 
 #### Operator
@@ -381,18 +423,20 @@ _Appears in:_
 
 Operator specifies the supported operators for value comparisons
 
+
+
 _Appears in:_
 - [Target](#target)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `lessThanOrEqual` _[OperatorValue](#operatorvalue)_ | LessThanOrEqual represents '<=' operator || ✓ |
-| `lessThan` _[OperatorValue](#operatorvalue)_ | LessThan represents '<' operator || ✓ |
-| `greaterThan` _[OperatorValue](#operatorvalue)_ | GreaterThan represents '>' operator || ✓ |
-| `greaterThanOrEqual` _[OperatorValue](#operatorvalue)_ | GreaterThanOrEqual represents '>=' operator || ✓ |
-| `equalTo` _[OperatorValue](#operatorvalue)_ | EqualTo represents '==' operator || ✓ |
-| `inRange` _[RangeValue](#rangevalue)_ | InRange represents operator checking the value is inclusively in the defined range, e.g. 2 <= x <= 5 || ✓ |
-| `notInRange` _[RangeValue](#rangevalue)_ | NotInRange represents operator checking the value is exclusively out of the defined range, e.g. x < 2 AND x > 5 || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `lessThanOrEqual` _[OperatorValue](#operatorvalue)_ | LessThanOrEqual represents '<=' operator || ✓ |  |
+| `lessThan` _[OperatorValue](#operatorvalue)_ | LessThan represents '<' operator || ✓ |  |
+| `greaterThan` _[OperatorValue](#operatorvalue)_ | GreaterThan represents '>' operator || ✓ |  |
+| `greaterThanOrEqual` _[OperatorValue](#operatorvalue)_ | GreaterThanOrEqual represents '>=' operator || ✓ |  |
+| `equalTo` _[OperatorValue](#operatorvalue)_ | EqualTo represents '==' operator || ✓ |  |
+| `inRange` _[RangeValue](#rangevalue)_ | InRange represents operator checking the value is inclusively in the defined range, e.g. 2 <= x <= 5 || ✓ |  |
+| `notInRange` _[RangeValue](#rangevalue)_ | NotInRange represents operator checking the value is exclusively out of the defined range, e.g. x < 2 AND x > 5 || ✓ |  |
 
 
 #### OperatorValue
@@ -401,12 +445,14 @@ _Appears in:_
 
 OperatorValue represents the value to which the result is compared
 
+
+
 _Appears in:_
 - [Operator](#operator)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `fixedValue` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | FixedValue defines the value for comparison || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `fixedValue` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | FixedValue defines the value for comparison || x |  |
 
 
 #### ProviderRef
@@ -415,12 +461,14 @@ _Appears in:_
 
 ProviderRef represents the provider object
 
+
+
 _Appears in:_
 - [KeptnMetricSpec](#keptnmetricspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `name` _string_ | Name of the provider || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `name` _string_ | Name of the provider || x |  |
 
 
 #### ProviderResult
@@ -429,15 +477,17 @@ _Appears in:_
 
 ProviderResult stores reference of already collected provider query associated to its objective template
 
+
+
 _Appears in:_
 - [AnalysisStatus](#analysisstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `objectiveReference` _[ObjectReference](#objectreference)_ | Objective store reference to corresponding objective template || ✓ |
-| `query` _string_ | Query represents the executed query || ✓ |
-| `value` _string_ | Value is the value the provider returned || ✓ |
-| `errMsg` _string_ | ErrMsg stores any possible error at retrieval time || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `objectiveReference` _[ObjectReference](#objectreference)_ | Objective store reference to corresponding objective template || ✓ |  |
+| `query` _string_ | Query represents the executed query || ✓ |  |
+| `value` _string_ | Value is the value the provider returned || ✓ |  |
+| `errMsg` _string_ | ErrMsg stores any possible error at retrieval time || ✓ |  |
 
 
 #### RangeSpec
@@ -446,16 +496,18 @@ _Appears in:_
 
 RangeSpec defines the time range for which data is to be queried
 
+
+
 _Appears in:_
 - [IntervalResult](#intervalresult)
 - [KeptnMetricSpec](#keptnmetricspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `interval` _string_ | Interval specifies the duration of the time interval for the data query |5m| ✓ |
-| `step` _string_ | Step represents the query resolution step width for the data query || ✓ |
-| `aggregation` _string_ | Aggregation defines the type of aggregation function to be applied on the data. Accepted values: p90, p95, p99, max, min, avg, median || ✓ |
-| `storedResults` _integer_ | StoredResults indicates the upper limit of how many past results should be stored in the status of a KeptnMetric || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `interval` _string_ | Interval specifies the duration of the time interval for the data query |5m| ✓ |  |
+| `step` _string_ | Step represents the query resolution step width for the data query || ✓ |  |
+| `aggregation` _string_ | Aggregation defines the type of aggregation function to be applied on the data. Accepted values: p90, p95, p99, max, min, avg, median || ✓ | Enum: [p90 p95 p99 max min avg median] <br /> |
+| `storedResults` _integer_ | StoredResults indicates the upper limit of how many past results should be stored in the status of a KeptnMetric || ✓ | Maximum: 255 <br /> |
 
 
 #### RangeValue
@@ -464,13 +516,15 @@ _Appears in:_
 
 RangeValue represents a range which the value should fit
 
+
+
 _Appears in:_
 - [Operator](#operator)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `lowBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | LowBound defines the lower bound of the range || x |
-| `highBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | HighBound defines the higher bound of the range || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `lowBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | LowBound defines the lower bound of the range || x |  |
+| `highBound` _[Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity)_ | HighBound defines the higher bound of the range || x |  |
 
 
 #### Target
@@ -479,16 +533,20 @@ _Appears in:_
 
 Target defines the failure and warning criteria
 
+
+
 _Appears in:_
 - [Objective](#objective)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `failure` _[Operator](#operator)_ | Failure defines limits up to which an analysis fails || ✓ |
-| `warning` _[Operator](#operator)_ | Warning defines limits where the result does not pass or fail || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `failure` _[Operator](#operator)_ | Failure defines limits up to which an analysis fails || ✓ |  |
+| `warning` _[Operator](#operator)_ | Warning defines limits where the result does not pass or fail || ✓ |  |
 
 
 #### Timeframe
+
+
 
 
 
@@ -498,11 +556,11 @@ _Appears in:_
 - [AnalysisSpec](#analysisspec)
 - [AnalysisStatus](#analysisstatus)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `from` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | From is the time of start for the query. This field follows RFC3339 time format || ✓ |
-| `to` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | To is the time of end for the query. This field follows RFC3339 time format || ✓ |
-| `recent` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis for the last five minutes || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `from` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | From is the time of start for the query. This field follows RFC3339 time format || ✓ |  |
+| `to` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | To is the time of end for the query. This field follows RFC3339 time format || ✓ |  |
+| `recent` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis<br />for the last five minutes || ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 
 #### TotalScore
@@ -511,12 +569,14 @@ _Appears in:_
 
 TotalScore defines the required score for an analysis to be successful
 
+
+
 _Appears in:_
 - [AnalysisDefinitionSpec](#analysisdefinitionspec)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `passPercentage` _integer_ | PassPercentage defines the threshold to reach for an analysis to pass || x |
-| `warningPercentage` _integer_ | WarningPercentage defines the threshold to reach for an analysis to pass with a 'warning' status || x |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `passPercentage` _integer_ | PassPercentage defines the threshold to reach for an analysis to pass || x | Maximum: 100 <br />Minimum: 0 <br /> |
+| `warningPercentage` _integer_ | WarningPercentage defines the threshold to reach for an analysis to pass with a 'warning' status || x | Maximum: 100 <br />Minimum: 0 <br /> |
 
 

--- a/docs/docs/reference/api-reference/options/v1alpha1/index.md
+++ b/docs/docs/reference/api-reference/options/v1alpha1/index.md
@@ -24,16 +24,18 @@ Package v1alpha1 contains API Schema definitions for the options v1alpha1 API gr
 
 KeptnConfig is the Schema for the keptnconfigs API
 
+
+
 _Appears in:_
 - [KeptnConfigList](#keptnconfiglist)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `options.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnConfig` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |
-| `spec` _[KeptnConfigSpec](#keptnconfigspec)_ |  || ✓ |
-| `status` _string_ | unused field || ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `options.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnConfig` | | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation about [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects). || ✓ |  |
+| `spec` _[KeptnConfigSpec](#keptnconfigspec)_ |  || ✓ |  |
+| `status` _string_ | unused field || ✓ |  |
 
 
 #### KeptnConfigList
@@ -44,12 +46,14 @@ KeptnConfigList contains a list of KeptnConfig
 
 
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `apiVersion` _string_ | `options.keptn.sh/v1alpha1` | | |
-| `kind` _string_ | `KeptnConfigList` | | |
-| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |
-| `items` _[KeptnConfig](#keptnconfig) array_ |  || x |
+
+
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `apiVersion` _string_ | `options.keptn.sh/v1alpha1` | | | |
+| `kind` _string_ | `KeptnConfigList` | | | |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#listmeta-v1-meta)_ |  || ✓ |  |
+| `items` _[KeptnConfig](#keptnconfig) array_ |  || x |  |
 
 
 #### KeptnConfigSpec
@@ -58,15 +62,17 @@ KeptnConfigList contains a list of KeptnConfig
 
 KeptnConfigSpec defines the desired state of KeptnConfig
 
+
+
 _Appears in:_
 - [KeptnConfig](#keptnconfig)
 
-| Field | Description | Default | Optional |
-| --- | --- | --- | --- |
-| `OTelCollectorUrl` _string_ | OTelCollectorUrl can be used to set the Open Telemetry collector that the lifecycle operator should use || ✓ |
-| `keptnAppCreationRequestTimeoutSeconds` _integer_ | KeptnAppCreationRequestTimeoutSeconds is used to set the interval in which automatic app discovery searches for workload to put into the same auto-generated KeptnApp |30| ✓ |
-| `cloudEventsEndpoint` _string_ | CloudEventsEndpoint can be used to set the endpoint where Cloud Events should be posted by the lifecycle operator || ✓ |
-| `blockDeployment` _boolean_ | BlockDeployment is used to block the deployment of the application until the pre-deployment tasks and evaluations succeed |true| ✓ |
-| `observabilityTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | ObservabilityTimeout specifies the maximum time to observe the deployment phase of KeptnWorkload. If the workload does not deploy successfully within this time frame, it will be considered as failed. |5m| ✓ |
+| Field | Description | Default | Optional |Validation |
+| --- | --- | --- | --- | --- |
+| `OTelCollectorUrl` _string_ | OTelCollectorUrl can be used to set the Open Telemetry collector that the lifecycle operator should use || ✓ |  |
+| `keptnAppCreationRequestTimeoutSeconds` _integer_ | KeptnAppCreationRequestTimeoutSeconds is used to set the interval in which automatic app discovery<br />searches for workload to put into the same auto-generated KeptnApp |30| ✓ |  |
+| `cloudEventsEndpoint` _string_ | CloudEventsEndpoint can be used to set the endpoint where Cloud Events should be posted by the lifecycle operator || ✓ |  |
+| `blockDeployment` _boolean_ | BlockDeployment is used to block the deployment of the application until the pre-deployment<br />tasks and evaluations succeed |true| ✓ |  |
+| `observabilityTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | ObservabilityTimeout specifies the maximum time to observe the deployment phase of KeptnWorkload.<br />If the workload does not deploy successfully within this time frame, it will be<br />considered as failed. |5m| ✓ | Pattern: `^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$` <br />Type: string <br /> |
 
 


### PR DESCRIPTION
# Summary

This pr adds the validation field in our autogenerated crd docs, this way it is possible to see expected values for those fields that have a validation webhook.

🛑  This pr currently uses unreleased version of crd gen tool thus it must wait for an official release before merge!

Fixes  #2292

example validation field https://keptn--3068.org.readthedocs.build/3068/docs/reference/api-reference/metrics/v1beta1/#totalscore

![image](https://github.com/keptn/lifecycle-toolkit/assets/89971034/ecb797de-aafe-488e-b422-7ffef9186379)

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [x] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
