### PR TITLE
chore: remove not found docker repo

### DIFF
--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -8925,7 +8925,7 @@ spec:
           value: cluster.local
         - name: CERT_MANAGER_ENABLED
           value: "false"
-        image: testreg/myrep:v0.0.1
+        image: testreg/busybox:1.35
         imagePullPolicy: Always
         name: lifecycle-operator
         ports:

--- a/.github/scripts/.helm-tests/lifecycle-only/values.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/values.yaml
@@ -11,8 +11,8 @@ lifecycleOperator:
   promotionTasksEnabled: true
   lifecycleOperator:
     image:
-      repository: myrep
-      tag: v0.0.1
+      repository: busybox
+      tag: 1.35
       imagePullPolicy: Always
   scheduler:
     image:


### PR DESCRIPTION
This PR exchanges the made-up `myrep` docker repo for busybox to make renovate happy and remove some "not found" errors. Busybox is already in the list of ignored deps so it shouldn't be any additional deps burden for the team.