### PR TITLE
docs: review keptntaskdefinition examples

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -406,7 +406,6 @@ moq
 mowies
 mpod
 multigroup
-multipe
 mutatingwebhookconfigurations
 mwc
 mwh

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,7 +9,6 @@ config:
     allowed_elements:
       - details
       - summary
-      - a
   github-admonition: true
   max-one-sentence-per-line: true
 

--- a/docs/docs/assets/crd/deno-context.yaml
+++ b/docs/docs/assets/crd/deno-context.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  SECURE_DATA: dG9rZW46IG15dG9rZW4=
+---
+apiVersion: lifecycle.keptn.sh/v1beta1
+kind: KeptnTaskDefinition
+metadata:
+  name: pre-deployment-hello
+  annotations: ##accessible via "KEPTN_CONTEXT"
+    my: test
+spec:
+  deno:
+    parameters: ##accessible via "DATA"
+      map:
+        user: "myuser"
+    secureParameters: ##accessible via "SECURE_DATA"
+      secret: mysecret
+    inline:
+      code: |
+        const data = Deno.env.get("DATA")!;
+        const secret = Deno.env.get("SECURE_DATA")!;
+        const context = Deno.env.get("KEPTN_CONTEXT")!;
+        console.log(data);
+        console.log(secret);
+        console.log(context);

--- a/docs/docs/assets/crd/deno-context.yaml
+++ b/docs/docs/assets/crd/deno-context.yaml
@@ -10,14 +10,14 @@ apiVersion: lifecycle.keptn.sh/v1beta1
 kind: KeptnTaskDefinition
 metadata:
   name: pre-deployment-hello
-  annotations: ##accessible via "KEPTN_CONTEXT"
+  annotations: ## accessible via "KEPTN_CONTEXT"
     my: test
 spec:
   deno:
-    parameters: ##accessible via "DATA"
+    parameters: ## accessible via "DATA"
       map:
         user: "myuser"
-    secureParameters: ##accessible via "SECURE_DATA"
+    secureParameters: ## accessible via "SECURE_DATA"
       secret: mysecret
     inline:
       code: |

--- a/docs/docs/assets/crd/examples/configmap-for-deno-script.yaml
+++ b/docs/docs/assets/crd/examples/configmap-for-deno-script.yaml
@@ -3,7 +3,7 @@ kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment
 spec:
-  function:
+  deno:
     configMapRef:
       name: scheduled-deployment-cm-1
 ---

--- a/docs/docs/assets/crd/examples/configmapref-for-deno-script.yaml
+++ b/docs/docs/assets/crd/examples/configmapref-for-deno-script.yaml
@@ -1,8 +1,0 @@
-apiVersion: lifecycle.keptn.sh/v1beta1
-kind: KeptnTaskDefinition
-metadata:
-  name: keptntaskdefinition-sample
-spec:
-  deno:
-    configMapRef:
-      name: dev-configmap

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -243,7 +243,7 @@ your workloads and tasks in a `KeptnApp` (for instance a commit ID value).
 To do so, the metadata needs to be specified for the workload or for the application.
 Follow our guide on [Context and Metadata here](./metadata.md).
 
-<!-- markdownlint-disable MD046 MD013-->
+<!-- markdownlint-disable MD046 max-one-sentence-per-line-->
 
 !!! note
 
@@ -251,7 +251,7 @@ Follow our guide on [Context and Metadata here](./metadata.md).
     [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-deno-task)
     and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-python-task).
 
-<!-- markdownlint-enable MD046 MD013-->
+<!-- markdownlint-enable MD046 max-one-sentence-per-line-->
 
 
 ## Parameterized functions

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -244,6 +244,7 @@ To do so, the metadata needs to be specified for the workload or for the applica
 Follow our guide on [Context and Metadata here](./metadata.md).
 
 !!! note 
+
     For an example of how to access the `KEPTN_CONTEXT`, follow our reference page examples 
     [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-deno-task)
     and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-python-task).

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -244,10 +244,9 @@ To do so, the metadata needs to be specified for the workload or for the applica
 Follow our guide on [Context and Metadata here](./metadata.md).
 
 !!! note 
-  For an example of how to access the `KEPTN_CONTEXT`, follow our
-  reference page examples 
-  [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn-context-in-a-deno-task)
-  and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn-context-in-a-python-task).
+    For an example of how to access the `KEPTN_CONTEXT`, follow our reference page examples 
+    [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-deno-task)
+    and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-python-task).
 
 ## Parameterized functions
 

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -243,9 +243,9 @@ your workloads and tasks in a `KeptnApp` (for instance a commit ID value).
 To do so, the metadata needs to be specified for the workload or for the application.
 Follow our guide on [Context and Metadata here](./metadata.md).
 
-!!! note 
+!!! note
 
-    For an example of how to access the `KEPTN_CONTEXT`, follow our reference page examples 
+    For an example of how to access the `KEPTN_CONTEXT`, follow our reference page examples
     [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-deno-task)
     and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-python-task).
 

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -244,7 +244,7 @@ To do so, the metadata needs to be specified for the workload or for the applica
 Follow our guide on [Context and Metadata here](./metadata.md).
 
 For an example of how to access the `KEPTN_CONTEXT`, follow our
-[reference page](../reference/crd-reference/taskdefinition.md#example-6-accessing-keptn_context-environment-variable-in-a-deno-task)
+[reference page](../reference/crd-reference/taskdefinition.md#example-for-accessing-keptn_context-environment-variable)
 
 ## Parameterized functions
 

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -253,7 +253,6 @@ Follow our guide on [Context and Metadata here](./metadata.md).
 
 <!-- markdownlint-enable MD046 max-one-sentence-per-line-->
 
-
 ## Parameterized functions
 
 `KeptnTaskDefinition`s can use input parameters.

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -243,11 +243,16 @@ your workloads and tasks in a `KeptnApp` (for instance a commit ID value).
 To do so, the metadata needs to be specified for the workload or for the application.
 Follow our guide on [Context and Metadata here](./metadata.md).
 
+<!-- markdownlint-disable MD046 MD013-->
+
 !!! note
 
     For an example of how to access the `KEPTN_CONTEXT`, follow our reference page examples
     [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-deno-task)
     and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn_context-in-a-python-task).
+
+<!-- markdownlint-enable MD046 MD013-->
+
 
 ## Parameterized functions
 

--- a/docs/docs/guides/tasks.md
+++ b/docs/docs/guides/tasks.md
@@ -243,8 +243,11 @@ your workloads and tasks in a `KeptnApp` (for instance a commit ID value).
 To do so, the metadata needs to be specified for the workload or for the application.
 Follow our guide on [Context and Metadata here](./metadata.md).
 
-For an example of how to access the `KEPTN_CONTEXT`, follow our
-[reference page](../reference/crd-reference/taskdefinition.md#example-for-accessing-keptn_context-environment-variable)
+!!! note 
+  For an example of how to access the `KEPTN_CONTEXT`, follow our
+  reference page examples 
+  [for deno](../reference/crd-reference/taskdefinition.md#accessing-keptn-context-in-a-deno-task)
+  and [for python](../reference/crd-reference/taskdefinition.md#accessing-keptn-context-in-a-python-task).
 
 ## Parameterized functions
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -271,9 +271,9 @@ and Keptn sets up the container and runs the script as part of the task.
               as a JSON object.
               See [Parameterized functions](../../guides/tasks.md#parameterized-functions)
               for more information.
-              Also see examples for [deno](./#deno)
+              Also see examples for [deno](./#env-var-in-deno)
               and
-              [python](./#python).
+              [python](./#env-var-in-python).
 
             - **secureParameters** -- An optional field
               used to pass a Kubernetes secret.
@@ -287,7 +287,7 @@ and Keptn sets up the container and runs the script as part of the task.
               See [Create secret text](../../guides/tasks.md#create-secret-text)
               for details.
               Also see examples on secret usage in tasks runner
-              for [deno](./#deno) and [python](./#python).
+              for [deno](./#env-var-in-deno) and [python](./#env-var-in-python).
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -477,7 +477,7 @@ file.
     The following example shows how to pass data inside the parameter map,
     and how to load a secret in your code.
     The deno command does not takes modifiers so filling the `cmdParameters`
-    will do nothig.
+    will do nothing.
 
     ```yaml
     {% include "../../assets/crd/deno-context.yaml" %}

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -171,7 +171,7 @@ and Keptn sets up the container and runs the script as part of the task.
         In this case you may want to use a custom container instead. 
 
         ```yaml
-        { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
+        {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
         ```
 
     === "python-runtime"
@@ -367,6 +367,7 @@ file.
         ```
 
 ???+ note "Examples for httpRef script"
+    
     === "Example 2: httpRef script for a Deno script"
     
         This example fetches the Deno script from a remote webserver at runtime:
@@ -414,52 +415,52 @@ file.
 
 ???+ note "Examples for ConfigMap and ConfigMapRef"
 
-=== "Example 4: ConfigMapRef for a Deno script"
-
-    This example references a `ConfigMap` by the name of `dev-configmap`
-    that contains the code for the function to be executed.
-
-    ```yaml
-    {% include "../../assets/crd/examples/configmap-for-deno-script.yaml" %} 
-    ```
-
-=== "Example 4: ConfigMapRef for a python-runtime runner"
-
-    In this example the python runner refers to an existing configMap 
-    called `python-test-cm`
-
-    ```yaml
-    {% include "../../assets/crd/python-configmap.yaml" %}
-    ```
+    === "Example 4: ConfigMapRef for a Deno script"
+    
+        This example references a `ConfigMap` by the name of `dev-configmap`
+        that contains the code for the function to be executed.
+    
+        ```yaml
+        {% include "../../assets/crd/examples/configmap-for-deno-script.yaml" %} 
+        ```
+    
+    === "Example 4: ConfigMapRef for a python-runtime runner"
+    
+        In this example the python runner refers to an existing configMap 
+        called `python-test-cm`
+    
+        ```yaml
+        {% include "../../assets/crd/python-configmap.yaml" %}
+        ```
 
 ???+ note "Example for Accessing KEPTN_CONTEXT environment variable"
 
-=== "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
-
-    For Tasks triggered as pre- and post- deployment of applications
-    on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
-    As all environment variables, this can be accessed using language specific methods.
-    An example in Deno would be the following:
-
-    ```javascript
-    let context = Deno.env.get("KEPTN_CONTEXT");
-    ```
-
-=== "Example 5: Accessing KEPTN_CONTEXT environment variable in a Python task"
-
-    For Tasks triggered as pre- and post- deployment of applications
-    on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
-    As all environment variables, this can be accessed using language specific methods.
-    An example in Python would be the following:
-
-    ```python
-    import os
-    import yaml
-    data = os.getenv('KEPTN_CONTEXT')
-    dct = yaml.safe_load(data)
-    meta= dct['metadata']
-    print(meta)
-    ```
+    === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
+    
+        For Tasks triggered as pre- and post- deployment of applications
+        on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
+        As all environment variables, this can be accessed using language specific methods.
+        An example in Deno would be the following:
+    
+        ```javascript
+        let context = Deno.env.get("KEPTN_CONTEXT");
+        ```
+    
+    === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Python task"
+    
+        For Tasks triggered as pre- and post- deployment of applications
+        on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
+        As all environment variables, this can be accessed using language specific methods.
+        An example in Python would be the following:
+    
+        ```python
+        import os
+        import yaml
+        data = os.getenv('KEPTN_CONTEXT')
+        dct = yaml.safe_load(data)
+        meta= dct['metadata']
+        print(meta)
+        ```
 
 <!-- markdownlint-enable MD046 -->
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -271,7 +271,7 @@ and Keptn sets up the container and runs the script as part of the task.
                 per `KeptnTaskDefinition` resource.
 
                 See [Create secret text](../../guides/tasks.md#create-secret-text)
-                for details. 
+                for details.
                 Examples on secret usage in tasks runner are [here](#passing-secrets-environment-variables-and-modifying-the-python-command)
 
 ## Usage

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -216,7 +216,7 @@ and Keptn sets up the container and runs the script as part of the task.
                         should be handled by the pipeline engine tools being used
                         such as Jenkins, Argo Workflows, Flux, and Tekton.
                         See examples of usage for [deno](./#inline-script-for-deno)
-                        and for [python](./#inline-script-for-python)
+                        and for [python](./#inline-script-for-python).
 
                 - **httpRef** - Specify a script to be executed at runtime
                         from the remote webserver that is specified.
@@ -229,7 +229,7 @@ and Keptn sets up the container and runs the script as part of the task.
                         Only one script can be executed.
                         Any other scripts listed here are silently ignored.
                         See examples of usage for [deno](./#httpref-for-deno)
-                        and for [python](./#httpref-for-python)
+                        and for [python](./#httpref-for-python).
 
                 - **functionRef** -- Execute another `KeptnTaskDefinition` resources.
                     Populate this field with the value(s) of the `metadata.name` field
@@ -252,13 +252,13 @@ and Keptn sets up the container and runs the script as part of the task.
                     Any calls to additional `KeptnTaskDefinition` resources
                     are silently ignored.
                     See examples of usage for [deno](./#functionref-for-deno)
-                    and [python](./#functionref-for-python)
+                    and [python](./#functionref-for-python).
 
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
                   See examples of usage for [deno](./#configmapref-for-deno)
-                  and for [python](./#configmapref-for-python)
+                  and for [python](./#configmapref-for-python).
 
             - **parameters** - An optional field
               to supply input parameters to a function.

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -142,7 +142,6 @@ almost anything that you implemented with JES for Keptn v1.
           [Container](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container)
           spec documentation.
 
-<!-- markdownlint-disable MD046 -->
 ## Synopsis for predefined containers
 
 The predefined containers allow you to easily define a task
@@ -181,7 +180,6 @@ and Keptn sets up the container and runs the script as part of the task.
     ```yaml
     {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
     ```
-<!-- markdownlint-enable MD046 -->
 
 ### Fields for predefined containers
 
@@ -229,9 +227,9 @@ and Keptn sets up the container and runs the script as part of the task.
                     possibly with different parameters
                     that are set in the calling `KeptnTaskDefinition` resource.
 
-                    To be able to run the pre/post-deployment task, you must create
+                    To be able to run the pre-/post-deployment task, you must create
                     the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
-                    in the pre/post-deployment section of `KeptnAppContext`.
+                    in the pre-/post-deployment section of `KeptnAppContext`.
 
                     The `KeptnTaskDefinition` called with `functionref`
                     is the `parent task` whose runner is used for the execution
@@ -335,7 +333,6 @@ This task is then referenced in the
 [appcontext.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-2/appcontext.yaml)
 file.
 
-<!-- markdownlint-disable MD046 -->
 ## Examples for deno-runtime and python-runtime runners
 
 ### Examples for inline script
@@ -451,8 +448,6 @@ file.
     meta= dct['metadata']
     print(meta)
     ```
-
-<!-- markdownlint-enable MD046 -->
 
 ### Allowed libraries for the python-runtime runner
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -31,7 +31,7 @@ differentiated by the `spec` section:
   See
   [Synopsis for container-runtime](#synopsis-for-container-runtime)
   and
-  [a container-runtime runner](#examples-for-a-container-runtime-runner).
+  [a container-runtime runner](#example-for-a-container-runtime-runner).
 
 - Pre-defined containers
 
@@ -43,10 +43,11 @@ differentiated by the `spec` section:
       with a few limitations.
       You can use this to specify simple actions
       without having to define a full container.
+      See [runtime examples](./#deno-runtime-synopsis)
     - Use the pre-defined `python-runtime` runner
       to define your task using
       [Python 3](https://www.python.org/).
-      See [runtime examples](#examples-for-deno-runtime-and-python-runtime-runners)
+      See [runtime examples](./#python-runtime-synopsis)
       for practical usage of the pre-defined containers.
 
 ## Synopsis for all runners
@@ -83,7 +84,7 @@ These are described here.
           and code the functionality in Deno script,
           which is similar to JavaScript and Typescript.
           See
-          [Synopsis for predefined-containers](#synopsis-for-predefined-containers).
+          [Synopsis for predefined-containers](#).
         - **python** -- Use a `python-runtime` function
           and code the functionality in Python 3.
           See
@@ -154,7 +155,7 @@ and Keptn sets up the container and runs the script as part of the task.
 
 !!! note "Synopsis"
 
-    === "deno-runtime"
+    === "Deno-runtime synopsis"
     
         When using the `deno-runtime` runner to define a task,
         the executables are coded in
@@ -174,7 +175,7 @@ and Keptn sets up the container and runs the script as part of the task.
         {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
         ```
 
-    === "python-runtime"
+    === "Python-runtime synopsis"
         
         When using the `python-runtime` runner to define a task,
         the executables are coded in python3.
@@ -332,7 +333,7 @@ See
 [Executing sequential tasks](../../guides/tasks.md#executing-sequential-tasks)
 for more information.
 
-## a container-runtime runner
+## Example for a container-runtime runner
 
 For an example of a `KeptnTaskDefinition` that defines a custom container.
 see
@@ -348,7 +349,7 @@ This task is then referenced in the
 [appcontext.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-2/appcontext.yaml)
 file.
 
-## deno-runtime and python-runtime runners
+## Examples for deno-runtime and python-runtime runners
 
 <!-- markdownlint-disable MD046 -->
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -352,7 +352,7 @@ file.
 
 ## Examples for deno-runtime and python-runtime runners
 
-<!-- markdownlint-disable MD046 MD013 -->
+<!-- markdownlint-disable MD046 max-one-sentence-per-line -->
 
 ??? example "Inline scripts"
 
@@ -487,7 +487,7 @@ file.
     {% include "../../assets/crd/python-context.yaml" %}
     ```
 
-<!-- markdownlint-enable MD046 MD013-->
+<!-- markdownlint-enable MD046 max-one-sentence-per-line-->
 
 ## More examples
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -439,13 +439,12 @@ file.
         ```
 
 ??? example "Accessing KEPTN_CONTEXT environment variable"
+    
+    For Tasks triggered as pre- and post- deployment of applications
+    on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
+    As all environment variables, this can be accessed using language specific methods.
 
     === "Accessing KEPTN_CONTEXT in a Deno task"
-    
-        For Tasks triggered as pre- and post- deployment of applications
-        on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
-        As all environment variables, this can be accessed using language specific methods.
-        An example in Deno would be the following:
     
         ```javascript
         let context = Deno.env.get("KEPTN_CONTEXT");
@@ -453,11 +452,6 @@ file.
         ```
     
     === "Accessing KEPTN_CONTEXT in a Python task"
-    
-        For Tasks triggered as pre- and post- deployment of applications
-        on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
-        As all environment variables, this can be accessed using language specific methods.
-        An example in Python would be the following:
     
         ```python
         import os

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -165,6 +165,7 @@ and Keptn sets up the container and runs the script as part of the task.
     for permissions and importing data
     so a script that works properly elsewhere
     may not function out of the box when run in the `deno-runtime` runner.
+    In this case you may want to use a custom container instead.
 
 ```yaml
 {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
@@ -176,7 +177,8 @@ and Keptn sets up the container and runs the script as part of the task.
     the executables are coded in python3.
     The runner enables the following packages: requests, json, git, yaml.
     Note that other libraries may not function out of the box 
-    in the `python-runtime` runner.
+    in the `python-runtime` runner. 
+    In this case you may want to use a custom container instead.
 
     ```yaml
     {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -150,21 +150,21 @@ You do not need to specify the image, volumes, and so forth.
 Instead, just provide either a Deno or Python script
 and Keptn sets up the container and runs the script as part of the task.
 
-
+<!-- markdownlint-disable -->
 === "deno-runtime"
-
-When using the `deno-runtime` runner to define a task,
-the executables are coded in
-[Deno-script](https://deno.com/manual),
-(which is mostly the same as JavaScript and TypeScript)
-and executed in the
-`deno-runtime` runner,
-which is a lightweight runtime environment
-that executes in your namespace.
-Note that Deno has tighter restrictions
-for permissions and importing data
-so a script that works properly elsewhere
-may not function out of the box when run in the `deno-runtime` runner.
+    
+    When using the `deno-runtime` runner to define a task,
+    the executables are coded in
+    [Deno-script](https://deno.com/manual),
+    (which is mostly the same as JavaScript and TypeScript)
+    and executed in the
+    `deno-runtime` runner,
+    which is a lightweight runtime environment
+    that executes in your namespace.
+    Note that Deno has tighter restrictions
+    for permissions and importing data
+    so a script that works properly elsewhere
+    may not function out of the box when run in the `deno-runtime` runner.
 
 ```yaml
 {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
@@ -181,6 +181,7 @@ may not function out of the box when run in the `deno-runtime` runner.
     ```yaml
     {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
     ```
+<!-- markdownlint-enable -->
 
 ### Fields for predefined containers
 
@@ -338,6 +339,7 @@ file.
 
 ### Examples for inline script
 
+<!-- markdownlint-disable -->
 === "Example 1: inline script for a Deno script"
 
     This example defines a full-fledged Deno script
@@ -449,6 +451,7 @@ file.
     meta= dct['metadata']
     print(meta)
     ```
+<!-- markdownlint-enable -->
 
 ### Allowed libraries for the python-runtime runner
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -375,10 +375,10 @@ file.
         ```yaml
         {% include "../../assets/crd/examples/httpref-script-for-deno-script.yaml" %}
         ```
-    
-        For other example, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
-        and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
-        PodtatoHead example for a more complete example.
+        !!! note  
+            For other example, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
+            and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
+            PodtatoHead example for a more complete example.
     
     === "Example 2: httpRef for a python-runtime runner"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -84,11 +84,11 @@ These are described here.
           and code the functionality in Deno script,
           which is similar to JavaScript and Typescript.
           See
-          [Synopsis for predefined-containers](./#deno-runtime-synopsis).
+          [Synopsis for deno](./#deno-runtime-synopsis).
         - **python** -- Use a `python-runtime` function
           and code the functionality in Python 3.
           See
-          [Synopsis for predefined-containers](./#python-runtime-synopsis).
+          [Synopsis for python](./#python-runtime-synopsis).
         - **container** -- Use the runner defined
           for the `container-runtime` container.
           This is a standard Kubernetes container

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -354,7 +354,7 @@ file.
 
 ### Examples for inline script
 
-??? note ""
+??? example
 
     === "Example 1: inline script for a Deno script"
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -174,7 +174,7 @@ and Keptn sets up the container and runs the script as part of the task.
     ```
 
 === "Python-runtime synopsis"
-    
+
     When using the `python-runtime` runner to define a task,
     the executables are coded in python3.
     The runner enables the following packages: requests, json, git, yaml.
@@ -225,30 +225,26 @@ and Keptn sets up the container and runs the script as part of the task.
                         possibly with different parameters
                         that are provided in the calling `KeptnTaskDefinition` resource.
                         Another `KeptnTaskDefinition` resource could call this same script
-                        but with different parameters. 
+                        but with different parameters.
                         Only one script can be executed.
                         Any other scripts listed here are silently ignored.
-                        See examples of usage for [deno](#httpref-for-deno)
-                        and for [python](#httpref-for-python)
+                        See examples of usage for [deno](./#httpref-for-deno)
+                        and for [python](./#httpref-for-python)
 
                 - **functionRef** -- Execute another `KeptnTaskDefinition` resources.
                     Populate this field with the value(s) of the `metadata.name` field
                     for each `KeptnDefinitionTask` to be called.
-
                     Like the `httpRef` syntax,this is commonly used
                     to call a general function that is used in multiple places,
                     possibly with different parameters
                     that are set in the calling `KeptnTaskDefinition` resource.
-
                     To be able to run the pre-/post-deployment task, you must create
                     the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
                     in the pre-/post-deployment section of `KeptnAppContext`.
-
                     The `KeptnTaskDefinition` called with `functionref`
                     is the `parent task` whose runner is used for the execution
                     even if it is not the same runner defined in the
                     calling `KeptnTaskDefinition`.
-
                     Only one `KeptnTaskDefinition` resources can be listed
                     with the `functionRef` syntax
                     although that `KeptnTaskDefinition` can call multiple
@@ -263,7 +259,7 @@ and Keptn sets up the container and runs the script as part of the task.
                   resource that contains the function to be executed.
                   See examples of usage for [deno](./#configmapref-for-deno)
                   and for [python](./#configmapref-for-python)
-                  
+
             - **parameters** - An optional field
               to supply input parameters to a function.
               Keptn passes the values defined inside the `map` field
@@ -438,7 +434,7 @@ file.
         ```
 
 ??? example "Accessing KEPTN_CONTEXT environment variable"
-    
+
     For Tasks triggered as pre- and post- deployment of applications
     on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
     As all environment variables, this can be accessed using language specific methods.

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -379,10 +379,10 @@ file.
         ```yaml
         {% include "../../assets/crd/examples/httpref-script-for-deno-script.yaml" %}
         ```
-        !!! note  
-            For other example, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
-            and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
-            PodtatoHead example for a more complete example.
+          
+        For other example, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
+        and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
+        PodtatoHead example for a more complete example.
     
     === "Example 2: httpRef for a python-runtime runner"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -153,7 +153,7 @@ and Keptn sets up the container and runs the script as part of the task.
 <!-- markdownlint-disable MD046 -->
 
 ???+ note "Synopsis"
-    
+
     === "deno-runtime"
     
         When using the `deno-runtime` runner to define a task,
@@ -169,6 +169,7 @@ and Keptn sets up the container and runs the script as part of the task.
         so a script that works properly elsewhere
         may not function out of the box when run in the `deno-runtime` runner.
         In this case you may want to use a custom container instead. 
+
         ```yaml
         { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
         ```
@@ -343,76 +344,75 @@ file.
 
 ## Examples for deno-runtime and python-runtime runners
 
-### Examples for inline script
-
 <!-- markdownlint-disable MD046 -->
 
-=== "Example 1: inline script for a Deno script"
+???+ note "Examples for inline script"
 
-    This example defines a full-fledged Deno script
-    within the `KeptnTaskDefinition` YAML file:
+    === "Example 1: inline script for a Deno script"
 
-    ```yaml
-    {% include "../../assets/crd/examples/inline-script-for-deno-script.yaml" %} 
-    ```
+        This example defines a full-fledged Deno script
+        within the `KeptnTaskDefinition` YAML file:
+    
+        ```yaml
+        {% include "../../assets/crd/examples/inline-script-for-deno-script.yaml" %} 
+        ```
 
-=== "Example 1: inline code for a python-runtime runner"
+    === "Example 1: inline code for a python-runtime runner"
+    
+        You can embed python code directly in the task definition.
+        This example prints data stored in the parameters map:
+    
+        ```yaml
+        {% include "../../assets/crd/python-inline.yaml" %}
+        ```
 
-    You can embed python code directly in the task definition.
-    This example prints data stored in the parameters map:
+???+ note "Examples for httpRef script"
+    === "Example 2: httpRef script for a Deno script"
+    
+        This example fetches the Deno script from a remote webserver at runtime:
+    
+        ```yaml
+        {% include "../../assets/crd/examples/httpref-script-for-deno-script.yaml" %}
+        ```
+    
+        For another example, see the
+        [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
+    
+        See the
+        [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
+        PodtatoHead example for a more complete example.
+    
+    === "Example 2: httpRef for a python-runtime runner"
+    
+         ```yaml
+        {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
+        ```
 
-    ```yaml
-    {% include "../../assets/crd/python-inline.yaml" %}
-    ```
+???+ note "Examples for functionRef"
 
-### Examples for httpRef script
+    === "Example 3: functionRef for a Deno script"
+    
+        This example calls another defined task,
+        illustrating how one `KeptnTaskDefinition` can build
+        on top of other `KeptnTaskDefinition`s.
+        In this case, it calls `slack-notification-dev`,
+        passing `parameters` and `secureParameters` to that other task:
+    
+        ```yaml
+        {% include "../../assets/crd/examples/functionref-for-deno-script.yaml" %} 
+        ```
 
-=== "Example 2: httpRef script for a Deno script"
+    === "Example 3: functionRef for a python-runtime runner"
+    
+        You can refer to an existing `KeptnTaskDefinition`.
+        this example calls the inline example
+        but overrides the data printed with what is specified in the task:
+    
+        ```yaml
+        {% include "../../assets/crd/python-recursive.yaml" %}
+        ```
 
-    This example fetches the Deno script from a remote webserver at runtime:
-
-    ```yaml
-    {% include "../../assets/crd/examples/httpref-script-for-deno-script.yaml" %}
-    ```
-
-    For another example, see the
-    [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
-
-    See the
-    [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
-    PodtatoHead example for a more complete example.
-
-=== "Example 2: httpRef for a python-runtime runner"
-
-     ```yaml
-    {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
-    ```
-
-### Examples for functionRef
-
-=== "Example 3: functionRef for a Deno script"
-
-    This example calls another defined task,
-    illustrating how one `KeptnTaskDefinition` can build
-    on top of other `KeptnTaskDefinition`s.
-    In this case, it calls `slack-notification-dev`,
-    passing `parameters` and `secureParameters` to that other task:
-
-    ```yaml
-    {% include "../../assets/crd/examples/functionref-for-deno-script.yaml" %} 
-    ```
-
-=== "Example 3: functionRef for a python-runtime runner"
-
-    You can refer to an existing `KeptnTaskDefinition`.
-    this example calls the inline example
-    but overrides the data printed with what is specified in the task:
-
-    ```yaml
-    {% include "../../assets/crd/python-recursive.yaml" %}
-    ```
-
-### Examples for ConfigMap and ConfigMapRef
+???+ note "Examples for ConfigMap and ConfigMapRef"
 
 === "Example 4: ConfigMapRef for a Deno script"
 
@@ -432,7 +432,7 @@ file.
     {% include "../../assets/crd/python-configmap.yaml" %}
     ```
 
-### Example for Accessing KEPTN_CONTEXT environment variable
+???+ note "Example for Accessing KEPTN_CONTEXT environment variable"
 
 === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -349,7 +349,7 @@ file.
 
 <!-- markdownlint-disable MD046 max-one-sentence-per-line -->
 
-??? example "Inline scripts"
+??? abstract "Inline scripts"
 
     === "Inline script for deno"
 
@@ -369,7 +369,7 @@ file.
         {% include "../../assets/crd/python-inline.yaml" %}
         ```
 
-??? example "HttpRef"
+??? abstract "HttpRef"
 
     === "httpRef for deno"
     
@@ -389,7 +389,7 @@ file.
         {% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
         ```
 
-??? example "FunctionRef"
+??? abstract "FunctionRef"
 
     === "functionRef for deno"
     
@@ -413,7 +413,7 @@ file.
         {% include "../../assets/crd/python-recursive.yaml" %}
         ```
 
-??? example "ConfigMap and ConfigMapRef"
+??? abstract "ConfigMap and ConfigMapRef"
 
     === "ConfigMapRef for deno"
     
@@ -433,7 +433,7 @@ file.
         {% include "../../assets/crd/python-configmap.yaml" %}
         ```
 
-??? example "Accessing KEPTN_CONTEXT environment variable"
+??? abstract "Accessing KEPTN_CONTEXT environment variable"
 
     For Tasks triggered as pre- and post- deployment of applications
     on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
@@ -457,7 +457,7 @@ file.
         print(meta)
         ```
 
-??? example "Passing secrets, environment variables and modifying the runner command"
+??? abstract "Passing secrets, environment variables and modifying the runner command"
 
     === "Env var in deno"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -253,7 +253,6 @@ and Keptn sets up the container and runs the script as part of the task.
                     are silently ignored.
                     See examples of usage for [deno](./#functionref-for-deno)
                     and [python](./#functionref-for-python).
-
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -218,7 +218,7 @@ and Keptn sets up the container and runs the script as part of the task.
                         See examples of usage for [deno](./#inline-script-for-deno)
                         and for [python](./#inline-script-for-python)
 
-                  - **httpRef** - Specify a script to be executed at runtime
+                - **httpRef** - Specify a script to be executed at runtime
                         from the remote webserver that is specified.
                         This syntax allows you to call a general function
                         that is used in multiple places,

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -454,7 +454,7 @@ file.
     that contains the code for the function to be executed.
 
     ```yaml
-    {% include "../../assets/crd/examples/configmapref-for-deno-script.yaml" %} 
+    {% include "../../assets/crd/examples/configmap-for-deno-script.yaml" %} 
     ```
 
 === "Example 4: ConfigMapRef for a python-runtime runner"

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -352,7 +352,7 @@ file.
 
 ## Examples for deno-runtime and python-runtime runners
 
-<!-- markdownlint-disable MD046 -->
+<!-- markdownlint-disable MD046 MD013 -->
 
 ??? example "Inline scripts"
 
@@ -493,7 +493,7 @@ file.
     {% include "../../assets/crd/python-context.yaml" %}
     ```
 
-<!-- markdownlint-enable MD046 -->
+<!-- markdownlint-enable MD046 MD013-->
 
 ## More examples
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -346,7 +346,9 @@ file.
 
 <!-- markdownlint-disable MD046 -->
 
-???+ note "Examples for inline script"
+### Examples for inline script
+
+???+ note ""
 
     === "Example 1: inline script for a Deno script"
 
@@ -366,7 +368,9 @@ file.
         {% include "../../assets/crd/python-inline.yaml" %}
         ```
 
-???+ note "Examples for httpRef script"
+### Examples for httpRef script
+
+???+ note ""
     
     === "Example 2: httpRef script for a Deno script"
     
@@ -385,8 +389,9 @@ file.
         ```yaml
         {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
         ```
+### Examples for functionRef
 
-???+ note "Examples for functionRef"
+???+ note ""
 
     === "Example 3: functionRef for a Deno script"
     
@@ -409,8 +414,9 @@ file.
         ```yaml
         {% include "../../assets/crd/python-recursive.yaml" %}
         ```
+### Examples for ConfigMap and ConfigMapRef
 
-???+ note "Examples for ConfigMap and ConfigMapRef"
+???+ note ""
 
     === "Example 4: ConfigMapRef for a Deno script"
     
@@ -430,7 +436,9 @@ file.
         {% include "../../assets/crd/python-configmap.yaml" %}
         ```
 
-???+ note "Example for Accessing KEPTN_CONTEXT environment variable"
+### Example for Accessing KEPTN_CONTEXT environment variable
+
+???+ note ""
 
     === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -43,17 +43,11 @@ differentiated by the `spec` section:
       with a few limitations.
       You can use this to specify simple actions
       without having to define a full container.
-      See
-      <a href="#deno-runtime">Synopsis for Deno-runtime container</a>
-      and
-      [Deno-runtime examples](#examples-for-deno-runtime-and-python-runtime-runners).
     - Use the pre-defined `python-runtime` runner
       to define your task using
       [Python 3](https://www.python.org/).
-      See
-      <a href="#python-runtime">Synopsis for python-runtime runner</a>
-      and
-      [Examples for a python-runtime runner](#examples-for-deno-runtime-and-python-runtime-runners).
+    See [runtime examples](#examples-for-deno-runtime-and-python-runtime-runners)
+    for practical usage of the pre-defined containers.
 
 ## Synopsis for all runners
 
@@ -89,11 +83,11 @@ These are described here.
           and code the functionality in Deno script,
           which is similar to JavaScript and Typescript.
           See
-          <a href="#deno-runtime">Synopsis for deno-runtime container</a>
+          [Synopsis for predefined-containers](#synopsis-for-predefined-containers).
         - **python** -- Use a `python-runtime` function
           and code the functionality in Python 3.
           See
-          <a href="#python-runtime">Synopsis for python-runtime runner</a>
+          [Synopsis for predefined-containers](#synopsis-for-predefined-containers).
         - **container** -- Use the runner defined
           for the `container-runtime` container.
           This is a standard Kubernetes container

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -354,7 +354,7 @@ file.
 
 ### Examples for inline script
 
-!!! note ""
+??? note ""
 
     === "Example 1: inline script for a Deno script"
 
@@ -476,31 +476,31 @@ file.
         print(meta)
         ```
 
-    ### Passing secrets, environment variables and modifying the runner command
-    !!! note ""
-    
-        === "deno"
-        
-        The following example shows how to pass data inside the parameter map,
-        and how to load a secret in your code.
-        The deno command does not takes modifiers so filling the `cmdParameters`
-        will do nothig.
+### Passing secrets, environment variables and modifying the runner command
+!!! note ""
 
-        ```yaml
-        {% include "../../assets/crd/deno-context.yaml" %}
-        ```
-
-        === "python"
-        
-        The following example shows how to pass data inside the parameter map,
-        how to load a secret in your code,
-        and how to modify the python command.
-        In this case the container runs with the `-h` option,
-        which prints the help message for the python3 interpreter:
+    === "deno"
     
-        ```yaml
-        {% include "../../assets/crd/python-context.yaml" %}
-        ```
+    The following example shows how to pass data inside the parameter map,
+    and how to load a secret in your code.
+    The deno command does not takes modifiers so filling the `cmdParameters`
+    will do nothig.
+
+    ```yaml
+    {% include "../../assets/crd/deno-context.yaml" %}
+    ```
+
+    === "python"
+    
+    The following example shows how to pass data inside the parameter map,
+    how to load a secret in your code,
+    and how to modify the python command.
+    In this case the container runs with the `-h` option,
+    which prints the help message for the python3 interpreter:
+
+    ```yaml
+    {% include "../../assets/crd/python-context.yaml" %}
+    ```
 
 <!-- markdownlint-enable MD046 -->
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -31,7 +31,7 @@ differentiated by the `spec` section:
   See
   [Synopsis for container-runtime](#synopsis-for-container-runtime)
   and
-  [Examples for a container-runtime runner](#examples-for-a-container-runtime-runner).
+  [a container-runtime runner](#examples-for-a-container-runtime-runner).
 
 - Pre-defined containers
 
@@ -332,7 +332,7 @@ See
 [Executing sequential tasks](../../guides/tasks.md#executing-sequential-tasks)
 for more information.
 
-## Examples for a container-runtime runner
+## a container-runtime runner
 
 For an example of a `KeptnTaskDefinition` that defines a custom container.
 see
@@ -348,11 +348,11 @@ This task is then referenced in the
 [appcontext.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/examples/sample-app/version-2/appcontext.yaml)
 file.
 
-## Examples for deno-runtime and python-runtime runners
+## deno-runtime and python-runtime runners
 
 <!-- markdownlint-disable MD046 -->
 
-### Examples for inline script
+### Inline script
 
 ??? example
 
@@ -374,9 +374,9 @@ file.
         {% include "../../assets/crd/python-inline.yaml" %}
         ```
 
-### Examples for httpRef script
+### HttpRef
 
-!!! note ""
+??? example
 
     === "Example 2: httpRef script for a Deno script"
     
@@ -396,9 +396,9 @@ file.
         {% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
         ```
 
-### Examples for functionRef
+### FunctionRef
 
-!!! note ""
+??? example
 
     === "Example 3: functionRef for a Deno script"
     
@@ -422,9 +422,9 @@ file.
         {% include "../../assets/crd/python-recursive.yaml" %}
         ```
 
-### Examples for ConfigMap and ConfigMapRef
+### ConfigMap and ConfigMapRef
 
-!!! note ""
+??? example
 
     === "Example 4: ConfigMapRef for a Deno script"
     
@@ -446,7 +446,7 @@ file.
 
 ### Example for Accessing KEPTN_CONTEXT environment variable
 
-!!! note ""
+??? example
 
     === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
     
@@ -477,7 +477,7 @@ file.
         ```
 
 ### Passing secrets, environment variables and modifying the runner command
-!!! note ""
+??? example
 
     === "deno"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -278,7 +278,7 @@ and Keptn sets up the container and runs the script as part of the task.
                 Note that, currently, only one secret can be passed
                 per `KeptnTaskDefinition` resource.
 
-                  See [Create secret text](../../guides/tasks.md#create-secret-text)
+                See [Create secret text](../../guides/tasks.md#create-secret-text)
                 for details.
                 Also see examples on secret usage in tasks runner
                 for [deno](./#env-var-in-deno) and [python](./#env-var-in-python).

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -57,7 +57,7 @@ include the same lines at the top.
 These are described here.
 
 ```yaml
-{% include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  %}
+{ % include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  % }
 ```
 
 ### Fields used for all containers
@@ -122,7 +122,7 @@ you can use a `container-runtime` to execute
 almost anything that you implemented with JES for Keptn v1.
 
 ```yaml
-{% include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  %}
+{ % include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  % }
 ```
 
 ### Fields used only for container-runtime
@@ -211,63 +211,62 @@ and Keptn sets up the container and runs the script as part of the task.
               Only one of these can be specified per `KeptnTaskDefinition` resource:
 
                 - **inline** - Include the actual executable code to execute.
-                  You can code a sequence of executables here
-                  that need to be run in order
-                  as long as they are executables that are part of the lifecycle workflow.
-                  Task sequences that are not part of the lifecycle workflow
-                  should be handled by the pipeline engine tools being used
-                  such as Jenkins, Argo Workflows, Flux, and Tekton.
-                  See examples of usage for [deno](#inline-script-for-deno)
-                  and for [python](#inline-script-for-python)
+                        You can code a sequence of executables here
+                        that need to be run in order
+                        as long as they are executables that are part of the lifecycle workflow.
+                        Task sequences that are not part of the lifecycle workflow
+                        should be handled by the pipeline engine tools being used
+                        such as Jenkins, Argo Workflows, Flux, and Tekton.
+                        See examples of usage for [deno](#inline-script-for-deno)
+                        and for [python](#inline-script-for-python)
 
                 - **httpRef** - Specify a script to be executed at runtime
-                  from the remote webserver that is specified.
+                      from the remote webserver that is specified.
+                      This syntax allows you to call a general function
+                      that is used in multiple places,
+                      possibly with different parameters
+                      that are provided in the calling `KeptnTaskDefinition` resource.
+                      Another `KeptnTaskDefinition` resource could call this same script
+                      but with different parameters.
 
-                  This syntax allows you to call a general function
-                  that is used in multiple places,
-                  possibly with different parameters
-                  that are provided in the calling `KeptnTaskDefinition` resource.
-                  Another `KeptnTaskDefinition` resource could call this same script
-                  but with different parameters.
+                      Only one script can be executed.
+                      Any other scripts listed here are silently ignored.
+                      See examples of usage for [deno](#httpref-for-deno)
+                      and for [python](#httpref-for-python)
 
-                  Only one script can be executed.
-                  Any other scripts listed here are silently ignored.
-                  See examples of usage for [deno](#httpref-for-deno)
-                  and for [python](#httpref-for-python)
-                  
                 - **functionRef** -- Execute another `KeptnTaskDefinition` resources.
-                  Populate this field with the value(s) of the `metadata.name` field
-                  for each `KeptnDefinitionTask` to be called.
+                    Populate this field with the value(s) of the `metadata.name` field
+                    for each `KeptnDefinitionTask` to be called.
 
-                  Like the `httpRef` syntax,this is commonly used
-                  to call a general function that is used in multiple places,
-                  possibly with different parameters
-                  that are set in the calling `KeptnTaskDefinition` resource.
+                    Like the `httpRef` syntax,this is commonly used
+                    to call a general function that is used in multiple places,
+                    possibly with different parameters
+                    that are set in the calling `KeptnTaskDefinition` resource.
 
-                  To be able to run the pre-/post-deployment task, you must create
-                  the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
-                  in the pre-/post-deployment section of `KeptnAppContext`.
+                    To be able to run the pre-/post-deployment task, you must create
+                    the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
+                    in the pre-/post-deployment section of `KeptnAppContext`.
 
-                  The `KeptnTaskDefinition` called with `functionref`
-                  is the `parent task` whose runner is used for the execution
-                  even if it is not the same runner defined in the
-                  calling `KeptnTaskDefinition`.
+                    The `KeptnTaskDefinition` called with `functionref`
+                    is the `parent task` whose runner is used for the execution
+                    even if it is not the same runner defined in the
+                    calling `KeptnTaskDefinition`.
 
-                  Only one `KeptnTaskDefinition` resources can be listed
-                  with the `functionRef` syntax
-                  although that `KeptnTaskDefinition` can call multiple
-                  executables (programs, functions, and scripts).
-                  Any calls to additional `KeptnTaskDefinition` resources
-                  are silently ignored.
-                  See examples of usage for [deno](#functionref-for-deno) 
-                  and [python](#functionref-for-python)
+                    Only one `KeptnTaskDefinition` resources can be listed
+                    with the `functionRef` syntax
+                    although that `KeptnTaskDefinition` can call multiple
+                    executables (programs, functions, and scripts).
+                    Any calls to additional `KeptnTaskDefinition` resources
+                    are silently ignored.
+                    See examples of usage for [deno](#functionref-for-deno)
+                    and [python](#functionref-for-python)
 
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
                   See examples of usage for [deno](#configmapref-for-deno)
                   and for [python](#configmapref-for-python)
-                - 
+                  
             - **parameters** - An optional field
               to supply input parameters to a function.
               Keptn passes the values defined inside the `map` field
@@ -346,7 +345,7 @@ This is a trivial example that just runs `busybox`,
 then spawns a shell and runs the `sleep 30` command:
 
 ```yaml
-{% include "../../assets/crd/task-definition.yaml" %}
+{ % include "../../assets/crd/task-definition.yaml" % }
 ```
 
 This task is then referenced in the

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -535,7 +535,6 @@ This modifies the synopsis in the following ways:
 
 - [KeptnApp](app.md)
 - [Working with tasks](../../guides/tasks.md)
-- [KeptnApp and KeptnWorkload resources](../../components/lifecycle-operator/keptn-apps.md).
-- Getting started with
-  [Release Lifecycle Management](../../getting-started/lifecycle-management.md)
+- [KeptnApp and KeptnWorkload resources](../../components/lifecycle-operator/keptn-apps.md)
+- [Release Lifecycle Management](../../getting-started/lifecycle-management.md)
 - [Executing sequential tasks](../../guides/tasks.md#executing-sequential-tasks)

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -153,36 +153,38 @@ and Keptn sets up the container and runs the script as part of the task.
 <!-- markdownlint-disable MD046 -->
 
 ???+ note "Synopsis"
-=== "deno-runtime"
-
-    When using the `deno-runtime` runner to define a task,
-    the executables are coded in
-    [Deno-script](https://deno.com/manual),
-    (which is mostly the same as JavaScript and TypeScript)
-    and executed in the
-    `deno-runtime` runner,
-    which is a lightweight runtime environment
-    that executes in your namespace.
-    Note that Deno has tighter restrictions
-    for permissions and importing data
-    so a script that works properly elsewhere
-    may not function out of the box when run in the `deno-runtime` runner.
-    In this case you may want to use a custom container instead. 
-    ```yaml
-    { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
-    ```
-=== "python-runtime"
     
-    When using the `python-runtime` runner to define a task,
-    the executables are coded in python3.
-    The runner enables the following packages: requests, json, git, yaml.
-    Note that other libraries may not function out of the box 
-    in the `python-runtime` runner. 
-    In this case you may want to use a custom container instead.
+    === "deno-runtime"
+    
+        When using the `deno-runtime` runner to define a task,
+        the executables are coded in
+        [Deno-script](https://deno.com/manual),
+        (which is mostly the same as JavaScript and TypeScript)
+        and executed in the
+        `deno-runtime` runner,
+        which is a lightweight runtime environment
+        that executes in your namespace.
+        Note that Deno has tighter restrictions
+        for permissions and importing data
+        so a script that works properly elsewhere
+        may not function out of the box when run in the `deno-runtime` runner.
+        In this case you may want to use a custom container instead. 
+        ```yaml
+        { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
+        ```
 
-    ```yaml
-    {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
-    ```
+    === "python-runtime"
+        
+        When using the `python-runtime` runner to define a task,
+        the executables are coded in python3.
+        The runner enables the following packages: requests, json, git, yaml.
+        Note that other libraries may not function out of the box 
+        in the `python-runtime` runner. 
+        In this case you may want to use a custom container instead.
+    
+        ```yaml
+        {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
+        ```
 
 <!-- markdownlint-enable MD046 -->
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -419,7 +419,7 @@ file.
 === "Example 2: httpRef for a python-runtime runner"
 
      ```yaml
-    {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/runtimes/python-runtime/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
+    {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
     ```
 
 ### Examples for functionRef

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -208,7 +208,7 @@ and Keptn sets up the container and runs the script as part of the task.
               used to call the executables.
               Only one of these can be specified per `KeptnTaskDefinition` resource:
 
-                - **inline** - Include the actual executable code to execute.
+                - **inline** -- Include the actual executable code to execute.
                         You can code a sequence of executables here
                         that need to be run in order
                         as long as they are executables that are part of the lifecycle workflow.
@@ -218,7 +218,7 @@ and Keptn sets up the container and runs the script as part of the task.
                         See examples of usage for [deno](./#inline-script-for-deno)
                         and for [python](./#inline-script-for-python).
 
-                - **httpRef** - Specify a script to be executed at runtime
+                - **httpRef** -- Specify a script to be executed at runtime
                         from the remote webserver that is specified.
                         This syntax allows you to call a general function
                         that is used in multiple places,
@@ -253,13 +253,13 @@ and Keptn sets up the container and runs the script as part of the task.
                     are silently ignored.
                     See examples of usage for [deno](./#functionref-for-deno)
                     and [python](./#functionref-for-python).
-                - **ConfigMapRef** - Specify the name of a
+                - **ConfigMapRef** -- Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
                   See examples of usage for [deno](./#configmapref-for-deno)
                   and for [python](./#configmapref-for-python).
 
-            - **parameters** - An optional field
+            - **parameters** -- An optional field
               to supply input parameters to a function.
               Keptn passes the values defined inside the `map` field
               as a JSON object.

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -31,7 +31,7 @@ differentiated by the `spec` section:
   See
   [Synopsis for container-runtime](#synopsis-for-container-runtime)
   and
-  [a container-runtime runner](#example-for-a-container-runtime-runner).
+  [Example for a container-runtime runner](#example-for-a-container-runtime-runner).
 
 - Pre-defined containers
 
@@ -43,11 +43,11 @@ differentiated by the `spec` section:
       with a few limitations.
       You can use this to specify simple actions
       without having to define a full container.
-      See [runtime examples](./#deno-runtime-synopsis)
+      See [runtime examples](#examples-for-deno-runtime-and-python-runtime-runners)
     - Use the pre-defined `python-runtime` runner
       to define your task using
       [Python 3](https://www.python.org/).
-      See [runtime examples](./#python-runtime-synopsis)
+      See [runtime examples](#examples-for-deno-runtime-and-python-runtime-runners)
       for practical usage of the pre-defined containers.
 
 ## Synopsis for all runners
@@ -84,11 +84,11 @@ These are described here.
           and code the functionality in Deno script,
           which is similar to JavaScript and Typescript.
           See
-          [Synopsis for predefined-containers](#).
+          [Synopsis for predefined-containers](./#deno-runtime-synopsis).
         - **python** -- Use a `python-runtime` function
           and code the functionality in Python 3.
           See
-          [Synopsis for predefined-containers](#synopsis-for-predefined-containers).
+          [Synopsis for predefined-containers](./#python-runtime-synopsis).
         - **container** -- Use the runner defined
           for the `container-runtime` container.
           This is a standard Kubernetes container
@@ -436,7 +436,6 @@ file.
         ```yaml
         {% include "../../assets/crd/python-configmap.yaml" %}
         ```
-=
 
 ??? example "Accessing KEPTN_CONTEXT environment variable"
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -210,34 +210,22 @@ and Keptn sets up the container and runs the script as part of the task.
                   Task sequences that are not part of the lifecycle workflow
                   should be handled by the pipeline engine tools being used
                   such as Jenkins, Argo Workflows, Flux, and Tekton.
+                  Example of usage in task runners are [here](#examples-for-inline-script)
 
-                    - **deno example:**
-                      <a href="#example-1-inline-script-for-a-deno-script">Example 1: inline script for a Deno script</a>
+                - **httpRef** - Specify a script to be executed at runtime
+                  from the remote webserver that is specified.
 
-                    - **python example:**
-                      <!-- markdownlint-disable MD013 -->
-                      <a href="#example-1-inline-code-for-a-python-runtime-runner">Example 1: inline code for a python-runtime runner</a>
+                  This syntax allows you to call a general function
+                  that is used in multiple places,
+                  possibly with different parameters
+                  that are provided in the calling `KeptnTaskDefinition` resource.
+                  Another `KeptnTaskDefinition` resource could call this same script
+                  but with different parameters.
 
-                      <!-- markdownlint-enable MD013 -->
-                    - **httpRef** - Specify a script to be executed at runtime
-                      from the remote webserver that is specified.
+                  Only one script can be executed.
+                  Any other scripts listed here are silently ignored.
+                  Example of usage in task runners are [here](#examples-for-httpref-script)
 
-                    This syntax allows you to call a general function
-                    that is used in multiple places,
-                    possibly with different parameters
-                    that are provided in the calling `KeptnTaskDefinition` resource.
-                    Another `KeptnTaskDefinition` resource could call this same script
-                    but with different parameters.
-
-                    Only one script can be executed.
-                    Any other scripts listed here are silently ignored.
-
-                    - **deno example:**
-                      <a href="#example-2-httpref-script-for-a-deno-script">Example 2: httpRef script for a Deno script</a>
-                    - **python example:**
-                      <!-- markdownlint-disable MD033 -->
-                      <!-- <a href="#"></a> --><br>
-                      <!-- markdownlint-enable MD033 -->
                 - **functionRef** -- Execute another `KeptnTaskDefinition` resources.
                   Populate this field with the value(s) of the `metadata.name` field
                   for each `KeptnDefinitionTask` to be called.
@@ -258,27 +246,16 @@ and Keptn sets up the container and runs the script as part of the task.
 
                     Only one `KeptnTaskDefinition` resources can be listed
                     with the `functionRef` syntax
-                    although that `KeptnTaskDefinition` can call multipe
+                    although that `KeptnTaskDefinition` can call multiple
                     executables (programs, functions, and scripts).
                     Any calls to additional `KeptnTaskDefinition` resources
                     are silently ignored.
+                    Example of usage in task runners are [here](#examples-for-functionref)
 
-                    - **deno example:**
-                      <a href="#example-3-functionref-for-a-deno-script">Example 3: functionRef for a Deno script</a>
-                    - **python example:**
-                      <!-- markdownlint-disable MD013 -->
-                      <a href="#example-3-functionref-for-a-python-runtime-runner">Example 3: functionRef for a python-runtime runner</a>
-                      <!-- markdownlint-enable MD013 -->
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
-
-                    - **deno example:**
-                      <a href="#example-5-configmap-for-a-deno-script">Example 5: ConfigMap for a Deno script</a>
-                    - **python example:**
-                      <!-- markdownlint-disable MD013 -->
-                      <a href="#example-4-configmapref-for-a-python-runtime-runner">Example 4: ConfigMapRef for a python-runtime runner</a>
-                      <!-- markdownlint-enable MD013 -->
+                  Example of usage in task runners are [here](#examples-for-configmap-and-configmapref)  
 
             - **parameters** - An optional field
               to supply input parameters to a function.
@@ -290,13 +267,6 @@ and Keptn sets up the container and runs the script as part of the task.
               [Parameterized functions](../../guides/tasks.md#parameterized-functions)
               for more information.
 
-                - **deno example:**
-                  <a href="#example-3-functionref-for-a-deno-script">Example 3: functionRef for a Deno script</a>
-                - **python example:**
-                  <!-- markdownlint-disable MD013 -->
-                  <a href="#example-3-functionref-for-a-python-runtime-runner">Example 3: functionRef for a python-runner runner</a>
-                  <!-- markdownlint-enable MD013 -->
-
             - **secureParameters** -- An optional field
               used to pass a Kubernetes secret.
               The `secret` value is the Kubernetes secret name
@@ -307,14 +277,8 @@ and Keptn sets up the container and runs the script as part of the task.
                 per `KeptnTaskDefinition` resource.
 
                 See [Create secret text](../../guides/tasks.md#create-secret-text)
-                for details.
-
-                - **deno example:**
-                  <a href="#example-3-functionref-for-a-deno-script">Example 3: functionRef for a Deno script</a>
-                - **python example:**
-                  <!-- markdownlint-disable MD013 -->
-                  <a href="#example-3-functionref-for-a-python-runtime-runner">Example 3: functionRef for a python-runner runner</a>
-                  <!-- markdownlint-enable MD013 -->
+                for details. 
+                Examples on secret usage in tasks runner are [here](#passing-secrets-environment-variables-and-modifying-the-python-command)
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -178,6 +178,12 @@ and Keptn sets up the container and runs the script as part of the task.
 
 === "python-runtime"
 
+    When using the `python-runtime` runner to define a task,
+    the executables are coded in python3.
+    The runner enables the following packages: requests, json, git, yaml.
+    Note that other libraries may not function out of the box 
+    in the `python-runtime` runner.
+
     ```yaml
     {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
     ```
@@ -412,10 +418,9 @@ file.
 
 === "Example 2: httpRef for a python-runtime runner"
 
-    You can refer to code stored online.
-    For example, we have a few examples available in the
-    [python-runtime samples](https://github.com/keptn/lifecycle-toolkit/tree/main/runtimes/python-runtime/samples)
-    tree.
+     ```yaml
+    {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/runtimes/python-runtime/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
+    ```
 
 ### Examples for functionRef
 
@@ -441,7 +446,7 @@ file.
     {% include "../../assets/crd/python-recursive.yaml" %}
     ```
 
-### Examples for ConfigMapRef
+### Examples for ConfigMap and ConfigMapRef
 
 === "Example 4: ConfigMapRef for a Deno script"
 
@@ -454,23 +459,16 @@ file.
 
 === "Example 4: ConfigMapRef for a python-runtime runner"
 
+    In this example the python runner refers to an existing configMap 
+    called `python-test-cm`
+
     ```yaml
     {% include "../../assets/crd/python-configmap.yaml" %}
     ```
 
-### Examples for ConfigMap
-
-=== "Example 5: ConfigMap for a Deno script"
-
-    This example illustrates the use of both a `ConfigMapRef` and a `ConfigMap`:
-
-    ```yaml
-    {% include "../../assets/crd/examples/configmap-for-deno-script.yaml" %} 
-    ```
-
 ### Example for Accessing KEPTN_CONTEXT environment variable
 
-=== "Example 6: Accessing KEPTN_CONTEXT environment variable in a Deno task"
+=== "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
 
     For Tasks triggered as pre- and post- deployment of applications
     on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
@@ -480,8 +478,24 @@ file.
     ```javascript
     let context = Deno.env.get("KEPTN_CONTEXT");
     ```
+=== "Example 5: Accessing KEPTN_CONTEXT environment variable in a Python task"
+
+    For Tasks triggered as pre- and post- deployment of applications
+    on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
+    As all environment variables, this can be accessed using language specific methods.
+    An example in Python would be the following:
+
+    ```python
+    import os
+    import yaml
+    data = os.getenv('KEPTN_CONTEXT')
+    dct = yaml.safe_load(data)
+    meta= dct['metadata']
+    print(meta)
+    ```
 
 <!-- markdownlint-enable MD046 -->
+
 ### Allowed libraries for the python-runtime runner
 
 The following example shows how to use some of the allowed packages, namely:

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -152,39 +152,37 @@ and Keptn sets up the container and runs the script as part of the task.
 
 <!-- markdownlint-disable MD046 -->
 
-!!! note "Synopsis"
+???+ note "Synopsis"
 === "deno-runtime"
-    
-        When using the `deno-runtime` runner to define a task,
-        the executables are coded in
-        [Deno-script](https://deno.com/manual),
-        (which is mostly the same as JavaScript and TypeScript)
-        and executed in the
-        `deno-runtime` runner,
-        which is a lightweight runtime environment
-        that executes in your namespace.
-        Note that Deno has tighter restrictions
-        for permissions and importing data
-        so a script that works properly elsewhere
-        may not function out of the box when run in the `deno-runtime` runner.
-        In this case you may want to use a custom container instead.
-    
+
+    When using the `deno-runtime` runner to define a task,
+    the executables are coded in
+    [Deno-script](https://deno.com/manual),
+    (which is mostly the same as JavaScript and TypeScript)
+    and executed in the
+    `deno-runtime` runner,
+    which is a lightweight runtime environment
+    that executes in your namespace.
+    Note that Deno has tighter restrictions
+    for permissions and importing data
+    so a script that works properly elsewhere
+    may not function out of the box when run in the `deno-runtime` runner.
+    In this case you may want to use a custom container instead. 
     ```yaml
     { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
     ```
-    
 === "python-runtime"
     
-        When using the `python-runtime` runner to define a task,
-        the executables are coded in python3.
-        The runner enables the following packages: requests, json, git, yaml.
-        Note that other libraries may not function out of the box 
-        in the `python-runtime` runner. 
-        In this case you may want to use a custom container instead.
-    
-        ```yaml
-        {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
-        ```
+    When using the `python-runtime` runner to define a task,
+    the executables are coded in python3.
+    The runner enables the following packages: requests, json, git, yaml.
+    Note that other libraries may not function out of the box 
+    in the `python-runtime` runner. 
+    In this case you may want to use a custom container instead.
+
+    ```yaml
+    {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
+    ```
 
 <!-- markdownlint-enable MD046 -->
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -376,16 +376,13 @@ file.
         {% include "../../assets/crd/examples/httpref-script-for-deno-script.yaml" %}
         ```
     
-        For another example, see the
-        [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
-    
-        See the
-        [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
+        For other example, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
+        and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
         PodtatoHead example for a more complete example.
     
     === "Example 2: httpRef for a python-runtime runner"
     
-         ```yaml
+        ```yaml
         {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
         ```
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -152,8 +152,8 @@ and Keptn sets up the container and runs the script as part of the task.
 
 <!-- markdownlint-disable MD046 -->
 
-!!! example
-    === "deno-runtime"
+!!! note "Synopsis"
+=== "deno-runtime"
     
         When using the `deno-runtime` runner to define a task,
         the executables are coded in
@@ -173,7 +173,7 @@ and Keptn sets up the container and runs the script as part of the task.
     { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
     ```
     
-    === "python-runtime"
+=== "python-runtime"
     
         When using the `python-runtime` runner to define a task,
         the executables are coded in python3.

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -218,19 +218,18 @@ and Keptn sets up the container and runs the script as part of the task.
                         See examples of usage for [deno](./#inline-script-for-deno)
                         and for [python](./#inline-script-for-python)
 
-                - **httpRef** - Specify a script to be executed at runtime
-                      from the remote webserver that is specified.
-                      This syntax allows you to call a general function
-                      that is used in multiple places,
-                      possibly with different parameters
-                      that are provided in the calling `KeptnTaskDefinition` resource.
-                      Another `KeptnTaskDefinition` resource could call this same script
-                      but with different parameters.
-
-                      Only one script can be executed.
-                      Any other scripts listed here are silently ignored.
-                      See examples of usage for [deno](#httpref-for-deno)
-                      and for [python](#httpref-for-python)
+                  - **httpRef** - Specify a script to be executed at runtime
+                        from the remote webserver that is specified.
+                        This syntax allows you to call a general function
+                        that is used in multiple places,
+                        possibly with different parameters
+                        that are provided in the calling `KeptnTaskDefinition` resource.
+                        Another `KeptnTaskDefinition` resource could call this same script
+                        but with different parameters. 
+                        Only one script can be executed.
+                        Any other scripts listed here are silently ignored.
+                        See examples of usage for [deno](#httpref-for-deno)
+                        and for [python](#httpref-for-python)
 
                 - **functionRef** -- Execute another `KeptnTaskDefinition` resources.
                     Populate this field with the value(s) of the `metadata.name` field

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -57,7 +57,7 @@ include the same lines at the top.
 These are described here.
 
 ```yaml
-{ % include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  % }
+{% include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  %}
 ```
 
 ### Fields used for all containers
@@ -122,7 +122,7 @@ you can use a `container-runtime` to execute
 almost anything that you implemented with JES for Keptn v1.
 
 ```yaml
-{ % include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  % }
+{% include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  %}
 ```
 
 ### Fields used only for container-runtime
@@ -343,7 +343,7 @@ This is a trivial example that just runs `busybox`,
 then spawns a shell and runs the `sleep 30` command:
 
 ```yaml
-{ % include "../../assets/crd/task-definition.yaml" % }
+{% include "../../assets/crd/task-definition.yaml" %}
 ```
 
 This task is then referenced in the
@@ -470,7 +470,7 @@ file.
 
 ??? example "Passing secrets, environment variables and modifying the runner command"
 
-    === "deno"
+    === "Env var in deno"
     
     The following example shows how to pass data inside the parameter map,
     and how to load a secret in your code.
@@ -481,7 +481,7 @@ file.
     {% include "../../assets/crd/deno-context.yaml" %}
     ```
 
-    === "python"
+    === "Env var in python"
     
     The following example shows how to pass data inside the parameter map,
     how to load a secret in your code,

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -217,7 +217,8 @@ and Keptn sets up the container and runs the script as part of the task.
                   Task sequences that are not part of the lifecycle workflow
                   should be handled by the pipeline engine tools being used
                   such as Jenkins, Argo Workflows, Flux, and Tekton.
-                  Example of usage in task runners are [here](#examples-for-inline-script)
+                  See examples of usage for [deno](#inline-script-for-deno)
+                  and for [python](#inline-script-for-python)
 
                 - **httpRef** - Specify a script to be executed at runtime
                   from the remote webserver that is specified.
@@ -231,8 +232,9 @@ and Keptn sets up the container and runs the script as part of the task.
 
                   Only one script can be executed.
                   Any other scripts listed here are silently ignored.
-                  Example of usage in task runners are [here](#examples-for-httpref-script)
-
+                  See examples of usage for [deno](#httpref-for-deno)
+                  and for [python](#httpref-for-python)
+                  
                 - **functionRef** -- Execute another `KeptnTaskDefinition` resources.
                   Populate this field with the value(s) of the `metadata.name` field
                   for each `KeptnDefinitionTask` to be called.
@@ -257,22 +259,24 @@ and Keptn sets up the container and runs the script as part of the task.
                   executables (programs, functions, and scripts).
                   Any calls to additional `KeptnTaskDefinition` resources
                   are silently ignored.
-                  Example of usage in task runners are [here](#examples-for-functionref)
+                  See examples of usage for [deno](#functionref-for-deno) 
+                  and [python](#functionref-for-python)
 
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
-                  Example of usage in task runners are [here](#examples-for-configmap-and-configmapref)
-
+                  See examples of usage for [deno](#configmapref-for-deno)
+                  and for [python](#configmapref-for-python)
+                - 
             - **parameters** - An optional field
               to supply input parameters to a function.
               Keptn passes the values defined inside the `map` field
               as a JSON object.
-              See
-              [Passing secrets, environment variables, and modifying the python command](#passing-secrets-environment-variables-and-modifying-the-python-command)
-              and
-              [Parameterized functions](../../guides/tasks.md#parameterized-functions)
+              See [Parameterized functions](../../guides/tasks.md#parameterized-functions)
               for more information.
+              Also see examples for [deno](#deno)
+              and
+              [python](#python).
 
             - **secureParameters** -- An optional field
               used to pass a Kubernetes secret.
@@ -285,8 +289,8 @@ and Keptn sets up the container and runs the script as part of the task.
 
               See [Create secret text](../../guides/tasks.md#create-secret-text)
               for details.
-              Examples on secret usage in tasks runner
-              are [here](#passing-secrets-environment-variables-and-modifying-the-python-command)
+              Also see examples on secret usage in tasks runner
+              for [deno](#deno) and [python](#python).
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -153,46 +153,44 @@ and Keptn sets up the container and runs the script as part of the task.
 
 <!-- markdownlint-disable MD046 -->
 
-!!! note "Synopsis"
+=== "Deno-runtime synopsis"
 
-    === "Deno-runtime synopsis"
+    When using the `deno-runtime` runner to define a task,
+    the executables are coded in
+    [Deno-script](https://deno.com/manual),
+    (which is mostly the same as JavaScript and TypeScript)
+    and executed in the
+    `deno-runtime` runner,
+    which is a lightweight runtime environment
+    that executes in your namespace.
+    Note that Deno has tighter restrictions
+    for permissions and importing data
+    so a script that works properly elsewhere
+    may not function out of the box when run in the `deno-runtime` runner.
+    In this case you may want to use a custom container instead. 
+
+    ```yaml
+    {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
+    ```
+
+=== "Python-runtime synopsis"
     
-        When using the `deno-runtime` runner to define a task,
-        the executables are coded in
-        [Deno-script](https://deno.com/manual),
-        (which is mostly the same as JavaScript and TypeScript)
-        and executed in the
-        `deno-runtime` runner,
-        which is a lightweight runtime environment
-        that executes in your namespace.
-        Note that Deno has tighter restrictions
-        for permissions and importing data
-        so a script that works properly elsewhere
-        may not function out of the box when run in the `deno-runtime` runner.
-        In this case you may want to use a custom container instead. 
-
+    When using the `python-runtime` runner to define a task,
+    the executables are coded in python3.
+    The runner enables the following packages: requests, json, git, yaml.
+    
+    ??? example 
         ```yaml
-        {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
+        {% include "../../assets/crd/python-libs.yaml" %}
         ```
 
-    === "Python-runtime synopsis"
-        
-        When using the `python-runtime` runner to define a task,
-        the executables are coded in python3.
-        The runner enables the following packages: requests, json, git, yaml.
-        
-        ??? example 
-            ```yaml
-            {% include "../../assets/crd/python-libs.yaml" %}
-            ```
+    Note that other libraries may not function out of the box 
+    in the `python-runtime` runner. 
+    In this case you may want to use a custom container instead.
 
-        Note that other libraries may not function out of the box 
-        in the `python-runtime` runner. 
-        In this case you may want to use a custom container instead.
-    
-        ```yaml
-        {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
-        ```
+    ```yaml
+    {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
+    ```
 
 <!-- markdownlint-enable MD046 -->
 
@@ -217,8 +215,8 @@ and Keptn sets up the container and runs the script as part of the task.
                         Task sequences that are not part of the lifecycle workflow
                         should be handled by the pipeline engine tools being used
                         such as Jenkins, Argo Workflows, Flux, and Tekton.
-                        See examples of usage for [deno](#inline-script-for-deno)
-                        and for [python](#inline-script-for-python)
+                        See examples of usage for [deno](./#inline-script-for-deno)
+                        and for [python](./#inline-script-for-python)
 
                 - **httpRef** - Specify a script to be executed at runtime
                       from the remote webserver that is specified.
@@ -258,14 +256,14 @@ and Keptn sets up the container and runs the script as part of the task.
                     executables (programs, functions, and scripts).
                     Any calls to additional `KeptnTaskDefinition` resources
                     are silently ignored.
-                    See examples of usage for [deno](#functionref-for-deno)
-                    and [python](#functionref-for-python)
+                    See examples of usage for [deno](./#functionref-for-deno)
+                    and [python](./#functionref-for-python)
 
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
-                  See examples of usage for [deno](#configmapref-for-deno)
-                  and for [python](#configmapref-for-python)
+                  See examples of usage for [deno](./#configmapref-for-deno)
+                  and for [python](./#configmapref-for-python)
                   
             - **parameters** - An optional field
               to supply input parameters to a function.
@@ -273,9 +271,9 @@ and Keptn sets up the container and runs the script as part of the task.
               as a JSON object.
               See [Parameterized functions](../../guides/tasks.md#parameterized-functions)
               for more information.
-              Also see examples for [deno](#deno)
+              Also see examples for [deno](./#deno)
               and
-              [python](#python).
+              [python](./#python).
 
             - **secureParameters** -- An optional field
               used to pass a Kubernetes secret.
@@ -289,7 +287,7 @@ and Keptn sets up the container and runs the script as part of the task.
               See [Create secret text](../../guides/tasks.md#create-secret-text)
               for details.
               Also see examples on secret usage in tasks runner
-              for [deno](#deno) and [python](#python).
+              for [deno](./#deno) and [python](./#python).
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -46,8 +46,8 @@ differentiated by the `spec` section:
     - Use the pre-defined `python-runtime` runner
       to define your task using
       [Python 3](https://www.python.org/).
-    See [runtime examples](#examples-for-deno-runtime-and-python-runtime-runners)
-    for practical usage of the pre-defined containers.
+      See [runtime examples](#examples-for-deno-runtime-and-python-runtime-runners)
+      for practical usage of the pre-defined containers.
 
 ## Synopsis for all runners
 
@@ -56,7 +56,7 @@ include the same lines at the top.
 These are described here.
 
 ```yaml
-{% include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  %}
+{ % include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  % }
 ```
 
 ### Fields used for all containers
@@ -121,7 +121,7 @@ you can use a `container-runtime` to execute
 almost anything that you implemented with JES for Keptn v1.
 
 ```yaml
-{% include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  %}
+{ % include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  % }
 ```
 
 ### Fields used only for container-runtime
@@ -151,38 +151,41 @@ Instead, just provide either a Deno or Python script
 and Keptn sets up the container and runs the script as part of the task.
 
 <!-- markdownlint-disable MD046 -->
-=== "deno-runtime"
+
+!!! example
+    === "deno-runtime"
     
-    When using the `deno-runtime` runner to define a task,
-    the executables are coded in
-    [Deno-script](https://deno.com/manual),
-    (which is mostly the same as JavaScript and TypeScript)
-    and executed in the
-    `deno-runtime` runner,
-    which is a lightweight runtime environment
-    that executes in your namespace.
-    Note that Deno has tighter restrictions
-    for permissions and importing data
-    so a script that works properly elsewhere
-    may not function out of the box when run in the `deno-runtime` runner.
-    In this case you may want to use a custom container instead.
-
-```yaml
-{% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
-```
-
-=== "python-runtime"
-
-    When using the `python-runtime` runner to define a task,
-    the executables are coded in python3.
-    The runner enables the following packages: requests, json, git, yaml.
-    Note that other libraries may not function out of the box 
-    in the `python-runtime` runner. 
-    In this case you may want to use a custom container instead.
-
+        When using the `deno-runtime` runner to define a task,
+        the executables are coded in
+        [Deno-script](https://deno.com/manual),
+        (which is mostly the same as JavaScript and TypeScript)
+        and executed in the
+        `deno-runtime` runner,
+        which is a lightweight runtime environment
+        that executes in your namespace.
+        Note that Deno has tighter restrictions
+        for permissions and importing data
+        so a script that works properly elsewhere
+        may not function out of the box when run in the `deno-runtime` runner.
+        In this case you may want to use a custom container instead.
+    
     ```yaml
-    {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
+    { % include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" % }
     ```
+    
+    === "python-runtime"
+    
+        When using the `python-runtime` runner to define a task,
+        the executables are coded in python3.
+        The runner enables the following packages: requests, json, git, yaml.
+        Note that other libraries may not function out of the box 
+        in the `python-runtime` runner. 
+        In this case you may want to use a custom container instead.
+    
+        ```yaml
+        {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
+        ```
+
 <!-- markdownlint-enable MD046 -->
 
 ### Fields for predefined containers
@@ -226,32 +229,32 @@ and Keptn sets up the container and runs the script as part of the task.
                   Populate this field with the value(s) of the `metadata.name` field
                   for each `KeptnDefinitionTask` to be called.
 
-                    Like the `httpRef` syntax,this is commonly used
-                    to call a general function that is used in multiple places,
-                    possibly with different parameters
-                    that are set in the calling `KeptnTaskDefinition` resource.
+                  Like the `httpRef` syntax,this is commonly used
+                  to call a general function that is used in multiple places,
+                  possibly with different parameters
+                  that are set in the calling `KeptnTaskDefinition` resource.
 
-                    To be able to run the pre-/post-deployment task, you must create
-                    the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
-                    in the pre-/post-deployment section of `KeptnAppContext`.
+                  To be able to run the pre-/post-deployment task, you must create
+                  the `KeptnAppContext` resource and link the `KeptnTaskDefinition`
+                  in the pre-/post-deployment section of `KeptnAppContext`.
 
-                    The `KeptnTaskDefinition` called with `functionref`
-                    is the `parent task` whose runner is used for the execution
-                    even if it is not the same runner defined in the
-                    calling `KeptnTaskDefinition`.
+                  The `KeptnTaskDefinition` called with `functionref`
+                  is the `parent task` whose runner is used for the execution
+                  even if it is not the same runner defined in the
+                  calling `KeptnTaskDefinition`.
 
-                    Only one `KeptnTaskDefinition` resources can be listed
-                    with the `functionRef` syntax
-                    although that `KeptnTaskDefinition` can call multiple
-                    executables (programs, functions, and scripts).
-                    Any calls to additional `KeptnTaskDefinition` resources
-                    are silently ignored.
-                    Example of usage in task runners are [here](#examples-for-functionref)
+                  Only one `KeptnTaskDefinition` resources can be listed
+                  with the `functionRef` syntax
+                  although that `KeptnTaskDefinition` can call multiple
+                  executables (programs, functions, and scripts).
+                  Any calls to additional `KeptnTaskDefinition` resources
+                  are silently ignored.
+                  Example of usage in task runners are [here](#examples-for-functionref)
 
                 - **ConfigMapRef** - Specify the name of a
                   [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)
                   resource that contains the function to be executed.
-                  Example of usage in task runners are [here](#examples-for-configmap-and-configmapref)  
+                  Example of usage in task runners are [here](#examples-for-configmap-and-configmapref)
 
             - **parameters** - An optional field
               to supply input parameters to a function.
@@ -269,12 +272,13 @@ and Keptn sets up the container and runs the script as part of the task.
               that is mounted into the runtime and made available to functions
               using the `SECURE_DATA` environment variable.
 
-                Note that, currently, only one secret can be passed
-                per `KeptnTaskDefinition` resource.
+              Note that, currently, only one secret can be passed
+              per `KeptnTaskDefinition` resource.
 
-                See [Create secret text](../../guides/tasks.md#create-secret-text)
-                for details.
-                Examples on secret usage in tasks runner are [here](#passing-secrets-environment-variables-and-modifying-the-python-command)
+              See [Create secret text](../../guides/tasks.md#create-secret-text)
+              for details.
+              Examples on secret usage in tasks runner
+              are [here](#passing-secrets-environment-variables-and-modifying-the-python-command)
 
 ## Usage
 
@@ -330,7 +334,7 @@ This is a trivial example that just runs `busybox`,
 then spawns a shell and runs the `sleep 30` command:
 
 ```yaml
-{% include "../../assets/crd/task-definition.yaml" %}
+{ % include "../../assets/crd/task-definition.yaml" % }
 ```
 
 This task is then referenced in the
@@ -351,6 +355,7 @@ file.
     ```yaml
     {% include "../../assets/crd/examples/inline-script-for-deno-script.yaml" %} 
     ```
+
 === "Example 1: inline code for a python-runtime runner"
 
     You can embed python code directly in the task definition.
@@ -439,6 +444,7 @@ file.
     ```javascript
     let context = Deno.env.get("KEPTN_CONTEXT");
     ```
+
 === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Python task"
 
     For Tasks triggered as pre- and post- deployment of applications
@@ -454,6 +460,7 @@ file.
     meta= dct['metadata']
     print(meta)
     ```
+
 <!-- markdownlint-enable MD046 -->
 
 ### Allowed libraries for the python-runtime runner
@@ -462,7 +469,7 @@ The following example shows how to use some of the allowed packages, namely:
 requests, json, git, and yaml:
 
 ```yaml
-{% include "../../assets/crd/python-libs.yaml" %}
+{ % include "../../assets/crd/python-libs.yaml" % }
 ```
 
 ### Passing secrets, environment variables and modifying the python command
@@ -474,7 +481,7 @@ In this case the container runs with the `-h` option,
 which prints the help message for the python3 interpreter:
 
 ```yaml
-{% include "../../assets/crd/python-context.yaml" %}
+{ % include "../../assets/crd/python-context.yaml" % }
 ```
 
 ## More examples

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -152,7 +152,7 @@ and Keptn sets up the container and runs the script as part of the task.
 
 <!-- markdownlint-disable MD046 -->
 
-???+ note "Synopsis"
+!!! note "Synopsis"
 
     === "deno-runtime"
     
@@ -348,7 +348,7 @@ file.
 
 ### Examples for inline script
 
-???+ note ""
+!!! note ""
 
     === "Example 1: inline script for a Deno script"
 
@@ -370,7 +370,7 @@ file.
 
 ### Examples for httpRef script
 
-???+ note ""
+!!! note ""
 
     === "Example 2: httpRef script for a Deno script"
     
@@ -380,7 +380,7 @@ file.
         {% include "../../assets/crd/examples/httpref-script-for-deno-script.yaml" %}
         ```
           
-        For other example, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
+        For other examples, see the [sample-app](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml).
         and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
         PodtatoHead example for a more complete example.
     
@@ -392,7 +392,7 @@ file.
 
 ### Examples for functionRef
 
-???+ note ""
+!!! note ""
 
     === "Example 3: functionRef for a Deno script"
     
@@ -418,7 +418,7 @@ file.
 
 ### Examples for ConfigMap and ConfigMapRef
 
-???+ note ""
+!!! note ""
 
     === "Example 4: ConfigMapRef for a Deno script"
     
@@ -440,7 +440,7 @@ file.
 
 ### Example for Accessing KEPTN_CONTEXT environment variable
 
-???+ note ""
+!!! note ""
 
     === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -260,28 +260,28 @@ and Keptn sets up the container and runs the script as part of the task.
                   and for [python](./#configmapref-for-python).
 
             - **parameters** -- An optional field
-              to supply input parameters to a function.
-              Keptn passes the values defined inside the `map` field
-              as a JSON object.
-              See [Parameterized functions](../../guides/tasks.md#parameterized-functions)
-              for more information.
-              Also see examples for [deno](./#env-var-in-deno)
-              and
-              [python](./#env-var-in-python).
+                to supply input parameters to a function.
+                Keptn passes the values defined inside the `map` field
+                as a JSON object.
+                See [Parameterized functions](../../guides/tasks.md#parameterized-functions)
+                for more information.
+                Also see examples for [deno](./#env-var-in-deno)
+                and
+                [python](./#env-var-in-python).
 
             - **secureParameters** -- An optional field
-              used to pass a Kubernetes secret.
-              The `secret` value is the Kubernetes secret name
-              that is mounted into the runtime and made available to functions
-              using the `SECURE_DATA` environment variable.
+                used to pass a Kubernetes secret.
+                The `secret` value is the Kubernetes secret name
+                that is mounted into the runtime and made available to functions
+                using the `SECURE_DATA` environment variable.
 
-              Note that, currently, only one secret can be passed
-              per `KeptnTaskDefinition` resource.
+                Note that, currently, only one secret can be passed
+                per `KeptnTaskDefinition` resource.
 
-              See [Create secret text](../../guides/tasks.md#create-secret-text)
-              for details.
-              Also see examples on secret usage in tasks runner
-              for [deno](./#env-var-in-deno) and [python](./#env-var-in-python).
+                  See [Create secret text](../../guides/tasks.md#create-secret-text)
+                for details.
+                Also see examples on secret usage in tasks runner
+                for [deno](./#env-var-in-deno) and [python](./#env-var-in-python).
 
 ## Usage
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -371,7 +371,7 @@ file.
 ### Examples for httpRef script
 
 ???+ note ""
-    
+
     === "Example 2: httpRef script for a Deno script"
     
         This example fetches the Deno script from a remote webserver at runtime:
@@ -387,8 +387,9 @@ file.
     === "Example 2: httpRef for a python-runtime runner"
     
         ```yaml
-        {% include "https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
+        {% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
         ```
+
 ### Examples for functionRef
 
 ???+ note ""
@@ -414,6 +415,7 @@ file.
         ```yaml
         {% include "../../assets/crd/python-recursive.yaml" %}
         ```
+
 ### Examples for ConfigMap and ConfigMapRef
 
 ???+ note ""

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -352,11 +352,9 @@ file.
 
 <!-- markdownlint-disable MD046 -->
 
-### Inline script
+??? example "Inline scripts"
 
-??? example
-
-    === "Example 1: inline script for a Deno script"
+    === "Inline script for deno"
 
         This example defines a full-fledged Deno script
         within the `KeptnTaskDefinition` YAML file:
@@ -365,7 +363,7 @@ file.
         {% include "../../assets/crd/examples/inline-script-for-deno-script.yaml" %} 
         ```
 
-    === "Example 1: inline code for a python-runtime runner"
+    === "Inline script for python"
     
         You can embed python code directly in the task definition.
         This example prints data stored in the parameters map:
@@ -374,11 +372,9 @@ file.
         {% include "../../assets/crd/python-inline.yaml" %}
         ```
 
-### HttpRef
+??? example "HttpRef"
 
-??? example
-
-    === "Example 2: httpRef script for a Deno script"
+    === "httpRef for deno"
     
         This example fetches the Deno script from a remote webserver at runtime:
     
@@ -390,17 +386,15 @@ file.
         and [sample-app/version-1](https://github.com/keptn-sandbox/lifecycle-toolkit-examples/blob/main/sample-app/version-1/app-pre-deploy.yaml)
         PodtatoHead example for a more complete example.
     
-    === "Example 2: httpRef for a python-runtime runner"
+    === "httpRef for python"
     
         ```yaml
         {% include "https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/lifecycle-operator/config/samples/python_execution/taskdefinition_pyfunction_upstream_hellopy.yaml" %}
         ```
 
-### FunctionRef
+??? example "FunctionRef"
 
-??? example
-
-    === "Example 3: functionRef for a Deno script"
+    === "functionRef for deno"
     
         This example calls another defined task,
         illustrating how one `KeptnTaskDefinition` can build
@@ -412,7 +406,7 @@ file.
         {% include "../../assets/crd/examples/functionref-for-deno-script.yaml" %} 
         ```
 
-    === "Example 3: functionRef for a python-runtime runner"
+    === "functionRef for python"
     
         You can refer to an existing `KeptnTaskDefinition`.
         this example calls the inline example
@@ -422,11 +416,9 @@ file.
         {% include "../../assets/crd/python-recursive.yaml" %}
         ```
 
-### ConfigMap and ConfigMapRef
+??? example "ConfigMap and ConfigMapRef"
 
-??? example
-
-    === "Example 4: ConfigMapRef for a Deno script"
+    === "ConfigMapRef for deno"
     
         This example references a `ConfigMap` by the name of `dev-configmap`
         that contains the code for the function to be executed.
@@ -435,7 +427,7 @@ file.
         {% include "../../assets/crd/examples/configmap-for-deno-script.yaml" %} 
         ```
     
-    === "Example 4: ConfigMapRef for a python-runtime runner"
+    === "ConfigMapRef for python"
     
         In this example the python runner refers to an existing configMap 
         called `python-test-cm`
@@ -443,12 +435,11 @@ file.
         ```yaml
         {% include "../../assets/crd/python-configmap.yaml" %}
         ```
+=
 
-### Example for Accessing KEPTN_CONTEXT environment variable
+??? example "Accessing KEPTN_CONTEXT environment variable"
 
-??? example
-
-    === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Deno task"
+    === "Accessing KEPTN_CONTEXT in a Deno task"
     
         For Tasks triggered as pre- and post- deployment of applications
         on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
@@ -460,7 +451,7 @@ file.
         console.log(context);
         ```
     
-    === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Python task"
+    === "Accessing KEPTN_CONTEXT in a Python task"
     
         For Tasks triggered as pre- and post- deployment of applications
         on Kubernetes, Keptn populates an environment variable called `KEPTN_CONTEXT`.
@@ -476,8 +467,7 @@ file.
         print(meta)
         ```
 
-### Passing secrets, environment variables and modifying the runner command
-??? example
+??? example "Passing secrets, environment variables and modifying the runner command"
 
     === "deno"
     

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -179,6 +179,12 @@ and Keptn sets up the container and runs the script as part of the task.
         When using the `python-runtime` runner to define a task,
         the executables are coded in python3.
         The runner enables the following packages: requests, json, git, yaml.
+        
+        ??? example 
+            ```yaml
+            {% include "../../assets/crd/python-libs.yaml" %}
+            ```
+
         Note that other libraries may not function out of the box 
         in the `python-runtime` runner. 
         In this case you may want to use a custom container instead.
@@ -451,6 +457,7 @@ file.
     
         ```javascript
         let context = Deno.env.get("KEPTN_CONTEXT");
+        console.log(context);
         ```
     
     === "Example 5: Accessing KEPTN_CONTEXT environment variable in a Python task"
@@ -469,33 +476,38 @@ file.
         print(meta)
         ```
 
+    ### Passing secrets, environment variables and modifying the runner command
+    !!! note ""
+    
+        === "deno"
+        
+        The following example shows how to pass data inside the parameter map,
+        and how to load a secret in your code.
+        The deno command does not takes modifiers so filling the `cmdParameters`
+        will do nothig.
+
+        ```yaml
+        {% include "../../assets/crd/deno-context.yaml" %}
+        ```
+
+        === "python"
+        
+        The following example shows how to pass data inside the parameter map,
+        how to load a secret in your code,
+        and how to modify the python command.
+        In this case the container runs with the `-h` option,
+        which prints the help message for the python3 interpreter:
+    
+        ```yaml
+        {% include "../../assets/crd/python-context.yaml" %}
+        ```
+
 <!-- markdownlint-enable MD046 -->
-
-### Allowed libraries for the python-runtime runner
-
-The following example shows how to use some of the allowed packages, namely:
-requests, json, git, and yaml:
-
-```yaml
-{% include "../../assets/crd/python-libs.yaml" %}
-```
-
-### Passing secrets, environment variables and modifying the python command
-
-The following examples show how to pass data inside the parameter map,
-how to load a secret in your code,
-and how to modify the python command.
-In this case the container runs with the `-h` option,
-which prints the help message for the python3 interpreter:
-
-```yaml
-{% include "../../assets/crd/python-context.yaml" %}
-```
 
 ## More examples
 
 See
-the [lifecycle-operator/config/samples](https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples/function_execution)
+the [lifecycle-operator/config/samples](https://github.com/keptn/lifecycle-toolkit/tree/main/lifecycle-operator/config/samples)
 directory for more example `KeptnTaskDefinition` YAML files.
 
 ## Files

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -150,7 +150,7 @@ You do not need to specify the image, volumes, and so forth.
 Instead, just provide either a Deno or Python script
 and Keptn sets up the container and runs the script as part of the task.
 
-<!-- markdownlint-disable MD046-->
+<!-- markdownlint-disable MD046 -->
 === "deno-runtime"
     
     When using the `deno-runtime` runner to define a task,
@@ -183,7 +183,7 @@ and Keptn sets up the container and runs the script as part of the task.
     ```yaml
     {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
     ```
-<!-- markdownlint-enable MD046-->
+<!-- markdownlint-enable MD046 -->
 
 ### Fields for predefined containers
 
@@ -341,7 +341,8 @@ file.
 
 ### Examples for inline script
 
-<!-- markdownlint-disable -->
+<!-- markdownlint-disable MD046 -->
+
 === "Example 1: inline script for a Deno script"
 
     This example defines a full-fledged Deno script
@@ -453,7 +454,7 @@ file.
     meta= dct['metadata']
     print(meta)
     ```
-<!-- markdownlint-enable -->
+<!-- markdownlint-enable MD046 -->
 
 ### Allowed libraries for the python-runtime runner
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -56,7 +56,7 @@ include the same lines at the top.
 These are described here.
 
 ```yaml
-{ % include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  % }
+{% include "../../assets/crd/examples/synopsis-for-all-runners.yaml"  %}
 ```
 
 ### Fields used for all containers
@@ -121,7 +121,7 @@ you can use a `container-runtime` to execute
 almost anything that you implemented with JES for Keptn v1.
 
 ```yaml
-{ % include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  % }
+{% include "../../assets/crd/examples/synopsis-for-container-runtime.yaml"  %}
 ```
 
 ### Fields used only for container-runtime
@@ -335,7 +335,7 @@ This is a trivial example that just runs `busybox`,
 then spawns a shell and runs the `sleep 30` command:
 
 ```yaml
-{ % include "../../assets/crd/task-definition.yaml" % }
+{% include "../../assets/crd/task-definition.yaml" %}
 ```
 
 This task is then referenced in the
@@ -470,7 +470,7 @@ The following example shows how to use some of the allowed packages, namely:
 requests, json, git, and yaml:
 
 ```yaml
-{ % include "../../assets/crd/python-libs.yaml" % }
+{% include "../../assets/crd/python-libs.yaml" %}
 ```
 
 ### Passing secrets, environment variables and modifying the python command
@@ -482,7 +482,7 @@ In this case the container runs with the `-h` option,
 which prints the help message for the python3 interpreter:
 
 ```yaml
-{ % include "../../assets/crd/python-context.yaml" % }
+{% include "../../assets/crd/python-context.yaml" %}
 ```
 
 ## More examples

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -150,24 +150,25 @@ You do not need to specify the image, volumes, and so forth.
 Instead, just provide either a Deno or Python script
 and Keptn sets up the container and runs the script as part of the task.
 
+
 === "deno-runtime"
 
-    When using the `deno-runtime` runner to define a task,
-    the executables are coded in
-    [Deno-script](https://deno.com/manual),
-    (which is mostly the same as JavaScript and TypeScript)
-    and executed in the
-    `deno-runtime` runner,
-    which is a lightweight runtime environment
-    that executes in your namespace.
-    Note that Deno has tighter restrictions
-    for permissions and importing data
-    so a script that works properly elsewhere
-    may not function out of the box when run in the `deno-runtime` runner.
+When using the `deno-runtime` runner to define a task,
+the executables are coded in
+[Deno-script](https://deno.com/manual),
+(which is mostly the same as JavaScript and TypeScript)
+and executed in the
+`deno-runtime` runner,
+which is a lightweight runtime environment
+that executes in your namespace.
+Note that Deno has tighter restrictions
+for permissions and importing data
+so a script that works properly elsewhere
+may not function out of the box when run in the `deno-runtime` runner.
 
-    ```yaml
-    {% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
-    ```
+```yaml
+{% include "../../assets/crd/examples/synopsis-for-deno-runtime-container.yaml" %}
+```
 
 === "python-runtime"
 

--- a/docs/docs/reference/crd-reference/taskdefinition.md
+++ b/docs/docs/reference/crd-reference/taskdefinition.md
@@ -150,7 +150,7 @@ You do not need to specify the image, volumes, and so forth.
 Instead, just provide either a Deno or Python script
 and Keptn sets up the container and runs the script as part of the task.
 
-<!-- markdownlint-disable -->
+<!-- markdownlint-disable MD046-->
 === "deno-runtime"
     
     When using the `deno-runtime` runner to define a task,
@@ -181,7 +181,7 @@ and Keptn sets up the container and runs the script as part of the task.
     ```yaml
     {% include "../../assets/crd/examples/synopsis-for-python-runtime-runner.yaml" %}
     ```
-<!-- markdownlint-enable -->
+<!-- markdownlint-enable MD046-->
 
 ### Fields for predefined containers
 

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function.yaml
@@ -3,7 +3,7 @@ kind: KeptnTaskDefinition
 metadata:
   name: slack-notification-deployment-1
 spec:
-  function:
+  deno:
     functionRef:
       name: slack-notification
     secureParameters:

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function_configmap.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function_configmap.yaml
@@ -3,7 +3,7 @@ kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment
 spec:
-  function:
+  deno:
     configMapRef:
       name: scheduled-deployment-cm-1
 ---

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function_inline.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function_inline.yaml
@@ -3,7 +3,7 @@ kind: KeptnTaskDefinition
 metadata:
   name: scheduled-deployment
 spec:
-  function:
+  deno:
     inline:
       code: |
         let text = Deno.env.get("DATA");

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function_inline_slack.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function_inline_slack.yaml
@@ -3,7 +3,7 @@ kind: KeptnTaskDefinition
 metadata:
   name: slack-notification-inline
 spec:
-  function:
+  deno:
     inlineRef:
       code: |
         let text = Deno.env.get("SECURE_DATA");

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function_upstream.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function_upstream.yaml
@@ -3,6 +3,6 @@ kind: KeptnTaskDefinition
 metadata:
   name: slack-notification
 spec:
-  function:
+  deno:
     httpRef:
       url: https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/runtimes/deno-runtime/samples/ts/slack.ts

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function_upstream_scheduler.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function_upstream_scheduler.yaml
@@ -3,6 +3,6 @@ kind: KeptnTaskDefinition
 metadata:
   name: schedule-upstream-deployment
 spec:
-  function:
+  deno:
     httpRef:
       url: https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/runtimes/deno-runtime/samples/ts/schedule.ts

--- a/lifecycle-operator/config/samples/function_execution/taskdefinition_function_upstream_slack.yaml
+++ b/lifecycle-operator/config/samples/function_execution/taskdefinition_function_upstream_slack.yaml
@@ -3,6 +3,6 @@ kind: KeptnTaskDefinition
 metadata:
   name: slack-notification
 spec:
-  function:
+  deno:
     httpRef:
       url: https://raw.githubusercontent.com/keptn/lifecycle-toolkit/main/runtimes/deno-runtime/samples/ts/slack.ts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,8 @@ plugins:
       blog_dir: blog
       draft_if_future_date: true
 markdown_extensions:
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/test/chainsaw/allowed-namespaces/simple-deployment-not-allowed/chainsaw-test.yaml
+++ b/test/chainsaw/allowed-namespaces/simple-deployment-not-allowed/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
             file: 00-assert.yaml
     - name: step-01
       try:
-# we expect none of these resources to be present
+        # we expect none of these resources to be present
         - error:
             resource:
               apiVersion: lifecycle.keptn.sh/v1beta1


### PR DESCRIPTION

# Summary

This pr cleans up our KeptnTaskDefinition examples

Fixes #3083 

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
