### PR TITLE
made doc changes

### DIFF
--- a/docs/docs/contribute/docs/markdownlint.md
+++ b/docs/docs/contribute/docs/markdownlint.md
@@ -1,0 +1,40 @@
+---
+comments: true
+---
+
+# Markdownlint
+
+We are using [markdownlint](https://github.com/DavidAnson/markdownlint) to ensure consistent styling
+within our Markdown files.
+Specifically we are using [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli).
+
+>
+We are using `GNU make` to ensure the same functionality locally and within our CI builds.
+This should allow easier debugging and problem resolution.
+
+## Markdownlint execution
+
+To verify that your markdown code conforms to the rules, run the following on your local branch:
+
+```shell
+make markdownlint
+```
+
+To use the auto-fix option, run:
+
+```shell
+make markdownlint-fix
+```
+
+## Markdownlint Configuration
+
+We use the default configuration values for `markdownlint`.
+
+This means:
+
+[.markdownlint-cli2.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/.markdownlint-cli2.yaml)
+contains the rule configuration
+
+We use the default values, so tools like
+[markdownlint for VSCode](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+can be used without additional configuration.

--- a/docs/docs/contribute/software/golangci-lint.md
+++ b/docs/docs/contribute/software/golangci-lint.md
@@ -2,18 +2,17 @@
 comments: true
 ---
 
-# Linter Requirements
+# Golangci-lint
 
-This project uses a set of linters to ensure good code quality.
+This project uses Golangci-lint to ensure good code quality.
 In order to make proper use of those linters inside an IDE,
 the following configuration is required.
 
-## Golangci-lint
 
 Further information can also be found in
 the [`golangci-lint` documentation](https://golangci-lint.run/usage/integrations/).
 
-### Visual Studio Code
+## Visual Studio Code
 
 In Visual Studio Code the
 [Golang](https://marketplace.visualstudio.com/items?itemName=aldijav.golangwithdidi)
@@ -43,7 +42,7 @@ configuration file enables all linters used in this project.
 },
 ```
 
-### GoLand / IntelliJ requirements
+## GoLand / IntelliJ requirements
 
 * Install either the **GoLand** or **IntelliJ**  Integrated Development Environment
 (IDE) for the Go programming language, plus the [Go Linter](https://plugins.jetbrains.com/plugin/12496-go-linter) plugin.
@@ -61,40 +60,3 @@ If you are on Windows, you need to install **make** for the above process to com
 > **Note**
 When using the make command on Windows, you may receive an `unrecognized command` error for a command that is installed.
 This usually indicates that `PATH` for the binary is not set correctly).
-
-## Markdownlint
-
-We are using [markdownlint](https://github.com/DavidAnson/markdownlint) to ensure consistent styling
-within our Markdown files.
-Specifically we are using [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli).
-
->
-We are using `GNU make` to ensure the same functionality locally and within our CI builds.
-This should allow easier debugging and problem resolution.
-
-### Markdownlint execution
-
-To verify that your markdown code conforms to the rules, run the following on your local branch:
-
-```shell
-make markdownlint
-```
-
-To use the auto-fix option, run:
-
-```shell
-make markdownlint-fix
-```
-
-### Markdownlint Configuration
-
-We use the default configuration values for `markdownlint`.
-
-This means:
-
-[.markdownlint-cli2.yaml](https://github.com/keptn/lifecycle-toolkit/blob/main/.markdownlint-cli2.yaml)
-contains the rule configuration
-
-We use the default values, so tools like
-[markdownlint for VSCode](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
-can be used without additional configuration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,11 +212,12 @@ nav:
           - docs/contribute/software/index.md
           - Software development environment: docs/contribute/software/dev-environ.md
           - Add a metrics provider: docs/contribute/software/add-new-metric-provider.md
+          - Add Golangci-lint: docs/contribute/software/golangci-lint.md
       - Documentation contributions:
           - docs/contribute/docs/index.md
           - Contribution guidelines for documentation: docs/contribute/docs/contrib-guidelines-docs.md
           - Build Documentation Locally: docs/contribute/docs/local-building.md
-          - Linter Requirements: docs/contribute/docs/linter-requirements.md
+          - Markdown Linting: docs/contribute/docs/markdownlint.md
           - Source File Structure: docs/contribute/docs/source-file-structure.md
           - Coding the docs: docs/contribute/docs/code-docs.md
           - Spell Checker: docs/contribute/docs/spell-check.md


### PR DESCRIPTION
# Summary

Separates the markdown lint page and the golangci-lint page , in appropriate locations, as described in the issue.

Fixes #3139

# Checks

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)(
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines))
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My content follows the style guidelines of this project (YAMLLint, markdown-lint)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my content including grammar and typo errors and also checked the rendered page
  from the Netlify deploy preview
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
