### PR TITLE
feat(lifecycle-operator): adapt KeptnConfig reconciler to set up observabilityTimeout parameter

### DIFF
--- a/lifecycle-operator/controllers/common/config/config.go
+++ b/lifecycle-operator/controllers/common/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"sync"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const defaultKeptnAppCreationRequestTimeout = 30 * time.Second
@@ -17,6 +19,8 @@ type IConfig interface {
 	GetDefaultNamespace() string
 	SetBlockDeployment(value bool)
 	GetBlockDeployment() bool
+	SetObservabilityTimeout(timeout metav1.Duration)
+	GetObservabilityTimeout() metav1.Duration
 }
 
 type ControllerConfig struct {
@@ -24,6 +28,7 @@ type ControllerConfig struct {
 	cloudEventsEndpoint            string
 	defaultNamespace               string
 	blockDeployment                bool
+	observabilityTimeout           metav1.Duration
 }
 
 var instance *ControllerConfig
@@ -34,6 +39,9 @@ func Instance() *ControllerConfig {
 		instance = &ControllerConfig{
 			keptnAppCreationRequestTimeout: defaultKeptnAppCreationRequestTimeout,
 			blockDeployment:                true,
+			observabilityTimeout: metav1.Duration{
+				Duration: time.Duration(5 * time.Minute),
+			},
 		}
 	})
 	return instance
@@ -69,4 +77,12 @@ func (o *ControllerConfig) SetBlockDeployment(value bool) {
 
 func (o *ControllerConfig) GetBlockDeployment() bool {
 	return o.blockDeployment
+}
+
+func (o *ControllerConfig) SetObservabilityTimeout(timeout metav1.Duration) {
+	o.observabilityTimeout = timeout
+}
+
+func (o *ControllerConfig) GetObservabilityTimeout() metav1.Duration {
+	return o.observabilityTimeout
 }

--- a/lifecycle-operator/controllers/common/config/config_test.go
+++ b/lifecycle-operator/controllers/common/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConfig_GetDefaultCreationRequestTimeout(t *testing.T) {
@@ -63,4 +64,20 @@ func TestConfig_SetAndGetBlockDeployment(t *testing.T) {
 	require.True(t, blocked)
 	i.SetBlockDeployment(false)
 	require.False(t, i.GetBlockDeployment())
+}
+
+func TestConfig_SetAndGetObservabilityTimeout(t *testing.T) {
+	i := Instance()
+
+	require.Equal(t, metav1.Duration{
+		Duration: time.Duration(5 * time.Minute),
+	}, i.GetObservabilityTimeout())
+
+	i.SetObservabilityTimeout(metav1.Duration{
+		Duration: time.Duration(10 * time.Minute),
+	})
+
+	require.Equal(t, metav1.Duration{
+		Duration: time.Duration(10 * time.Minute),
+	}, i.GetObservabilityTimeout())
 }

--- a/lifecycle-operator/controllers/common/config/fake/config_mock.go
+++ b/lifecycle-operator/controllers/common/config/fake/config_mock.go
@@ -4,6 +4,7 @@
 package fake
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sync"
 	"time"
 )
@@ -26,6 +27,9 @@ import (
 //			GetDefaultNamespaceFunc: func() string {
 //				panic("mock out the GetDefaultNamespace method")
 //			},
+//			GetObservabilityTimeoutFunc: func() metav1.Duration {
+//				panic("mock out the GetObservabilityTimeout method")
+//			},
 //			SetBlockDeploymentFunc: func(value bool)  {
 //				panic("mock out the SetBlockDeployment method")
 //			},
@@ -37,6 +41,9 @@ import (
 //			},
 //			SetDefaultNamespaceFunc: func(namespace string)  {
 //				panic("mock out the SetDefaultNamespace method")
+//			},
+//			SetObservabilityTimeoutFunc: func(timeout metav1.Duration)  {
+//				panic("mock out the SetObservabilityTimeout method")
 //			},
 //		}
 //
@@ -57,6 +64,9 @@ type MockConfig struct {
 	// GetDefaultNamespaceFunc mocks the GetDefaultNamespace method.
 	GetDefaultNamespaceFunc func() string
 
+	// GetObservabilityTimeoutFunc mocks the GetObservabilityTimeout method.
+	GetObservabilityTimeoutFunc func() metav1.Duration
+
 	// SetBlockDeploymentFunc mocks the SetBlockDeployment method.
 	SetBlockDeploymentFunc func(value bool)
 
@@ -68,6 +78,9 @@ type MockConfig struct {
 
 	// SetDefaultNamespaceFunc mocks the SetDefaultNamespace method.
 	SetDefaultNamespaceFunc func(namespace string)
+
+	// SetObservabilityTimeoutFunc mocks the SetObservabilityTimeout method.
+	SetObservabilityTimeoutFunc func(timeout metav1.Duration)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -82,6 +95,9 @@ type MockConfig struct {
 		}
 		// GetDefaultNamespace holds details about calls to the GetDefaultNamespace method.
 		GetDefaultNamespace []struct {
+		}
+		// GetObservabilityTimeout holds details about calls to the GetObservabilityTimeout method.
+		GetObservabilityTimeout []struct {
 		}
 		// SetBlockDeployment holds details about calls to the SetBlockDeployment method.
 		SetBlockDeployment []struct {
@@ -103,15 +119,22 @@ type MockConfig struct {
 			// Namespace is the namespace argument value.
 			Namespace string
 		}
+		// SetObservabilityTimeout holds details about calls to the SetObservabilityTimeout method.
+		SetObservabilityTimeout []struct {
+			// Timeout is the timeout argument value.
+			Timeout metav1.Duration
+		}
 	}
 	lockGetBlockDeployment        sync.RWMutex
 	lockGetCloudEventsEndpoint    sync.RWMutex
 	lockGetCreationRequestTimeout sync.RWMutex
 	lockGetDefaultNamespace       sync.RWMutex
+	lockGetObservabilityTimeout   sync.RWMutex
 	lockSetBlockDeployment        sync.RWMutex
 	lockSetCloudEventsEndpoint    sync.RWMutex
 	lockSetCreationRequestTimeout sync.RWMutex
 	lockSetDefaultNamespace       sync.RWMutex
+	lockSetObservabilityTimeout   sync.RWMutex
 }
 
 // GetBlockDeployment calls GetBlockDeploymentFunc.
@@ -219,6 +242,33 @@ func (mock *MockConfig) GetDefaultNamespaceCalls() []struct {
 	mock.lockGetDefaultNamespace.RLock()
 	calls = mock.calls.GetDefaultNamespace
 	mock.lockGetDefaultNamespace.RUnlock()
+	return calls
+}
+
+// GetObservabilityTimeout calls GetObservabilityTimeoutFunc.
+func (mock *MockConfig) GetObservabilityTimeout() metav1.Duration {
+	if mock.GetObservabilityTimeoutFunc == nil {
+		panic("MockConfig.GetObservabilityTimeoutFunc: method is nil but IConfig.GetObservabilityTimeout was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetObservabilityTimeout.Lock()
+	mock.calls.GetObservabilityTimeout = append(mock.calls.GetObservabilityTimeout, callInfo)
+	mock.lockGetObservabilityTimeout.Unlock()
+	return mock.GetObservabilityTimeoutFunc()
+}
+
+// GetObservabilityTimeoutCalls gets all the calls that were made to GetObservabilityTimeout.
+// Check the length with:
+//
+//	len(mockedIConfig.GetObservabilityTimeoutCalls())
+func (mock *MockConfig) GetObservabilityTimeoutCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetObservabilityTimeout.RLock()
+	calls = mock.calls.GetObservabilityTimeout
+	mock.lockGetObservabilityTimeout.RUnlock()
 	return calls
 }
 
@@ -347,5 +397,37 @@ func (mock *MockConfig) SetDefaultNamespaceCalls() []struct {
 	mock.lockSetDefaultNamespace.RLock()
 	calls = mock.calls.SetDefaultNamespace
 	mock.lockSetDefaultNamespace.RUnlock()
+	return calls
+}
+
+// SetObservabilityTimeout calls SetObservabilityTimeoutFunc.
+func (mock *MockConfig) SetObservabilityTimeout(timeout metav1.Duration) {
+	if mock.SetObservabilityTimeoutFunc == nil {
+		panic("MockConfig.SetObservabilityTimeoutFunc: method is nil but IConfig.SetObservabilityTimeout was just called")
+	}
+	callInfo := struct {
+		Timeout metav1.Duration
+	}{
+		Timeout: timeout,
+	}
+	mock.lockSetObservabilityTimeout.Lock()
+	mock.calls.SetObservabilityTimeout = append(mock.calls.SetObservabilityTimeout, callInfo)
+	mock.lockSetObservabilityTimeout.Unlock()
+	mock.SetObservabilityTimeoutFunc(timeout)
+}
+
+// SetObservabilityTimeoutCalls gets all the calls that were made to SetObservabilityTimeout.
+// Check the length with:
+//
+//	len(mockedIConfig.SetObservabilityTimeoutCalls())
+func (mock *MockConfig) SetObservabilityTimeoutCalls() []struct {
+	Timeout metav1.Duration
+} {
+	var calls []struct {
+		Timeout metav1.Duration
+	}
+	mock.lockSetObservabilityTimeout.RLock()
+	calls = mock.calls.SetObservabilityTimeout
+	mock.lockSetObservabilityTimeout.RUnlock()
 	return calls
 }

--- a/lifecycle-operator/controllers/options/keptnconfig_controller.go
+++ b/lifecycle-operator/controllers/options/keptnconfig_controller.go
@@ -77,6 +77,7 @@ func (r *KeptnConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	r.config.SetCreationRequestTimeout(time.Duration(cfg.Spec.KeptnAppCreationRequestTimeoutSeconds) * time.Second)
 	r.config.SetCloudEventsEndpoint(cfg.Spec.CloudEventsEndpoint)
 	r.config.SetBlockDeployment(cfg.Spec.BlockDeployment)
+	r.config.SetBlockDeployment(cfg.Spec.ObservabilityTimeout)
 	result, err := r.reconcileOtelCollectorUrl(cfg)
 	if err != nil {
 		return result, err

--- a/lifecycle-operator/controllers/options/keptnconfig_controller.go
+++ b/lifecycle-operator/controllers/options/keptnconfig_controller.go
@@ -77,7 +77,7 @@ func (r *KeptnConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	r.config.SetCreationRequestTimeout(time.Duration(cfg.Spec.KeptnAppCreationRequestTimeoutSeconds) * time.Second)
 	r.config.SetCloudEventsEndpoint(cfg.Spec.CloudEventsEndpoint)
 	r.config.SetBlockDeployment(cfg.Spec.BlockDeployment)
-	r.config.SetBlockDeployment(cfg.Spec.ObservabilityTimeout)
+	r.config.SetObservabilityTimeout(cfg.Spec.ObservabilityTimeout)
 	result, err := r.reconcileOtelCollectorUrl(cfg)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
part-of: #3134

Depends on: https://github.com/keptn/lifecycle-toolkit/pull/3149