### PR TITLE
chore: pin GHA deps, set default readonly in GHA

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -207,8 +207,8 @@ jobs:
       - build_image
     strategy:
       matrix:
-        scheduling-gates: [ gates_on, gates_off ]
-        allowed-namespaces: [ allowed_ns_on, allowed_ns_off ]
+        scheduling-gates: [gates_on, gates_off]
+        allowed-namespaces: [allowed_ns_on, allowed_ns_off]
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       scheduling-gates: ${{ matrix.scheduling-gates }}
@@ -217,14 +217,14 @@ jobs:
 
   load-tests:
     name: Load Tests
-    needs: [ prepare_ci_run, build_image ]
+    needs: [prepare_ci_run, build_image]
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/load-test.yml
 
   e2e_tests:
     name: End to End Tests
-    needs: [ prepare_ci_run, build_image ]
+    needs: [prepare_ci_run, build_image]
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/e2e-test.yml
@@ -232,7 +232,7 @@ jobs:
   helm_charts_publish:
     name: Publish helm chart changes to charts repo
     if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
-    needs: [ prepare_ci_run, build_image ]
+    needs: [prepare_ci_run, build_image]
     strategy:
       matrix:
         config:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,6 +16,9 @@ on:
       - "mkdocs.yml"
       - ".github/actions/spelling/*"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   GO_VERSION: "~1.20"
   # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,11 +43,11 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Extract branch name
         id: extract_branch
-        uses: keptn/gh-action-extract-branch-name@main
+        uses: keptn/gh-action-extract-branch-name@6ca4fe061da10c66b2d7341fd1fb12962ad911b2 # pin@main
 
       - name: Get current date and time
         id: get_datetime
@@ -91,10 +91,10 @@ jobs:
             folder: "keptn-cert-manager/"
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -106,7 +106,7 @@ jobs:
         run: make unit-test
 
       - name: Report code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # pin@v4
         with:
           flags: ${{ matrix.config.name }}
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -138,21 +138,21 @@ jobs:
             folder: "keptn-cert-manager/"
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Cache build tools
         id: cache-build-tools
-        uses: actions/cache@v4
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # pin@v4
         with:
           path: ./${{ matrix.config.folder }}bin
           key: build-tools-${{ github.ref_name }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # pin@v3
 
       - name: Build Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v5
         with:
           context: ${{ matrix.config.folder }}
           platforms: linux/amd64,linux/arm64
@@ -172,7 +172,7 @@ jobs:
           outputs: type=oci,dest=/tmp/${{ matrix.config.name }}-image.tar
 
       - name: Upload image as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: ${{ matrix.config.name }}-image.tar
           path: /tmp/${{ matrix.config.name }}-image.tar
@@ -188,7 +188,7 @@ jobs:
         run: echo "" > tag
 
       - name: Upload tag for tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: dev-${{ env.DATETIME }}
           path: tag
@@ -207,8 +207,8 @@ jobs:
       - build_image
     strategy:
       matrix:
-        scheduling-gates: [gates_on, gates_off]
-        allowed-namespaces: [allowed_ns_on, allowed_ns_off]
+        scheduling-gates: [ gates_on, gates_off ]
+        allowed-namespaces: [ allowed_ns_on, allowed_ns_off ]
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
       scheduling-gates: ${{ matrix.scheduling-gates }}
@@ -217,14 +217,14 @@ jobs:
 
   load-tests:
     name: Load Tests
-    needs: [prepare_ci_run, build_image]
+    needs: [ prepare_ci_run, build_image ]
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/load-test.yml
 
   e2e_tests:
     name: End to End Tests
-    needs: [prepare_ci_run, build_image]
+    needs: [ prepare_ci_run, build_image ]
     with:
       runtime_tag: dev-${{ needs.prepare_ci_run.outputs.DATETIME }}
     uses: ./.github/workflows/e2e-test.yml
@@ -232,7 +232,7 @@ jobs:
   helm_charts_publish:
     name: Publish helm chart changes to charts repo
     if: github.event_name == 'push' && needs.prepare_ci_run.outputs.NON_FORKED_AND_NON_ROBOT_RUN == 'true'
-    needs: [prepare_ci_run, build_image]
+    needs: [ prepare_ci_run, build_image ]
     strategy:
       matrix:
         config:
@@ -247,10 +247,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out keptn repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Check out helm-charts repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           repository: 'keptn/lifecycle-toolkit-charts'
           path: ./helm-charts-repository
@@ -272,7 +272,7 @@ jobs:
         run: rsync -av --delete --exclude='charts/*.tgz' ./${{ matrix.config.path }}/ ./helm-charts-repository/charts/${{ matrix.config.name }}/
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # pin@v6
         with:
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
           path: ./helm-charts-repository

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -34,7 +34,7 @@ jobs:
         run: make component-test
 
       - name: Report code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # pin@v4
         with:
           flags: component-tests
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -4,6 +4,10 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: false
+
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   GO_VERSION: "~1.20"
 defaults:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,6 +6,10 @@ on:
         description: "Tag for the runner image"
         type: "string"
         required: true
+
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   GO_VERSION: "~1.20"
 defaults:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -29,7 +29,7 @@ jobs:
             folder: "scheduler/"
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Setup cluster
         uses: ./.github/actions/deploy-keptn-on-cluster
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload ${{ matrix.config.name }} cluster logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: logs-e2e-tests-${{ matrix.config.name }}
           path: .github/scripts/logs

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -7,6 +7,9 @@ on:
     - cron: "0 23 * * *"
   workflow_dispatch: # Allow for running this manually.
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   snapshot:
     name: github-repo-stats

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -5,9 +5,10 @@ on:
     # Run this once per day, towards the end of the day for keeping the most
     # recent data point most meaningful (hours are interpreted in UTC).
     - cron: "0 23 * * *"
-  workflow_dispatch: # Allow for running this manually.
+  workflow_dispatch:
+    # Allow for running this manually.
 
-# Declare default permissions as read only.
+    # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
     steps:
       - name: run-ghrs
         # Use latest release.
-        uses: jgehrcke/github-repo-stats@v1.4.2
+        uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa # pin@v1.4.2
         with:
           databranch: github-repo-stats
           ghtoken: ${{ secrets.KEPTN_BOT_TOKEN }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,15 +41,15 @@ jobs:
             folder: "keptn-cert-manager/"
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # pin@v4
         with:
           working-directory: ${{ matrix.config.folder }}
           version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,6 +15,10 @@ on:
       - ".golangci.yml"
       - ".github/workflows/golangci-lint.yml"
       - "!docs/**"
+
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   # renovate: datasource=github-releases depName=golangci/golangci-lint
   GOLANGCI_LINT_VERSION: "v1.55.2"

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -14,6 +14,10 @@ on:
     paths:
       - 'docs/**'
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 jobs:
   htmltest:
     # The type of runner that the job will run on

--- a/.github/workflows/htmltest.yaml
+++ b/.github/workflows/htmltest.yaml
@@ -17,7 +17,6 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-
 jobs:
   htmltest:
     # The type of runner that the job will run on
@@ -26,13 +25,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           submodules: true
           fetch-depth: 0
 
       - name: Cache HTMLTest packages
-        uses: actions/cache@v4
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # pin@v4
         with:
           path: |
             tmp/.htmltest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Setup cluster
         uses: ./.github/actions/deploy-keptn-on-cluster
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/deploy-prometheus-on-cluster
 
       - name: Install Chainsaw
-        uses: kyverno/action-install-chainsaw@v0.1.8
+        uses: kyverno/action-install-chainsaw@4932dd3a67eedf380e704f5c294851a2f83c638f # pin@v0.1.8
 
       - name: Run Scheduling Gates Integration Tests
         if: inputs.scheduling-gates == 'gates_on' && inputs.allowed-namespaces == 'allowed_ns_off'
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload cluster logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: logs-integration-tests-${{ inputs.scheduling-gates }}-${{ inputs.allowed-namespaces }}
           path: .github/scripts/logs

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,6 +14,10 @@ on:
         description: "Decides whether to allow only certain namespaces"
         type: "string"
         default: allowed_ns_off
+
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   GO_VERSION: "~1.20"
 defaults:

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -6,6 +6,10 @@ on:
         description: "Tag for the runner images"
         type: "string"
         required: true
+
+# Declare default permissions as read only.
+permissions: read-all
+
 env:
   GO_VERSION: "~1.20"
   # renovate: datasource=github-tags depName=cloud-bulldozer/kube-burner

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Cache build tools
         id: cache-build-tools
-        uses: actions/cache@v4
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # pin@v4
         with:
           path: /usr/local/bin/kube-burner
           key: kube-burner-${{ env.KUBE_BURNER_VERSION }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: load-tests-results
           path: ./collected-metrics
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload cluster logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: logs-load-tests
           path: .github/scripts/logs

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -21,7 +21,6 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-
 env:
   GO_VERSION: "~1.20"
 
@@ -33,8 +32,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # pin@v1
         with:
           config-file: '.github/mlc_config.json'
           use-verbose-mode: true
@@ -46,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Run TOC generation
         run: |
@@ -73,10 +72,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -18,6 +18,10 @@ on:
       - 'lifecycle-operator/apis/**'
       - 'metrics-operator/api/**'
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 env:
   GO_VERSION: "~1.20"
 

--- a/.github/workflows/release-examples.yml
+++ b/.github/workflows/release-examples.yml
@@ -18,6 +18,10 @@ on:
         default: false
         required: false
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 jobs:
   release-examples:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-examples.yml
+++ b/.github/workflows/release-examples.yml
@@ -21,23 +21,22 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-
 jobs:
   release-examples:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Checkout examples repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           repository: keptn-sandbox/lifecycle-toolkit-examples
           path: ${{ inputs.examples_dir }}
           token: ${{ secrets.KEPTN_BOT_TOKEN }}
 
       - name: Get Latest Release Information
-        uses: octokit/request-action@v2.1.9
+        uses: octokit/request-action@89697eb6635e52c6e1e5559f15b5c91ba5100cb0 # pin@v2.1.9
         id: latest_release
         with:
           route: GET /repos/:owner/:repository/releases/latest
@@ -52,7 +51,7 @@ jobs:
 
       - name: Push content
         if: inputs.dry_run != true
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # pin@v9
         with:
           default_author: github_actions
           cwd: ${{ inputs.examples_dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,8 @@ on:
       - "[0-9]+.[0-9]+.x"
   workflow_dispatch:
 
-# Declare default permissions as read only.
+    # Declare default permissions as read only.
 permissions: read-all
-
 
 defaults:
   run:
@@ -39,11 +38,11 @@ jobs:
       BUILD_TIME: ${{ steps.get_datetime.outputs.BUILD_TIME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Extract branch name
         id: extract_branch
-        uses: keptn/gh-action-extract-branch-name@main
+        uses: keptn/gh-action-extract-branch-name@6ca4fe061da10c66b2d7341fd1fb12962ad911b2 # pin@main
 
       - name: Get current date and time
         id: get_datetime
@@ -54,7 +53,7 @@ jobs:
           echo "BUILD_TIME=$BUILD_TIME" >> "$GITHUB_OUTPUT"
 
       - name: Run release please
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # pin@v3
         id: release
         with:
           command: manifest
@@ -82,7 +81,7 @@ jobs:
 
       - name: Create release matrix
         id: build-matrix
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7
         env:
           CHANGED_ITEMS: ${{ steps.release.outputs.paths_released }}
           KEPTN_TAG: ${{ steps.release.outputs.tag_name }}
@@ -150,23 +149,23 @@ jobs:
       GIT_SHA: ${{ needs.release-please.outputs.GIT_SHA }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           submodules: recursive
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # pin@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # pin@v3
         with:
           registry: "ghcr.io"
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Cosign
-        uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
+        uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # pin@v3.4.0
 
       - name: Clean up image tag
         id: clean-image-tag
@@ -184,7 +183,7 @@ jobs:
 
       - name: Build Docker Image
         id: docker_build_image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v5
         with:
           context: ${{ matrix.config.folder }}
           platforms: linux/amd64,linux/arm64
@@ -213,14 +212,14 @@ jobs:
             ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0.15.8
+        uses: anchore/sbom-action@b6a39da80722a2cb0ef5d197531764a89b5d48c3 # pin@v0.15.8
         with:
           image: ${{ env.IMAGE_NAME }}:${{ steps.clean-image-tag.outputs.IMAGE_TAG }}
           artifact-name: sbom-${{ matrix.config.name }}
           output-file: ./sbom-${{ matrix.config.name }}.spdx.json
 
       - name: Attach SBOM to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1
         with:
           tag_name: ${{ matrix.config.tagName }}
           files: ./sbom-${{ matrix.config.name }}.spdx.json
@@ -239,7 +238,7 @@ jobs:
             ${{ env.IMAGE_NAME }}@${{ env.IMAGE_DIGEST }}
 
       - name: Upload verification log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: cosign-attest-verification-log
           path: ./cosign-attest-output.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
       - "[0-9]+.[0-9]+.x"
   workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -8,6 +8,10 @@ on:
         description: 'Take CI build artifacts from branch (e.g., master, release-x.y.z)'
         required: true
         default: 'main'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -289,7 +289,7 @@ jobs:
   create_issue:
     name: Create GitHub Issue
     runs-on: ubuntu-22.04
-    needs: [ security-scans, govulncheck, trivy ]
+    needs: [security-scans, govulncheck, trivy]
     if: failure() && github.event_name == 'schedule'
     steps:
       - name: Formulate bug issue

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -54,7 +54,7 @@ jobs:
           echo "RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts from last successful build of target branch
-        uses: dawidd6/action-download-artifact@v3.1.2
+        uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67 # pin@v3.1.2
         id: download_artifacts_push
         with:
           # Download last successful artifact from a CI build
@@ -65,14 +65,14 @@ jobs:
           path: ./dist
 
       - name: Upload tag
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: tag
           path: |
             ./dist/dev-*/
 
       - name: Upload images
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: images
           path: |
@@ -99,21 +99,21 @@ jobs:
     steps:
       - name: Set up Go
         if: matrix.tool == 'kubeconform'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: false
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           fetch-depth: 0
           submodules: 'true'
 
       - name: Download tag
         id: download_manifests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v4
         with:
           name: tag
           path: tag
@@ -148,7 +148,7 @@ jobs:
 
       - name: KICS Scan
         if: matrix.tool == 'kics'
-        uses: Checkmarx/kics-github-action@v1.7.0
+        uses: Checkmarx/kics-github-action@8a44970e3d2eca668be41abe9d4e06709c3b3609 # pin@v1.7.0
         with:
           path: scans
           config_path: .github/kics-config.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload KICS results
         if: always() && matrix.tool == 'kics'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # pin@v4
         with:
           name: kics-results
           path: results.json
@@ -224,14 +224,14 @@ jobs:
           - "certificate-operator"
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           fetch-depth: 0
           submodules: 'true'
 
       - name: Download images
         id: download_images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # pin@v4
         with:
           name: images
           path: images
@@ -242,7 +242,7 @@ jobs:
 
       - name: Trivy image scan scheduler
         if: matrix.image == 'scheduler'
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # 0.18.0
+        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@0.18.0
         with:
           input: "images/${{ matrix.image }}-image.tar"
           severity: 'CRITICAL,HIGH'
@@ -251,7 +251,7 @@ jobs:
 
       - name: Trivy image scan
         if: matrix.image != 'scheduler'
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # 0.18.0
+        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@0.18.0
         with:
           input: "images/${{ matrix.image }}-image.tar"
           severity: 'CRITICAL,HIGH'
@@ -270,14 +270,14 @@ jobs:
           - "keptn-cert-manager"
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5
         with:
           cache-dependency-path: ${{ matrix.artifact }}/go.sum
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -289,7 +289,7 @@ jobs:
   create_issue:
     name: Create GitHub Issue
     runs-on: ubuntu-22.04
-    needs: [security-scans, govulncheck, trivy]
+    needs: [ security-scans, govulncheck, trivy ]
     if: failure() && github.event_name == 'schedule'
     steps:
       - name: Formulate bug issue
@@ -311,7 +311,7 @@ jobs:
           echo "Note: This issue was auto-generated from [security-scan.yml](.github/workflows/security-scan.yml)" >> security-scan-failure.md
 
       - name: Create issue if versions differ
-        uses: JasonEtco/create-an-issue@v2.9.2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # pin@v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/set-date.yml
+++ b/.github/workflows/set-date.yml
@@ -3,6 +3,10 @@ name: Set the Date in the project
 on:
   issues:
     types: [assigned, closed]
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   set_date:
     runs-on: ubuntu-22.04

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -9,6 +9,10 @@ on:
       - 'reopened'
       - 'synchronize'
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 jobs:
   spelling:
     name: Check Spelling

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -38,7 +38,25 @@ jobs:
           post_comment: 0
           use_magic_file: 1
           report-timing: 1
-          warnings: bad-regex binary-file deprecated-feature large-file limited-references no-newline-at-eof noisy-file non-alpha-in-dictionary token-is-substring unexpected-line-ending whitespace-in-dictionary minified-file unsupported-configuration no-files-to-check
+          warnings:
+            bad-regex
+            binary-file
+            deprecated-feature
+            large-file
+            limited-references
+            no-newline-at-eof
+            noisy-file
+            non-alpha-in-dictionary
+            token-is-substring
+            unexpected-line-ending
+            whitespace-in-dictionary
+            minified-file
+            unsupported-configuration
+            no-files-to-check
           use_sarif: false
           extra_dictionary_limit: 20
-          extra_dictionaries: cspell:software-terms/dict/softwareTerms.txt cspell:k8s/dict/k8s.txt cspell:golang/dict/go.txt cspell:html/dict/html.txt
+          extra_dictionaries:
+            cspell:software-terms/dict/softwareTerms.txt
+            cspell:k8s/dict/k8s.txt
+            cspell:golang/dict/go.txt
+            cspell:html/dict/html.txt

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -12,7 +12,6 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-
 jobs:
   spelling:
     name: Check Spelling
@@ -30,7 +29,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.22
+        uses: check-spelling/check-spelling@00c989c97749eb0cb2d256bdc55ac61b0096c6d3 # pin@v0.0.22
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && 1 }}
           checkout: true
@@ -39,25 +38,7 @@ jobs:
           post_comment: 0
           use_magic_file: 1
           report-timing: 1
-          warnings:
-            bad-regex
-            binary-file
-            deprecated-feature
-            large-file
-            limited-references
-            no-newline-at-eof
-            noisy-file
-            non-alpha-in-dictionary
-            token-is-substring
-            unexpected-line-ending
-            whitespace-in-dictionary
-            minified-file
-            unsupported-configuration
-            no-files-to-check
+          warnings: bad-regex binary-file deprecated-feature large-file limited-references no-newline-at-eof noisy-file non-alpha-in-dictionary token-is-substring unexpected-line-ending whitespace-in-dictionary minified-file unsupported-configuration no-files-to-check
           use_sarif: false
           extra_dictionary_limit: 20
-          extra_dictionaries:
-            cspell:software-terms/dict/softwareTerms.txt
-            cspell:k8s/dict/k8s.txt
-            cspell:golang/dict/go.txt
-            cspell:html/dict/html.txt
+          extra_dictionaries: cspell:software-terms/dict/softwareTerms.txt cspell:k8s/dict/k8s.txt cspell:golang/dict/go.txt cspell:html/dict/html.txt

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,15 +5,14 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
-# Declare default permissions as read only.
+    # Declare default permissions as read only.
 permissions: read-all
-
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # pin@v9
         with:
           days-before-stale: 60
           days-before-close: 7
@@ -30,7 +29,7 @@ jobs:
   stale-good-first-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # pin@v9
         with:
           days-before-stale: 21
           stale-issue-message: |
@@ -42,7 +41,7 @@ jobs:
           only-issue-labels: 'good first issue'
           stale-issue-label: 'update-requested'
 
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # pin@v9
         with:
           days-before-stale: 28
           stale-issue-message: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -2,6 +2,10 @@ name: Set PR Labels
 
 on:
   pull_request_target:
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   set-labels:
     permissions:

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -3,7 +3,7 @@ name: Set PR Labels
 on:
   pull_request_target:
 
-# Declare default permissions as read only.
+    # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Update Labels
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # pin@v5
         with:
           sync-labels: true

--- a/.github/workflows/validate-helm-chart.yml
+++ b/.github/workflows/validate-helm-chart.yml
@@ -16,7 +16,6 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-
 defaults:
   run:
     shell: bash
@@ -37,10 +36,10 @@ jobs:
             path: keptn-cert-manager/chart
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # pin@v4.0.2
         with:
           node-version: 16
 
@@ -74,7 +73,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Check if Helm template is up to date
         run: ./.github/scripts/helm-test.sh

--- a/.github/workflows/validate-helm-chart.yml
+++ b/.github/workflows/validate-helm-chart.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - "**/chart/**"
 
+# Declare default permissions as read only.
+permissions: read-all
+
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -5,6 +5,10 @@ on:
       - opened
       - edited
       - synchronize
+
+# Declare default permissions as read only.
+permissions: read-all
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Validate Pull Request
-        uses: amannn/action-semantic-pull-request@v5.4.0
+        uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # pin@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/yaml-checks.yaml
+++ b/.github/workflows/yaml-checks.yaml
@@ -19,6 +19,10 @@ on:
       - '**.yaml'
       - '**.yml'
       - '.yamllint'
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   yamllint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/yaml-checks.yaml
+++ b/.github/workflows/yaml-checks.yaml
@@ -27,7 +27,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
 
       - name: Lint YAML files
         run: make yamllint

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -7,8 +7,8 @@ comments: true
 This is the documentation homepage.
 If you are new to Keptn, please check out the following sections:
 
-- [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about
-- [Get Started](./getting-started/index.md) helps you get going with your first use cases for Keptn
+- [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about.
+- [Get Started](./getting-started/index.md) helps you get going with your first use cases for Keptn.
 - [Installation](./installation/index.md) guides you through
 the installation procedure for Keptn
 and provides information about special configuration options

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -7,8 +7,8 @@ comments: true
 This is the documentation homepage.
 If you are new to Keptn, please check out the following sections:
 
-- [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about.
-- [Get Started](./getting-started/index.md) helps you get going with your first use cases for Keptn.
+- [Core Concepts](./core-concepts/index.md) will help you understand what Keptn is all about
+- [Get Started](./getting-started/index.md) helps you get going with your first use cases for Keptn
 - [Installation](./installation/index.md) guides you through
 the installation procedure for Keptn
 and provides information about special configuration options


### PR DESCRIPTION
### This PR
- sets all workflows to readonly by default
- pins all github actions deps to a commit hash