### PR TITLE
ci: use codecov token to upload coverage reports

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -106,6 +106,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           flags: ${{ matrix.config.name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build_image:
     name: Build Docker Image

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -30,3 +30,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           flags: component-tests
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Description
Since codecov-action [v4](https://github.com/codecov/codecov-action/releases/tag/v4.0.0), codecov only allows coverage upload WITHOUT token for PRs with forks as sources. Every other scenario now needs a token, which we didn't use until now.
This is added in this PR to get proper coverage reports again.