### PR TITLE
docs: remove wrong documentation on lifecycle of single Pods

### DIFF
--- a/docs/docs/components/lifecycle-operator/keptn-apps.md
+++ b/docs/docs/components/lifecycle-operator/keptn-apps.md
@@ -14,8 +14,8 @@ with the ability to handle extra phases.
 It can execute the pre-/post-deployment evaluations of a workload
 and run pre-/post-deployment tasks.
 
-In its state, it tracks the currently active `Workload Versions`
-(a `DaemonSet`, `StatefulSet`, or `ReplicaSet` resource),
+In its state, it tracks the currently active workloads
+(`DaemonSet`, `StatefulSet`, or `ReplicaSet` resources),
 as well as the overall state of the Pre Deployment phase,
 which Keptn can use to determine
 whether the pods belonging to a workload

--- a/docs/docs/components/lifecycle-operator/keptn-apps.md
+++ b/docs/docs/components/lifecycle-operator/keptn-apps.md
@@ -14,8 +14,8 @@ with the ability to handle extra phases.
 It can execute the pre-/post-deployment evaluations of a workload
 and run pre-/post-deployment tasks.
 
-In its state, it tracks the currently active `Workload Instances`
-(`Pod`, `DaemonSet`, `StatefulSet`, and `ReplicaSet` resources),
+In its state, it tracks the currently active `Workload Versions`
+(a `DaemonSet`, `StatefulSet`, or `ReplicaSet` resource),
 as well as the overall state of the Pre Deployment phase,
 which Keptn can use to determine
 whether the pods belonging to a workload

--- a/docs/docs/installation/upgrade.md
+++ b/docs/docs/installation/upgrade.md
@@ -46,8 +46,8 @@ then reinstall Keptn from a Helm chart and re-apply your manifests.
 
 To start the upgrade process, follow the steps below:
 
-1. To not loose all of your data, we encourage you to do a backup of the manifests,
-which you applied to the cluster (`Pods`, `Deployments`,
+1. To not lose all of your data, we encourage you to do a backup of the manifests,
+which you applied to the cluster (`Deployments`,
 `StatefulSets`, `DaemonSets`, `KeptnApps`,... ).
 After the re-installation of Keptn with Helm, you can re-apply
 these manifests and restart the Keptn deployment process.


### PR DESCRIPTION

# Summary

Keptn does not track single pods lifecycle but only Workloads (Deployments, Daemonsets,StatefulSets...)
Some places in the docs where not superclear about this so edited them. 

Fixed some typos as well.


# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
