### PR TITLE
docs: add Example section to KeptnTask CRD ref

### DIFF
--- a/docs/docs/reference/crd-reference/task.md
+++ b/docs/docs/reference/crd-reference/task.md
@@ -131,6 +131,8 @@ you must update the value of the `metadata.name` field.
 A common practice is to just increment the value incrementally,
 so `helloworldtask-1` becomes `helloworldtask-2`, etc.
 
+## Example
+
 For a full example of how to create a `KeptnTask` resource
 to use for a deployment being done outside of Kubernetes, see
 [Keptn for Non-Kubernetes Applications](../../use-cases/non-k8s.md).
@@ -147,4 +149,5 @@ in Keptn v0.8.0.
 ## See also
 
 * [KeptnTaskDefinition](taskdefinition.md)
+* [Keptn for Non-Kubernetes Applications](../../use-cases/non-k8s.md)
 * [Keptn for Non-Kubernetes Applications](../../use-cases/non-k8s.md)

--- a/docs/docs/reference/crd-reference/task.md
+++ b/docs/docs/reference/crd-reference/task.md
@@ -150,4 +150,3 @@ in Keptn v0.8.0.
 
 * [KeptnTaskDefinition](taskdefinition.md)
 * [Keptn for Non-Kubernetes Applications](../../use-cases/non-k8s.md)
-* [Keptn for Non-Kubernetes Applications](../../use-cases/non-k8s.md)


### PR DESCRIPTION
# Summary

Adds "Example" subsection to `KeptnTask` CRD reference.  This just includes an existing sentence that references the guide chapter but it means that users can use the ref page to quickly locate an example.

Also added link to that guide chapter in the "See also" section.

Fixes # https://github.com/keptn/lifecycle-toolkit/issues/3178

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [x] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
