### PR TITLE
chore: bump Go base images and pipelines version to 1.21

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,7 +20,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
   # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
   CONTROLLER_TOOLS_VERSION: "v0.13.0"
   ENVTEST_K8S_VERSION: "1.24.2"

--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ permissions: read-all
 env:
   # renovate: datasource=github-releases depName=golangci/golangci-lint
   GOLANGCI_LINT_VERSION: "v1.55.2"
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
 jobs:
   golangci-lint:
     name: golangci-lint

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
 defaults:
   run:
     shell: bash

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
   # renovate: datasource=github-tags depName=cloud-bulldozer/kube-burner
   KUBE_BURNER_VERSION: "v1.7.11"
 defaults:

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -22,7 +22,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
 
 defaults:
   run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
   # renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
   CONTROLLER_TOOLS_VERSION: "v0.13.0"
   SCHEDULER_COMPATIBLE_K8S_VERSION: "v0.24.3"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 env:
-  GO_VERSION: "~1.20"
+  GO_VERSION: "~1.21"
 
 jobs:
   prepare-security-scans:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: '1.20'
+  go: "~1.21"
 linters:
   enable:
     - gofmt         # Gofmt checks whether code was gofmt-ed. By default, this tool runs with -s option to check for code simplification

--- a/keptn-cert-manager/Dockerfile
+++ b/keptn-cert-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.20.4-alpine3.16 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21.8-alpine3.19 AS builder
 
 ENV CGO_ENABLED=0
 

--- a/lifecycle-operator/Dockerfile
+++ b/lifecycle-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.4-alpine3.16 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21.8-alpine3.19 AS builder
 
 ENV CGO_ENABLED=0
 

--- a/metrics-operator/Dockerfile
+++ b/metrics-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.4-alpine3.16 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21.8-alpine3.19 AS builder
 
 ENV CGO_ENABLED=0
 

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.4-alpine3.16 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.21.8-alpine3.19 AS builder
 
 ENV CGO_ENABLED=0
 


### PR DESCRIPTION
Follow up for the failing security check:

https://github.com/keptn/lifecycle-toolkit/pull/3217