### PR TITLE
docs: test docdiff beta feature

### DIFF
--- a/docs/docs/guides/auto-app-discovery.md
+++ b/docs/docs/guides/auto-app-discovery.md
@@ -26,6 +26,8 @@ that names this `KeptnApp` and identifies the Namespace where it resides.
 It also includes a `spec.workloads` list
 that defines the workloads to be included.
 
+This is a test paragraph that should be marked by the docdiff addon.
+
 As an example, consider the following application,
 consisting of multiple deployments,
 which is going to be deployed into a Keptn-enabled namespace.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -13,6 +13,12 @@
   {{ super() }}
 {% endblock %}
 
+{% block content %}}
+<div role="main">
+{{ super() }}
+</div>
+{% endblock %}}
+
 <!-- More minimal footer -->
 {% block footer %}
 <footer class="md-footer">

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -13,7 +13,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block content %}}
+{% block content %}
 <div role="main">
 {{ super() }}
 </div>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -13,7 +13,7 @@
   {{ super() }}
 {% endblock %}
 
-{% block content %}
+{% block container %}
 <div role="main">
 {{ super() }}
 </div>


### PR DESCRIPTION
notes:
- the addon can be enabled by pressing `D` on the keyboard when focussed on the docs page preview
- the addon make use of a main element that has the `role=main` attribute which we currently don't have