### PR TITLE
docs: correct container image reference to dockerhub

### DIFF
--- a/docs/docs/contribute/software/dev-environ.md
+++ b/docs/docs/contribute/software/dev-environ.md
@@ -99,7 +99,7 @@ you need to install the following on your system:
    You identify your private repository with the `RELEASE_REGISTRY=` argument
    and can add any `TAG` arguments you like.
    For example, the following command builds the environment
-   and pushes the image to the `docker.io/exampleuser` DockerHub:
+   and pushes the image to the `docker.io/exampleuser` DockerHub repository:
 
 ```shell
 make build-deploy-dev-environment RELEASE_REGISTRY=docker.io/exampleuser TAG=main

--- a/docs/docs/contribute/software/dev-environ.md
+++ b/docs/docs/contribute/software/dev-environ.md
@@ -99,7 +99,7 @@ you need to install the following on your system:
    You identify your private repository with the `RELEASE_REGISTRY=` argument
    and can add any `TAG` arguments you like.
    For example, the following command builds the environment
-   and pushes the image to the `docker.io/exampleuser` GitHub repository:
+   and pushes the image to the `docker.io/exampleuser` DockerHub:
 
 ```shell
 make build-deploy-dev-environment RELEASE_REGISTRY=docker.io/exampleuser TAG=main


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

This pull request addresses a minor documentation inaccuracy. Previously, the [second point ](https://keptn.sh/stable/docs/contribute/software/dev-environ/)in the first step section mentioned pushing the image to a GitHub repository (intended destination is Docker Hub). This change clarifies the paragraph to reflect the correct behavior: the command pushes the built image to Docker Hub.


