### PR TITLE
docs: corrected grammatical error in Keptn Metrics

### DIFF
--- a/docs/docs/getting-started/metrics.md
+++ b/docs/docs/getting-started/metrics.md
@@ -29,8 +29,7 @@ Each has plugins but it is difficult to maintain them,
 especially if you are using multiple tools,
 and multiple observability platforms,
 and multiple instances of some tools or observability platforms.
-The Keptn metrics feature unites all these metrics
-integrates metrics from all these sources into a single set of metrics.
+The Keptn metrics feature unites metrics from all these sources into a single set.
 
 ## Using this exercise
 


### PR DESCRIPTION
# Description

<!-- DOCS SECTION -->
<!-- USE THIS FOR DOCS CONTRIBUTIONS -->

# Summary

There is redundancy with the repetition of the word "metrics" in the last sentence of the third paragraph of the Keptn Metrics section in the file [lifecycle-toolkit/docs/docs/getting-started/metrics.md](https://github.com/keptn/lifecycle-toolkit/blob/main/docs/docs/getting-started/metrics.md#keptn-metrics)

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
