### PR TITLE
chore(python-runtime): pin libexpat version to fix CVE-2023-52425

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -45,7 +45,6 @@ argocd
 argoproj
 ARMO
 artifacthub
-Artificathub
 asdfg
 authurl
 automerge
@@ -373,6 +372,7 @@ kyverno
 lastword
 Lato
 LFC
+libexpat
 Lifcycle
 lifecyclekeptnsh
 linenums
@@ -448,7 +448,6 @@ onsi
 opencontainers
 openfeature
 Openshift
-openssf
 opentelemetry
 opentracing
 operatorcommon

--- a/runtimes/python-runtime/Dockerfile
+++ b/runtimes/python-runtime/Dockerfile
@@ -6,8 +6,7 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolki
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.licenses="Apache-2.0"
 
-
-RUN apk --no-cache add curl
+RUN apk --no-cache add curl libexpat==2.6.0-r0
 
 RUN pip install -q --disable-pip-version-check pyyaml GitPython requests
 


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

This PR pins the version of libexpat to `2.6.0-r0` to resolve [CVE-2023-52425](https://nvd.nist.gov/vuln/detail/CVE-2023-52425).

Fixes #3120 
