### PR TITLE
fix: assert keptn-cert-manager integration test more precisely

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -10,3 +10,4 @@ spec:
     assert: 6m40s
     cleanup: 6m40s
     error: 6m40s
+    exec: 6m40s

--- a/test/chainsaw/testcertificate/cert-recreates/00-assert.yaml
+++ b/test/chainsaw/testcertificate/cert-recreates/00-assert.yaml
@@ -22,3 +22,21 @@ metadata:
     control-plane: lifecycle-operator
 status:
   readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: keptn-system
+  labels:
+    control-plane: lifecycle-operator
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: keptn-system
+  labels:
+    control-plane: metrics-operator
+status:
+  phase: Running

--- a/test/chainsaw/testcertificate/cert-recreates/01-assert.yaml
+++ b/test/chainsaw/testcertificate/cert-recreates/01-assert.yaml
@@ -22,3 +22,21 @@ metadata:
     control-plane: lifecycle-operator
 status:
   readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: keptn-system
+  labels:
+    control-plane: lifecycle-operator
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: keptn-system
+  labels:
+    control-plane: metrics-operator
+status:
+  phase: Running

--- a/test/chainsaw/testcertificate/cert-recreates/02-assert.yaml
+++ b/test/chainsaw/testcertificate/cert-recreates/02-assert.yaml
@@ -24,3 +24,21 @@ metadata:
   namespace: keptn-system
 status:
   readyReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: keptn-system
+  labels:
+    control-plane: lifecycle-operator
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: keptn-system
+  labels:
+    control-plane: metrics-operator
+status:
+  phase: Running


### PR DESCRIPTION
## Description

Since the `testcertificate` integration test does restart `lifecycle-operator` and `metrics-operator` Deployments, it should properly assert that the pods are running after the restart. If this is not the case after the restart -> chainsaw continues with another test (`non-blocking-deployment`), but since the pods are not yet up and running, it fails.

Also there was a need to increase the `execTimeout` in the chainsaw configuration to allow the scripts with retry logic to be executed for longer than the default 5s