### PR TITLE
test(helm-chart): add tests for local/global values

### DIFF
--- a/.github/scripts/.helm-tests/certificates-only/result.yaml
+++ b/.github/scripts/.helm-tests/certificates-only/result.yaml
@@ -271,7 +271,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator

--- a/.github/scripts/.helm-tests/certificates-only/result.yaml
+++ b/.github/scripts/.helm-tests/certificates-only/result.yaml
@@ -5,17 +5,14 @@ kind: ServiceAccount
 metadata:
   name: certificate-operator
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: keptn
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
 ---
 # Source: keptn/charts/certManager/templates/certificate-operator-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,15 +20,12 @@ kind: ClusterRole
 metadata:
   name: certificate-operator-role
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -78,8 +72,6 @@ kind: ClusterRoleBinding
 metadata:
   name: certificate-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -87,9 +79,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,15 +96,12 @@ kind: Role
 metadata:
   name: certificate-operator-role
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
 rules:
 - apiGroups:
   - ""
@@ -140,8 +128,6 @@ kind: RoleBinding
 metadata:
   name: certificate-operator-leader-election-rolebinding
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -149,10 +135,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
-    ciao: commonannotation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -168,8 +152,6 @@ kind: RoleBinding
 metadata:
   name: certificate-operator-role-binding
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -177,9 +159,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -195,8 +176,6 @@ kind: Deployment
 metadata:
   name: certificate-operator
   namespace: "helmtests"
-  annotations:
-    ciao: commonannotation
   labels:
     app.kubernetes.io/component: keptn-cert-manager
     app.kubernetes.io/part-of: keptn
@@ -204,9 +183,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    mamma: test
 spec:
   replicas: 1
   selector:
@@ -239,7 +217,7 @@ spec:
               value: "true"
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
-          image: testreg/keptn/certificate-operator:v0.0.0
+          image: ghcr.io/keptn/certificate-operator:v0.0.0
           imagePullPolicy: IfNotPresent
           name: certificate-operator
           resources:
@@ -271,7 +249,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator

--- a/.github/scripts/.helm-tests/certificates-only/values.yaml
+++ b/.github/scripts/.helm-tests/certificates-only/values.yaml
@@ -5,13 +5,3 @@ lifecycleOperator:
   enabled: false
 metricsOperator:
   enabled: false
-
-global:
-  certManagerEnabled: true
-  imageRegistry: "testreg"
-  imagePullSecrets: []
-  commonAnnotations:
-    ciao: commonannotation
-  commonLabels:
-    mamma : "test"
-    app.kubernetes.io/version: vmyversion

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-operator-service-account.yaml
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 ---
 # Source: keptn/charts/lifecycleOperator/templates/lifecycle-manager-config.yaml
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   controller_manager_config.yaml: |
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   scheduler-config.yaml: |
@@ -114,7 +114,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 data:
   controller_manager_config.yaml: |
@@ -137,7 +137,6 @@ metadata:
   name: keptnapps.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -145,7 +144,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -499,7 +498,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -611,7 +610,6 @@ metadata:
   name: keptnappcreationrequests.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -619,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -720,7 +718,6 @@ metadata:
   name: keptnappversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -728,7 +725,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -1992,7 +1989,6 @@ metadata:
   name: keptnconfigs.options.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2000,7 +1996,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: options.keptn.sh
@@ -2081,7 +2077,6 @@ metadata:
   name: keptnevaluations.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2089,7 +2084,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2642,7 +2637,6 @@ metadata:
   name: keptnevaluationdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2650,7 +2644,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2930,7 +2924,6 @@ metadata:
   name: keptntasks.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2938,7 +2931,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -3529,7 +3522,6 @@ metadata:
   name: keptntaskdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -3537,7 +3529,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -6970,7 +6962,6 @@ metadata:
   name: keptnworkloads.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -6978,7 +6969,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -7395,7 +7386,6 @@ metadata:
   name: keptnworkloadversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -7403,7 +7393,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -8075,7 +8065,6 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -8083,7 +8072,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -8430,7 +8419,6 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -8438,7 +8426,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -9127,7 +9115,6 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9135,7 +9122,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -9276,7 +9263,6 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9284,7 +9270,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -9813,7 +9799,6 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9821,7 +9806,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -10038,7 +10023,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -10090,7 +10075,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10281,7 +10266,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10656,7 +10641,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10676,7 +10661,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
   - apiGroups:
@@ -10784,7 +10769,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -10809,7 +10794,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10830,7 +10815,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10851,7 +10836,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10872,7 +10857,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10893,7 +10878,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10914,7 +10899,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10935,7 +10920,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -10970,7 +10955,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -11015,7 +11000,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -11060,7 +11045,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -11108,7 +11093,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11132,7 +11117,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11153,7 +11138,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11174,7 +11159,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11195,7 +11180,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11216,7 +11201,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11237,7 +11222,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11259,7 +11244,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -11283,7 +11268,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -11307,7 +11292,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -11338,7 +11323,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -11364,7 +11349,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 spec:
   replicas: 1
@@ -11430,7 +11415,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -11449,7 +11434,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   replicas: 1
@@ -11558,7 +11543,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -11579,7 +11564,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   replicas: 1
@@ -11640,7 +11625,7 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-
+      
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:
@@ -11661,7 +11646,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   replicas: 1
@@ -11757,7 +11742,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator
@@ -11779,7 +11764,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -11801,7 +11786,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -11818,15 +11803,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: lifecycle-mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/part-of: "keptn"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:
@@ -11871,14 +11854,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: lifecycle-validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:
@@ -11907,14 +11888,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: metrics-validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -11430,7 +11430,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -11558,7 +11558,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -11640,7 +11640,7 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-      imagePullSecrets: []
+
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:
@@ -11757,7 +11757,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/.github/scripts/.helm-tests/default/values.yaml
+++ b/.github/scripts/.helm-tests/default/values.yaml
@@ -14,10 +14,3 @@ metricsOperator:
   enabled: true
   image:
     tag: v0.0.0
-
-global:
-  commonLabels:
-    app.kubernetes.io/version: vmyversion
-  imagePullPolicy: IfNotPresent
-  caInjectionAnnotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/lifecycle-manager-config.yaml
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   controller_manager_config.yaml: |
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   scheduler-config.yaml: |
@@ -83,7 +83,6 @@ metadata:
   name: keptnapps.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -91,7 +90,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -445,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -557,7 +556,6 @@ metadata:
   name: keptnappcreationrequests.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -565,7 +563,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -666,7 +664,6 @@ metadata:
   name: keptnappversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -674,7 +671,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -1938,7 +1935,6 @@ metadata:
   name: keptnconfigs.options.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -1946,7 +1942,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: options.keptn.sh
@@ -2027,7 +2023,6 @@ metadata:
   name: keptnevaluations.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2035,7 +2030,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2588,7 +2583,6 @@ metadata:
   name: keptnevaluationdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2596,7 +2590,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2876,7 +2870,6 @@ metadata:
   name: keptntasks.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2884,7 +2877,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -3475,7 +3468,6 @@ metadata:
   name: keptntaskdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -3483,7 +3475,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -6916,7 +6908,6 @@ metadata:
   name: keptnworkloads.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -6924,7 +6915,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -7341,7 +7332,6 @@ metadata:
   name: keptnworkloadversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -7349,7 +7339,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -8024,7 +8014,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8215,7 +8205,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8590,7 +8580,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8610,7 +8600,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8631,7 +8621,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8655,7 +8645,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8700,7 +8690,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8745,7 +8735,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8766,7 +8756,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8787,7 +8777,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8809,7 +8799,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -8833,7 +8823,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -8859,7 +8849,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   replicas: 1
@@ -8925,7 +8915,7 @@ spec:
           value: cluster.local
         - name: CERT_MANAGER_ENABLED
           value: "false"
-        image: testreg/busybox:1.35
+        image: ghcr.io/busybox:1.35
         imagePullPolicy: Always
         name: lifecycle-operator
         ports:
@@ -8968,7 +8958,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -8989,7 +8979,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   replicas: 1
@@ -9014,7 +9004,7 @@ spec:
           value: "otel-collector:4317"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: testreg/keptn/scheduler:v0.0.0
+        image: ghcr.io/keptn/scheduler:v0.0.0
         imagePullPolicy: IfNotPresent
         name: scheduler
         resources:
@@ -9050,7 +9040,7 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-
+      
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:
@@ -9062,15 +9052,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: lifecycle-mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/part-of: "keptn"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:
@@ -9115,14 +9103,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: lifecycle-validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -8968,7 +8968,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -9050,7 +9050,7 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-      imagePullSecrets: []
+
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:

--- a/.github/scripts/.helm-tests/lifecycle-only/values.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/values.yaml
@@ -1,10 +1,5 @@
 global:
   certManagerEnabled: false
-  imageRegistry: "testreg"
-  commonLabels:
-    app.kubernetes.io/version: vmyversion
-  caInjectionAnnotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
 
 lifecycleOperator:
   enabled: true

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -5,15 +5,13 @@ kind: ServiceAccount
 metadata:
   name: certificate-operator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: keptn
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -22,13 +20,11 @@ kind: ServiceAccount
 metadata:
   name: keptn-scheduler
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -41,9 +37,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
-    test/jj: test
 ---
 # Source: keptn/charts/lifecycleOperator/templates/lifecycle-manager-config.yaml
 apiVersion: v1
@@ -51,13 +46,11 @@ kind: ConfigMap
 metadata:
   name: lifecycle-manager-config
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   controller_manager_config.yaml: |
@@ -79,13 +72,11 @@ kind: ConfigMap
 metadata:
   name: scheduler-config
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   scheduler-config.yaml: |
@@ -107,8 +98,6 @@ metadata:
   name: keptnapps.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -116,7 +105,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -463,7 +452,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     cert-manager.io/inject-ca-from: 'helmtests/keptn-certs'
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -471,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -583,8 +571,6 @@ metadata:
   name: keptnappcreationrequests.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -592,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -693,8 +679,6 @@ metadata:
   name: keptnappversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -702,7 +686,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -1966,8 +1950,6 @@ metadata:
   name: keptnconfigs.options.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -1975,7 +1957,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: options.keptn.sh
@@ -2056,8 +2038,6 @@ metadata:
   name: keptnevaluations.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2065,7 +2045,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2618,8 +2598,6 @@ metadata:
   name: keptnevaluationdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2627,7 +2605,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2907,8 +2885,6 @@ metadata:
   name: keptntasks.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2916,7 +2892,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -3507,8 +3483,6 @@ metadata:
   name: keptntaskdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -3516,7 +3490,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -6949,8 +6923,6 @@ metadata:
   name: keptnworkloads.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -6958,7 +6930,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -7375,8 +7347,6 @@ metadata:
   name: keptnworkloadversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -7384,7 +7354,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -8055,13 +8025,11 @@ kind: ClusterRole
 metadata:
   name: certificate-operator-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -8109,13 +8077,11 @@ kind: ClusterRole
 metadata:
   name: keptn-scheduler
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8302,13 +8268,11 @@ kind: ClusterRole
 metadata:
   name: lifecycle-operator-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8679,13 +8643,11 @@ kind: ClusterRole
 metadata:
   name: keptn-test-lifecycleOperator-server-resources
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8701,8 +8663,6 @@ kind: ClusterRoleBinding
 metadata:
   name: certificate-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -8710,7 +8670,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8727,13 +8687,11 @@ kind: ClusterRoleBinding
 metadata:
   name: keptn-scheduler
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8750,13 +8708,11 @@ kind: ClusterRoleBinding
 metadata:
   name: lifecycle-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8773,13 +8729,11 @@ kind: Role
 metadata:
   name: certificate-operator-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -8807,8 +8761,6 @@ kind: Role
 metadata:
   name: leader-election-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -8816,7 +8768,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8857,13 +8809,11 @@ kind: Role
 metadata:
   name: lifecycle-operator-leader-election-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -8904,8 +8854,6 @@ kind: RoleBinding
 metadata:
   name: certificate-operator-leader-election-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -8913,9 +8861,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
-    test/jj: test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -8931,8 +8878,6 @@ kind: RoleBinding
 metadata:
   name: certificate-operator-role-binding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -8940,7 +8885,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8957,13 +8902,11 @@ kind: RoleBinding
 metadata:
   name: extension-apiserver-authentication-reader
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -8980,13 +8923,11 @@ kind: RoleBinding
 metadata:
   name: lifecycle-operator-leader-election-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9003,13 +8944,11 @@ kind: RoleBinding
 metadata:
   name: lifecycle-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -9026,14 +8965,12 @@ kind: Service
 metadata:
   name: lifecycle-operator-metrics-service
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     control-plane: lifecycle-operator
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -9053,13 +8990,11 @@ kind: Service
 metadata:
   name: lifecycle-webhook-service
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -9078,8 +9013,6 @@ kind: Deployment
 metadata:
   name: certificate-operator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/component: keptn-cert-manager
     app.kubernetes.io/part-of: keptn
@@ -9087,7 +9020,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 spec:
   replicas: 1
@@ -9153,7 +9086,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -9172,9 +9105,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
-    test/jj: test
 spec:
   replicas: 1
   selector:
@@ -9282,7 +9214,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -9303,9 +9235,8 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
-    test/jj: test
 spec:
   replicas: 1
   selector:
@@ -9365,7 +9296,7 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-
+      
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:
@@ -9377,16 +9308,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: lifecycle-mutating-webhook-configuration
-  annotations:
-    test/jj: test
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/part-of: "keptn"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:
@@ -9431,15 +9359,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: lifecycle-validating-webhook-configuration
-  annotations:
-    test/jj: test
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.1
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -9153,7 +9153,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -9282,7 +9282,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -9365,7 +9365,7 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-      imagePullSecrets: []
+
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/values.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/values.yaml
@@ -13,13 +13,3 @@ lifecycleOperator:
       imagePullPolicy: Never
 metricsOperator:
   enabled: false
-
-global:
-  certManagerEnabled: true
-  commonLabels:
-    app.kubernetes.io/version: vmyversion
-  commonAnnotations:
-    test/jj: test
-  imagePullPolicy: IfNotPresent
-  caInjectionAnnotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -11670,7 +11670,8 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-      imagePullSecrets: []
+      imagePullSecrets:
+        - name: registry-secret
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -11802,7 +11803,8 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+      imagePullSecrets:
+        - name: registry-secret
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -11888,7 +11890,8 @@ spec:
             path: /healthz
             port: 10259
             scheme: HTTPS
-      imagePullSecrets: []
+      imagePullSecrets:
+        - name: registry-secret
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:
@@ -12010,7 +12013,8 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+      imagePullSecrets:
+        - name: registry-secret
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -5,6 +5,9 @@ kind: ServiceAccount
 metadata:
   name: certificate-operator
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: keptn
@@ -12,6 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -20,11 +25,16 @@ kind: ServiceAccount
 metadata:
   name: keptn-scheduler
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 ---
 # Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
@@ -38,7 +48,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
+    globalAnnotation1: test1
+    globalAnnotation2: test2
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-operator-service-account.yaml
 apiVersion: v1
@@ -46,11 +60,16 @@ kind: ServiceAccount
 metadata:
   name: metrics-operator
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 ---
 # Source: keptn/charts/lifecycleOperator/templates/lifecycle-manager-config.yaml
@@ -59,11 +78,16 @@ kind: ConfigMap
 metadata:
   name: lifecycle-manager-config
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   controller_manager_config.yaml: |
@@ -85,11 +109,16 @@ kind: ConfigMap
 metadata:
   name: scheduler-config
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 data:
   scheduler-config.yaml: |
@@ -110,11 +139,16 @@ kind: ConfigMap
 metadata:
   name: metrics-operator-config
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 data:
   controller_manager_config.yaml: |
@@ -137,6 +171,9 @@ metadata:
   name: keptnapps.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -145,6 +182,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -491,6 +530,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     cert-manager.io/inject-ca-from: 'helmtests/keptn-certs'
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -499,6 +540,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -610,6 +653,9 @@ metadata:
   name: keptnappcreationrequests.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -618,6 +664,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -718,6 +766,9 @@ metadata:
   name: keptnappversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -726,6 +777,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   conversion:
@@ -1989,6 +2042,9 @@ metadata:
   name: keptnconfigs.options.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -1997,6 +2053,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: options.keptn.sh
@@ -2077,6 +2135,9 @@ metadata:
   name: keptnevaluations.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2085,6 +2146,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2637,6 +2700,9 @@ metadata:
   name: keptnevaluationdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2645,6 +2711,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -2924,6 +2992,9 @@ metadata:
   name: keptntasks.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2932,6 +3003,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -3522,6 +3595,9 @@ metadata:
   name: keptntaskdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -3530,6 +3606,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -6962,6 +7040,9 @@ metadata:
   name: keptnworkloads.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -6970,6 +7051,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -7386,6 +7469,9 @@ metadata:
   name: keptnworkloadversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -7394,6 +7480,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   group: lifecycle.keptn.sh
@@ -8065,6 +8153,9 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -8073,6 +8164,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -8419,6 +8512,9 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -8427,6 +8523,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -9115,6 +9213,9 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9123,6 +9224,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -9263,6 +9366,9 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9271,6 +9377,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -9799,6 +9907,9 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    caAnnotation1: bla
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9807,6 +9918,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -10019,11 +10132,16 @@ kind: ClusterRole
 metadata:
   name: certificate-operator-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -10071,11 +10189,16 @@ kind: ClusterRole
 metadata:
   name: keptn-scheduler
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10262,11 +10385,16 @@ kind: ClusterRole
 metadata:
   name: lifecycle-operator-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10637,11 +10765,16 @@ kind: ClusterRole
 metadata:
   name: keptn-test-lifecycleOperator-server-resources
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10657,11 +10790,16 @@ kind: ClusterRole
 metadata:
   name: metrics-operator-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
   - apiGroups:
@@ -10765,11 +10903,16 @@ kind: ClusterRole
 metadata:
   name: metrics-operator-server-resources
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -10787,6 +10930,9 @@ kind: ClusterRoleBinding
 metadata:
   name: certificate-operator-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -10795,6 +10941,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10811,11 +10959,16 @@ kind: ClusterRoleBinding
 metadata:
   name: keptn-scheduler
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10832,11 +10985,16 @@ kind: ClusterRoleBinding
 metadata:
   name: lifecycle-operator-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10853,11 +11011,16 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-operator-hpa-controller
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10874,11 +11037,16 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-operator-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10895,11 +11063,16 @@ kind: ClusterRoleBinding
 metadata:
   name: system-auth-delegator
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10916,11 +11089,16 @@ kind: Role
 metadata:
   name: certificate-operator-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -10948,6 +11126,9 @@ kind: Role
 metadata:
   name: leader-election-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -10956,6 +11137,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -10996,11 +11179,16 @@ kind: Role
 metadata:
   name: lifecycle-operator-leader-election-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 rules:
 - apiGroups:
@@ -11041,11 +11229,16 @@ kind: Role
 metadata:
   name: metrics-operator-leader-election-role
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -11086,6 +11279,9 @@ kind: RoleBinding
 metadata:
   name: certificate-operator-leader-election-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -11094,7 +11290,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
+    globalAnnotation1: test1
+    globalAnnotation2: test2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11110,6 +11310,9 @@ kind: RoleBinding
 metadata:
   name: certificate-operator-role-binding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -11118,6 +11321,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11134,11 +11339,16 @@ kind: RoleBinding
 metadata:
   name: extension-apiserver-authentication-reader
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11155,11 +11365,16 @@ kind: RoleBinding
 metadata:
   name: lifecycle-operator-leader-election-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11176,11 +11391,16 @@ kind: RoleBinding
 metadata:
   name: lifecycle-operator-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11197,11 +11417,16 @@ kind: RoleBinding
 metadata:
   name: metrics-operator-leader-election-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11218,11 +11443,16 @@ kind: RoleBinding
 metadata:
   name: metrics-operator-rolebinding
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11239,12 +11469,17 @@ kind: Service
 metadata:
   name: lifecycle-operator-metrics-service
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     control-plane: lifecycle-operator
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -11264,11 +11499,16 @@ kind: Service
 metadata:
   name: lifecycle-webhook-service
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 spec:
   type: ClusterIP
@@ -11287,12 +11527,17 @@ kind: Service
 metadata:
   name: metrics-operator-service
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     control-plane: metrics-operator
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -11319,11 +11564,16 @@ kind: Service
 metadata:
   name: metrics-webhook-service
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -11342,6 +11592,9 @@ kind: Deployment
 metadata:
   name: certificate-operator
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/component: keptn-cert-manager
     app.kubernetes.io/part-of: keptn
@@ -11350,6 +11603,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/version: v2.1.0
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: cert-manager-0.2.2
 spec:
   replicas: 1
@@ -11384,7 +11639,7 @@ spec:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
           image: global-registry.io/keptn/certificate-operator:v2.1.0
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Never
           name: certificate-operator
           resources:
             limits:
@@ -11435,7 +11690,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
+    globalAnnotation1: test1
+    globalAnnotation2: test2
 spec:
   replicas: 1
   selector:
@@ -11501,7 +11760,7 @@ spec:
         - name: CERT_MANAGER_ENABLED
           value: "true"
         image: global-registry.io/keptn/lifecycle-operator:v0.9.1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         name: lifecycle-operator
         ports:
         - containerPort: 9443
@@ -11565,7 +11824,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
+    globalAnnotation1: test1
+    globalAnnotation2: test2
 spec:
   replicas: 1
   selector:
@@ -11590,7 +11853,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
         image: global-registry.io/keptn/scheduler:v0.9.1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         name: scheduler
         resources:
           limits:
@@ -11638,6 +11901,9 @@ kind: Deployment
 metadata:
   name: metrics-operator
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/part-of: keptn
     app.kubernetes.io/component: metrics-operator
@@ -11647,6 +11913,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   replicas: 1
@@ -11695,7 +11963,7 @@ spec:
         - name: CERT_MANAGER_ENABLED
           value: "true"
         image: global-registry.io/keptn/metrics-operator:v0.9.2
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         name: metrics-operator
         ports:
         - containerPort: 9443
@@ -11760,11 +12028,16 @@ kind: APIService
 metadata:
   name: v1beta1.custom.metrics.k8s.io
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -11782,11 +12055,16 @@ kind: APIService
 metadata:
   name: v1beta2.custom.metrics.k8s.io
   namespace: "helmtests"
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -11803,6 +12081,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: lifecycle-mutating-webhook-configuration
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
+    caAnnotation1: bla
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/part-of: "keptn"
@@ -11810,6 +12092,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:
@@ -11854,12 +12138,18 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: lifecycle-validating-webhook-configuration
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
+    caAnnotation1: bla
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: lifecycle-operator
     app.kubernetes.io/version: v0.9.1
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: lifecycle-operator-0.2.2
 webhooks:
 - admissionReviewVersions:
@@ -11888,12 +12178,18 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: metrics-validating-webhook-configuration
+  annotations:
+    globalAnnotation1: test1
+    globalAnnotation2: test2
+    caAnnotation1: bla
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
     app.kubernetes.io/version: v0.9.2
+    globalLabel1: test1
+    globalLabel2: test2
     helm.sh/chart: metrics-operator-0.1.3
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -2215,6 +2215,8 @@ spec:
                 type: string
               evaluationDefinition:
                 type: string
+              failAction:
+                type: string
               retries:
                 default: 10
                 type: integer
@@ -2604,8 +2606,6 @@ spec:
                   which includes the objectives for the KeptnEvaluation.
                   The KeptnEvaluationDefinition can be
                   located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
-                type: string
-              failAction:
                 type: string
               retries:
                 default: 10

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -1,0 +1,11958 @@
+---
+# Source: keptn/charts/certManager/templates/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: certificate-operator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keptn-scheduler
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lifecycle-operator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-operator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-manager-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lifecycle-manager-config
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: ":8081"
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: "6b866dd9.keptn.sh"
+    metrics:
+      bindAddress: "127.0.0.1:8080"
+    webhook:
+      port: 9443
+---
+# Source: keptn/charts/lifecycleOperator/templates/scheduler-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scheduler-config
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
+    profiles: 
+      - plugins:
+          permit:
+            enabled:
+            - name: KLCPermit
+        schedulerName: keptn-scheduler
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-manager-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-operator-config
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    health:
+      healthProbeBindAddress: ":8081"
+    kind: ControllerManagerConfig
+    leaderElection:
+      leaderElect: true
+      resourceName: "3f8532ca.keptn.sh"
+    metrics:
+      bindAddress: "127.0.0.1:8080"
+    webhook:
+      port: 9443
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnapp-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnapps.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: 'lifecycle-webhook-service'
+          namespace: 'helmtests'
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnApp
+    listKind: KeptnAppList
+    plural: keptnapps
+    singular: keptnapp
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppSpec defines the desired state of KeptnApp
+            properties:
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                type: integer
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: KeptnAppStatus defines the observed state of KeptnApp
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnApp.
+            properties:
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnApp.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnApp is the Schema for the keptnapps API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnApp.
+            properties:
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnApp.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnappcontext-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnappcontexts.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: 'helmtests/keptn-certs'
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppContext
+    listKind: KeptnAppContextList
+    plural: keptnappcontexts
+    singular: keptnappcontext
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppContext is the Schema for the keptnappcontexts API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppContextSpec defines the desired state of KeptnAppContext
+            properties:
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              promotionTasks:
+                description: |-
+                  PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              spanLinks:
+                description: |-
+                  SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.
+                  For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: KeptnAppContextStatus defines the observed state of KeptnAppContext
+            properties:
+              status:
+                description: unused field
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnappcreationrequest-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnappcreationrequests.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppCreationRequest
+    listKind: KeptnAppCreationRequestList
+    plural: keptnappcreationrequests
+    singular: keptnappcreationrequest
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppCreationRequest is the Schema for the keptnappcreationrequests
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppCreationRequest.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp the KeptnAppCreationRequest
+                  should create if no user-defined object with that name is found.
+                type: string
+            required:
+            - appName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppCreationRequest.
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppCreationRequest is the Schema for the keptnappcreationrequests
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppCreationRequest.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp the KeptnAppCreationRequest
+                  should create if no user-defined object with that name is found.
+                type: string
+            required:
+            - appName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppCreationRequest.
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnappversion-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnappversions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: 'lifecycle-webhook-service'
+          namespace: 'helmtests'
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnAppVersion
+    listKind: KeptnAppVersionList
+    plural: keptnappversions
+    shortNames:
+    - kav
+    singular: keptnappversion
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceID is a map storing TraceIDs of OpenTelemetry
+                  spans in lifecycle phases
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    evaluationDefinitionName:
+                      type: string
+                    evaluationName:
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    endTime:
+                      format: date-time
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    taskDefinitionName:
+                      type: string
+                    taskName:
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnAppVersionSpec defines the desired state of KeptnAppVersion
+            properties:
+              appName:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                type: string
+              revision:
+                default: 1
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                type: object
+              version:
+                type: string
+              workloads:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: KeptnAppVersionStatus defines the observed state of KeptnAppVersion
+            properties:
+              currentPhase:
+                type: string
+              endTime:
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              postDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              preDeploymentTaskStatus:
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              workloadStatus:
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    workload:
+                      properties:
+                        name:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppVersion.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnApp that has
+                  been deployed prior to this version.
+                type: string
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppVersion.
+            properties:
+              currentPhase:
+                description: CurrentPhase indicates the current phase of the KeptnAppVersion.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnAppVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnAppVersion.
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnAppVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnAppVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnAppVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnAppVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnAppVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnAppVersion.
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: WorkloadOverallStatus indicates the current status of
+                  the KeptnAppVersion's Workload deployment phase.
+                type: string
+              workloadStatus:
+                description: WorkloadStatus contains the current status of each KeptnWorkload
+                  that is part of the KeptnAppVersion.
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: Status indicates the current status of the KeptnWorkload.
+                      type: string
+                    workload:
+                      description: Workload refers to a KeptnWorkload that is part
+                        of the KeptnAppVersion.
+                      properties:
+                        name:
+                          description: Name is the name of the KeptnWorkload.
+                          type: string
+                        version:
+                          description: Version is the version of the KeptnWorkload.
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.workloadOverallStatus
+      name: WorkloadOverallStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.promotionStatus
+      name: PromotionStatus
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnAppVersion is the Schema for the keptnappversions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnAppVersion.
+            properties:
+              appName:
+                description: AppName is the name of the KeptnApp.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnApp that has
+                  been deployed prior to this version.
+                type: string
+              promotionTasks:
+                description: |-
+                  PromotionTasks is a list of all tasks to be performed during the promotion phase of the KeptnApp.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              revision:
+                default: 1
+                description: |-
+                  Revision can be modified to trigger another deployment of a KeptnApp of the same version.
+                  This can be used for restarting a KeptnApp which failed to deploy,
+                  e.g. due to a failed preDeploymentEvaluation/preDeploymentTask.
+                type: integer
+              spanLinks:
+                description: |-
+                  SpanLinks are links to OpenTelemetry span IDs for tracking. These links establish relationships between spans across different services, enabling distributed tracing.
+                  For more information on OpenTelemetry span links, refer to the documentation: https://opentelemetry.io/docs/concepts/signals/traces/#span-links
+                items:
+                  type: string
+                type: array
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: |-
+                  Version defines the version of the application. For automatically created KeptnApps,
+                  the version is a function of all KeptnWorkloads that are part of the KeptnApp.
+                type: string
+              workloads:
+                description: Workloads is a list of all KeptnWorkloads that are part
+                  of the KeptnApp.
+                items:
+                  description: KeptnWorkloadRef refers to a KeptnWorkload that is
+                    part of a KeptnApp
+                  properties:
+                    name:
+                      description: Name is the name of the KeptnWorkload.
+                      type: string
+                    version:
+                      description: Version is the version of the KeptnWorkload.
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            required:
+            - appName
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnAppVersion.
+            properties:
+              currentPhase:
+                description: CurrentPhase indicates the current phase of the KeptnAppVersion.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnAppVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnAppVersion.
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnAppVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnAppVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnAppVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnAppVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              promotionStatus:
+                default: Pending
+                description: PromotionStatus indicates the current status of the KeptnAppVersion's
+                  Promotion phase.
+                type: string
+              promotionTaskStatus:
+                description: PromotionTaskStatus indicates the current state of each
+                  promotionTask of the KeptnAppVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnAppVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnAppVersion.
+                type: string
+              workloadOverallStatus:
+                default: Pending
+                description: WorkloadOverallStatus indicates the current status of
+                  the KeptnAppVersion's Workload deployment phase.
+                type: string
+              workloadStatus:
+                description: WorkloadStatus contains the current status of each KeptnWorkload
+                  that is part of the KeptnAppVersion.
+                items:
+                  properties:
+                    status:
+                      default: Pending
+                      description: Status indicates the current status of the KeptnWorkload.
+                      type: string
+                    workload:
+                      description: Workload refers to a KeptnWorkload that is part
+                        of the KeptnAppVersion.
+                      properties:
+                        name:
+                          description: Name is the name of the KeptnWorkload.
+                          type: string
+                        version:
+                          description: Version is the version of the KeptnWorkload.
+                          type: string
+                      required:
+                      - name
+                      - version
+                      type: object
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnconfig-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnconfigs.options.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: options.keptn.sh
+  names:
+    kind: KeptnConfig
+    listKind: KeptnConfigList
+    plural: keptnconfigs
+    singular: keptnconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnConfig is the Schema for the keptnconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnConfigSpec defines the desired state of KeptnConfig
+            properties:
+              OTelCollectorUrl:
+                description: OTelCollectorUrl can be used to set the Open Telemetry
+                  collector that the lifecycle operator should use
+                type: string
+              blockDeployment:
+                default: true
+                description: |-
+                  BlockDeployment is used to block the deployment of the application until the pre-deployment
+                  tasks and evaluations succeed
+                type: boolean
+              cloudEventsEndpoint:
+                description: CloudEventsEndpoint can be used to set the endpoint where
+                  Cloud Events should be posted by the lifecycle operator
+                type: string
+              keptnAppCreationRequestTimeoutSeconds:
+                default: 30
+                description: |-
+                  KeptnAppCreationRequestTimeoutSeconds is used to set the interval in which automatic app discovery
+                  searches for workload to put into the same auto-generated KeptnApp
+                type: integer
+              observabilityTimeout:
+                default: 5m
+                description: |-
+                  ObservabilityTimeout specifies the maximum time to observe the deployment phase of KeptnWorkload.
+                  If the workload does not deploy successfully within this time frame, it will be
+                  considered as failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnevaluation-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnevaluations.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnEvaluation
+    listKind: KeptnEvaluationList
+    plural: keptnevaluations
+    shortNames:
+    - ke
+    singular: keptnevaluation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                type: object
+              overallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationSpec defines the desired state of KeptnEvaluation
+            properties:
+              appName:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              evaluationDefinition:
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                type: integer
+              retryInterval:
+                default: 5s
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnEvaluationStatus defines the observed state of KeptnEvaluation
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    status:
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                type: object
+              overallStatus:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+              retryCount:
+                default: 0
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluation.
+            properties:
+              appName:
+                description: AppName defines the KeptnApp for which the KeptnEvaluation
+                  is done.
+                type: string
+              appVersion:
+                description: AppVersion defines the version of the KeptnApp for which
+                  the KeptnEvaluation is done.
+                type: string
+              checkType:
+                description: Type indicates whether the KeptnEvaluation is part of
+                  the pre- or postDeployment phase.
+                type: string
+              evaluationDefinition:
+                description: |-
+                  EvaluationDefinition refers to the name of the KeptnEvaluationDefinition
+                  which includes the objectives for the KeptnEvaluation.
+                  The KeptnEvaluationDefinition can be
+                  located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                description: Workload defines the KeptnWorkload for which the KeptnEvaluation
+                  is done.
+                type: string
+              workloadVersion:
+                description: WorkloadVersion defines the version of the KeptnWorkload
+                  for which the KeptnEvaluation is done.
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: Status describes the current state of the KeptnEvaluation.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnEvaluation
+                  finished.
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      description: |-
+                        Message contains additional information about the evaluation of an objective.
+                        This can include explanations about why an evaluation has failed (e.g. due to a missed objective),
+                        or if there was any error during the evaluation of the objective.
+                      type: string
+                    status:
+                      description: Status indicates the status of the objective being
+                        evaluated.
+                      type: string
+                    value:
+                      description: Value represents the value of the KeptnMetric being
+                        evaluated.
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                description: |-
+                  EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: object
+              overallStatus:
+                default: Pending
+                description: |-
+                  OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived
+                  from the status of the individual objectives of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: string
+              retryCount:
+                default: 0
+                description: RetryCount indicates how many times the KeptnEvaluation
+                  has been attempted already.
+                type: integer
+              startTime:
+                description: StartTime represents the time at which the KeptnEvaluation
+                  started.
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.appName
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.retryCount
+      name: RetryCount
+      type: string
+    - jsonPath: .status.evaluationStatus
+      name: EvaluationStatus
+      type: string
+    - jsonPath: .status.overallStatus
+      name: OverallStatus
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluation is the Schema for the keptnevaluations API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluation.
+            properties:
+              appName:
+                description: AppName defines the KeptnApp for which the KeptnEvaluation
+                  is done.
+                type: string
+              appVersion:
+                description: AppVersion defines the version of the KeptnApp for which
+                  the KeptnEvaluation is done.
+                type: string
+              checkType:
+                description: Type indicates whether the KeptnEvaluation is part of
+                  the pre- or postDeployment phase.
+                type: string
+              evaluationDefinition:
+                description: |-
+                  EvaluationDefinition refers to the name of the KeptnEvaluationDefinition
+                  which includes the objectives for the KeptnEvaluation.
+                  The KeptnEvaluationDefinition can be
+                  located in the same namespace as the KeptnEvaluation, or in the Keptn namespace.
+                type: string
+              failAction:
+                type: string
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              workload:
+                description: Workload defines the KeptnWorkload for which the KeptnEvaluation
+                  is done.
+                type: string
+              workloadVersion:
+                description: WorkloadVersion defines the version of the KeptnWorkload
+                  for which the KeptnEvaluation is done.
+                type: string
+            required:
+            - evaluationDefinition
+            - workloadVersion
+            type: object
+          status:
+            description: Status describes the current state of the KeptnEvaluation.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnEvaluation
+                  finished.
+                format: date-time
+                type: string
+              evaluationStatus:
+                additionalProperties:
+                  properties:
+                    message:
+                      description: |-
+                        Message contains additional information about the evaluation of an objective.
+                        This can include explanations about why an evaluation has failed (e.g. due to a missed objective),
+                        or if there was any error during the evaluation of the objective.
+                      type: string
+                    status:
+                      description: Status indicates the status of the objective being
+                        evaluated.
+                      type: string
+                    value:
+                      description: Value represents the value of the KeptnMetric being
+                        evaluated.
+                      type: string
+                  required:
+                  - status
+                  - value
+                  type: object
+                description: |-
+                  EvaluationStatus describes the status of each objective of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: object
+              overallStatus:
+                default: Pending
+                description: |-
+                  OverallStatus describes the overall status of the KeptnEvaluation. The Overall status is derived
+                  from the status of the individual objectives of the KeptnEvaluationDefinition
+                  referenced by the KeptnEvaluation.
+                type: string
+              retryCount:
+                default: 0
+                description: RetryCount indicates how many times the KeptnEvaluation
+                  has been attempted already.
+                type: integer
+              startTime:
+                description: StartTime represents the time at which the KeptnEvaluation
+                  started.
+                format: date-time
+                type: string
+            required:
+            - evaluationStatus
+            - overallStatus
+            - retryCount
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnevaluationdefinition-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnevaluationdefinitions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnEvaluationDefinition
+    listKind: KeptnEvaluationDefinitionList
+    plural: keptnevaluationdefinitions
+    shortNames:
+    - ked
+    singular: keptnevaluationdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnEvaluationDefinitionSpec defines the desired state of
+              KeptnEvaluationDefinition
+            properties:
+              objectives:
+                items:
+                  properties:
+                    evaluationTarget:
+                      type: string
+                    name:
+                      type: string
+                    query:
+                      type: string
+                  required:
+                  - evaluationTarget
+                  - name
+                  - query
+                  type: object
+                type: array
+              source:
+                type: string
+            required:
+            - objectives
+            - source
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluationDefinition.
+            properties:
+              objectives:
+                description: |-
+                  Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this
+                  KeptnEvaluationDefinition to be successful.
+                items:
+                  properties:
+                    evaluationTarget:
+                      description: |-
+                        EvaluationTarget specifies the target value for the references KeptnMetric.
+                        Needs to start with either '<' or '>', followed by the target value (e.g. '<10').
+                      type: string
+                    keptnMetricRef:
+                      description: KeptnMetricRef references the KeptnMetric that
+                        should be evaluated.
+                      properties:
+                        name:
+                          description: Name is the name of the referenced KeptnMetric.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace where the referenced
+                            KeptnMetric is located.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+            required:
+            - objectives
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnEvaluationDefinition is the Schema for the keptnevaluationdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnEvaluationDefinition.
+            properties:
+              objectives:
+                description: |-
+                  Objectives is a list of objectives that have to be met for a KeptnEvaluation referencing this
+                  KeptnEvaluationDefinition to be successful.
+                items:
+                  properties:
+                    evaluationTarget:
+                      description: |-
+                        EvaluationTarget specifies the target value for the references KeptnMetric.
+                        Needs to start with either '<' or '>', followed by the target value (e.g. '<10').
+                      type: string
+                    keptnMetricRef:
+                      description: KeptnMetricRef references the KeptnMetric that
+                        should be evaluated.
+                      properties:
+                        name:
+                          description: Name is the name of the referenced KeptnMetric.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace where the referenced
+                            KeptnMetric is located.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - evaluationTarget
+                  - keptnMetricRef
+                  type: object
+                type: array
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnEvaluation can be attempted in the case of an error or
+                  missed evaluation objective, before considering the KeptnEvaluation to be failed.
+                type: integer
+              retryInterval:
+                default: 5s
+                description: |-
+                  RetryInterval specifies the interval at which the KeptnEvaluation is retried in the case of an error
+                  or a missed objective.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - objectives
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptntask-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptntasks.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnTask
+    listKind: KeptnTaskList
+    plural: keptntasks
+    singular: keptntask
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
+                - appVersion
+                - objectType
+                - taskType
+                - workloadName
+                - workloadVersion
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskSpec defines the desired state of KeptnTask
+            properties:
+              app:
+                type: string
+              appVersion:
+                type: string
+              checkType:
+                type: string
+              context:
+                properties:
+                  appName:
+                    type: string
+                  appVersion:
+                    type: string
+                  objectType:
+                    type: string
+                  taskType:
+                    type: string
+                  workloadName:
+                    type: string
+                  workloadVersion:
+                    type: string
+                required:
+                - appName
+                - appVersion
+                - objectType
+                - taskType
+                - workloadName
+                - workloadVersion
+                type: object
+              parameters:
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              secureParameters:
+                properties:
+                  secret:
+                    type: string
+                type: object
+              taskDefinition:
+                type: string
+              workload:
+                type: string
+              workloadVersion:
+                type: string
+            required:
+            - app
+            - appVersion
+            - context
+            - taskDefinition
+            - workload
+            - workloadVersion
+            type: object
+          status:
+            description: KeptnTaskStatus defines the observed state of KeptnTask
+            properties:
+              endTime:
+                format: date-time
+                type: string
+              jobName:
+                type: string
+              message:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: KeptnState  is a string containing current Phase state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTask.
+            properties:
+              checkType:
+                description: Type indicates whether the KeptnTask is part of the pre-
+                  or postDeployment phase.
+                type: string
+              context:
+                description: Context contains contextual information about the task
+                  execution.
+                properties:
+                  appName:
+                    description: AppName the name of the KeptnApp the KeptnTask is
+                      being executed for.
+                    type: string
+                  appVersion:
+                    description: AppVersion the version of the KeptnApp the KeptnTask
+                      is being executed for.
+                    type: string
+                  objectType:
+                    description: ObjectType indicates whether the KeptnTask is being
+                      executed for a KeptnApp or KeptnWorkload.
+                    type: string
+                  taskType:
+                    description: TaskType indicates whether the KeptnTask is part
+                      of the pre- or postDeployment phase.
+                    type: string
+                  workloadName:
+                    description: WorkloadName the name of the KeptnWorkload the KeptnTask
+                      is being executed for.
+                    type: string
+                  workloadVersion:
+                    description: WorkloadVersion the version of the KeptnWorkload
+                      the KeptnTask is being executed for.
+                    type: string
+                type: object
+              parameters:
+                description: Parameters contains parameters that will be passed to
+                  the job that executes the task.
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Inline contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'DATA' environment variable.
+                      The 'DATA'  environment variable's content will be a json
+                      encoded string containing all properties of the map provided.
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnTask can be attempted in the case of an error
+                  before considering the KeptnTask to be failed.
+                format: int32
+                type: integer
+              secureParameters:
+                description: |-
+                  SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                  These will be stored and accessed as secrets in the cluster.
+                properties:
+                  secret:
+                    description: |-
+                      Secret contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                      The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                      key of the referenced secret.
+                    type: string
+                type: object
+              taskDefinition:
+                description: |-
+                  TaskDefinition refers to the name of the KeptnTaskDefinition
+                  which includes the specification for the task to be performed.
+                  The KeptnTaskDefinition can be
+                  located in the same namespace as the KeptnTask, or in the Keptn namespace.
+                type: string
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - taskDefinition
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTask.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnTask finished.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job executing the Task.
+                type: string
+              message:
+                description: Message contains information about unexpected errors
+                  encountered during the execution of the KeptnTask.
+                type: string
+              reason:
+                description: Reason contains more information about the reason for
+                  the last transition of the Job executing the KeptnTask.
+                type: string
+              startTime:
+                description: StartTime represents the time at which the KeptnTask
+                  started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall state of the KeptnTask.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.appVersion
+      name: AppVersion
+      type: string
+    - jsonPath: .spec.workload
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.workloadVersion
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.jobName
+      name: Job Name
+      type: string
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTask is the Schema for the keptntasks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTask.
+            properties:
+              checkType:
+                description: Type indicates whether the KeptnTask is part of the pre-
+                  or postDeployment phase.
+                type: string
+              context:
+                description: Context contains contextual information about the task
+                  execution.
+                properties:
+                  appName:
+                    description: AppName the name of the KeptnApp the KeptnTask is
+                      being executed for.
+                    type: string
+                  appVersion:
+                    description: AppVersion the version of the KeptnApp the KeptnTask
+                      is being executed for.
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata contains additional key-value pairs for
+                      contextual information.
+                    type: object
+                  objectType:
+                    description: ObjectType indicates whether the KeptnTask is being
+                      executed for a KeptnApp or KeptnWorkload.
+                    type: string
+                  taskType:
+                    description: TaskType indicates whether the KeptnTask is part
+                      of the pre- or postDeployment phase.
+                    type: string
+                  workloadName:
+                    description: WorkloadName the name of the KeptnWorkload the KeptnTask
+                      is being executed for.
+                    type: string
+                  workloadVersion:
+                    description: WorkloadVersion the version of the KeptnWorkload
+                      the KeptnTask is being executed for.
+                    type: string
+                type: object
+              parameters:
+                description: Parameters contains parameters that will be passed to
+                  the job that executes the task.
+                properties:
+                  map:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Inline contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'DATA' environment variable.
+                      The 'DATA'  environment variable's content will be a json
+                      encoded string containing all properties of the map provided.
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries indicates how many times the KeptnTask can be attempted in the case of an error
+                  before considering the KeptnTask to be failed.
+                format: int32
+                type: integer
+              secureParameters:
+                description: |-
+                  SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                  These will be stored and accessed as secrets in the cluster.
+                properties:
+                  secret:
+                    description: |-
+                      Secret contains the parameters that will be made available to the job
+                      executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                      The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                      key of the referenced secret.
+                    type: string
+                type: object
+              taskDefinition:
+                description: |-
+                  TaskDefinition refers to the name of the KeptnTaskDefinition
+                  which includes the specification for the task to be performed.
+                  The KeptnTaskDefinition can be
+                  located in the same namespace as the KeptnTask, or in the Keptn namespace.
+                type: string
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+            required:
+            - taskDefinition
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTask.
+            properties:
+              endTime:
+                description: EndTime represents the time at which the KeptnTask finished.
+                format: date-time
+                type: string
+              jobName:
+                description: JobName is the name of the Job executing the Task.
+                type: string
+              message:
+                description: Message contains information about unexpected errors
+                  encountered during the execution of the KeptnTask.
+                type: string
+              reason:
+                description: Reason contains more information about the reason for
+                  the last transition of the Job executing the KeptnTask.
+                type: string
+              startTime:
+                description: StartTime represents the time at which the KeptnTask
+                  started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall state of the KeptnTask.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptntaskdefinition-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptntaskdefinitions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnTaskDefinition
+    listKind: KeptnTaskDefinitionList
+    plural: keptntaskdefinitions
+    singular: keptntaskdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMap:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnTaskDefinitionSpec defines the desired state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMapRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  functionRef:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                  httpRef:
+                    properties:
+                      url:
+                        type: string
+                    type: object
+                  inline:
+                    properties:
+                      code:
+                        type: string
+                    type: object
+                  parameters:
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secureParameters:
+                    properties:
+                      secret:
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: KeptnTaskDefinitionStatus defines the observed state of KeptnTaskDefinition
+            properties:
+              function:
+                properties:
+                  configMap:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTaskDefinition.
+            properties:
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false
+                  the pod will decline the service account
+                properties:
+                  type:
+                    type: boolean
+                required:
+                - type
+                type: object
+              container:
+                description: Container contains the definition for the container that
+                  is to be used in Job.
+                properties:
+                  args:
+                    description: |-
+                      Arguments to the entrypoint.
+                      The container image's CMD is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: |-
+                      Entrypoint array. Not executed within a shell.
+                      The container image's ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take precedence.
+                      Values defined by an Env with a duplicate key will take precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Container image name.
+                      More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management to default or override
+                      container images in workload controllers like Deployments and StatefulSets.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  lifecycle:
+                    description: |-
+                      Actions that the management system should take in response to container lifecycle events.
+                      Cannot be updated.
+                    properties:
+                      postStart:
+                        description: |-
+                          PostStart is called immediately after a container is created. If the handler fails,
+                          the container is terminated and restarted according to its restart policy.
+                          Other management of the container blocks until the hook completes.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: |-
+                          PreStop is called immediately before a container is terminated due to an
+                          API request or management event such as liveness/startup probe failure,
+                          preemption, resource contention, etc. The handler is not called if the
+                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                          container will eventually terminate within the Pod's termination grace
+                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                          or until the termination grace period is reached.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: |-
+                      Periodic probe of container liveness.
+                      Container will be restarted if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: |-
+                      Name of the container specified as a DNS_LABEL.
+                      Each container in a pod must have a unique name (DNS_LABEL).
+                      Cannot be updated.
+                    type: string
+                  ports:
+                    description: |-
+                      List of ports to expose from the container. Not specifying a port here
+                      DOES NOT prevent that port from being exposed. Any port which is
+                      listening on the default "0.0.0.0" address inside a container will be
+                      accessible from the network.
+                      Modifying this array with strategic merge patch may corrupt the data.
+                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: |-
+                            Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: |-
+                            Number of port to expose on the host.
+                            If specified, this must be a valid port number, 0 < x < 65536.
+                            If HostNetwork is specified, this must match ContainerPort.
+                            Most containers do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: |-
+                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                            named port in a pod must have a unique name. Name for the port that can be
+                            referred to by services.
+                          type: string
+                        protocol:
+                          default: TCP
+                          description: |-
+                            Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: |-
+                      Periodic probe of container service readiness.
+                      Container will be removed from service endpoints if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  resizePolicy:
+                    description: Resources resize policy for the container.
+                    items:
+                      description: ContainerResizePolicy represents resource resize
+                        policy for the container.
+                      properties:
+                        resourceName:
+                          description: |-
+                            Name of the resource to which this resource resize policy applies.
+                            Supported values: cpu, memory.
+                          type: string
+                        restartPolicy:
+                          description: |-
+                            Restart policy to apply when specified resource is resized.
+                            If not specified, it defaults to NotRequired.
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resources:
+                    description: |-
+                      Compute Resources required by this container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  restartPolicy:
+                    description: |-
+                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                      This field may only be set for init containers, and the only allowed value is "Always".
+                      For non-init containers or when this field is not specified,
+                      the restart behavior is defined by the Pod's restart policy and the container type.
+                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                      this init container will be continually restarted on
+                      exit until all regular containers have terminated. Once all regular
+                      containers have completed, all init containers with restartPolicy "Always"
+                      will be shut down. This lifecycle differs from normal init containers and
+                      is often referred to as a "sidecar" container. Although this init
+                      container still starts in the init container sequence, it does not wait
+                      for the container to complete before proceeding to the next init
+                      container. Instead, the next init container starts immediately after this
+                      init container is started, or after any startupProbe has successfully
+                      completed.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: |-
+                      StartupProbe indicates that the Pod has successfully initialized.
+                      If specified, no other probes are executed until this completes successfully.
+                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                      This cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: |-
+                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                      is not set, reads from stdin in the container will always result in EOF.
+                      Default is false.
+                    type: boolean
+                  stdinOnce:
+                    description: |-
+                      Whether the container runtime should close the stdin channel after it has been opened by
+                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container is restarted. If this
+                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                      Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: |-
+                      Optional: Path at which the file to which the container's termination message
+                      will be written is mounted into the container's filesystem.
+                      Message written is intended to be brief final status, such as an assertion failure message.
+                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb.
+                      Defaults to /dev/termination-log.
+                      Cannot be updated.
+                    type: string
+                  terminationMessagePolicy:
+                    description: |-
+                      Indicate how the termination message should be populated. File will use the contents of
+                      terminationMessagePath to populate the container status message on both success and failure.
+                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                      Defaults to File.
+                      Cannot be updated.
+                    type: string
+                  tty:
+                    description: |-
+                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                      Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: |-
+                      Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: |-
+                      Container's working directory.
+                      If not specified, the container runtime's default will be used, which
+                      might be configured in the container image.
+                      Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              deno:
+                description: Deno contains the definition for the Deno function that
+                  is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              function:
+                description: |-
+                  Deprecated
+                  Function contains the definition for the function that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              imagePullSecrets:
+                description: ImagePullSecrets is an optional field to specify the
+                  names of secrets to use for pulling container images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              python:
+                description: Python contains the definition for the python function
+                  that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case
+                  of an unsuccessful attempt.
+                format: int32
+                type: integer
+              serviceAccount:
+                description: ServiceAccount specifies the service account to be used
+                  in jobs to authenticate with the Kubernetes API and access cluster
+                  resources.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              ttlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.
+                  The timer starts when the status shows up to be Complete or Failed.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTaskDefinition.
+            properties:
+              function:
+                description: Function contains status information of the function
+                  definition for the task.
+                properties:
+                  configMap:
+                    description: ConfigMap indicates the ConfigMap in which the function
+                      code is stored.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnTaskDefinition is the Schema for the keptntaskdefinitions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnTaskDefinition.
+            properties:
+              automountServiceAccountToken:
+                description: |-
+                  AutomountServiceAccountToken allows to enable K8s to assign cluster API credentials to a pod, if set to false
+                  the pod will decline the service account
+                properties:
+                  type:
+                    type: boolean
+                required:
+                - type
+                type: object
+              container:
+                description: Container contains the definition for the container that
+                  is to be used in Job.
+                properties:
+                  args:
+                    description: |-
+                      Arguments to the entrypoint.
+                      The container image's CMD is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: |-
+                      Entrypoint array. Not executed within a shell.
+                      The container image's ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Cannot be updated.
+                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: |-
+                      List of environment variables to set in the container.
+                      Cannot be updated.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: |-
+                      List of sources to populate environment variables in the container.
+                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                      will be reported as an event when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take precedence.
+                      Values defined by an Env with a duplicate key will take precedence.
+                      Cannot be updated.
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Container image name.
+                      More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management to default or override
+                      container images in workload controllers like Deployments and StatefulSets.
+                    type: string
+                  imagePullPolicy:
+                    description: |-
+                      Image pull policy.
+                      One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  lifecycle:
+                    description: |-
+                      Actions that the management system should take in response to container lifecycle events.
+                      Cannot be updated.
+                    properties:
+                      postStart:
+                        description: |-
+                          PostStart is called immediately after a container is created. If the handler fails,
+                          the container is terminated and restarted according to its restart policy.
+                          Other management of the container blocks until the hook completes.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: |-
+                          PreStop is called immediately before a container is terminated due to an
+                          API request or management event such as liveness/startup probe failure,
+                          preemption, resource contention, etc. The handler is not called if the
+                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                          container will eventually terminate within the Pod's termination grace
+                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                          or until the termination grace period is reached.
+                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          tcpSocket:
+                            description: |-
+                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                              for the backward compatibility. There are no validation of this field and
+                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: |-
+                      Periodic probe of container liveness.
+                      Container will be restarted if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: |-
+                      Name of the container specified as a DNS_LABEL.
+                      Each container in a pod must have a unique name (DNS_LABEL).
+                      Cannot be updated.
+                    type: string
+                  ports:
+                    description: |-
+                      List of ports to expose from the container. Not specifying a port here
+                      DOES NOT prevent that port from being exposed. Any port which is
+                      listening on the default "0.0.0.0" address inside a container will be
+                      accessible from the network.
+                      Modifying this array with strategic merge patch may corrupt the data.
+                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                      Cannot be updated.
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      properties:
+                        containerPort:
+                          description: |-
+                            Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          format: int32
+                          type: integer
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: |-
+                            Number of port to expose on the host.
+                            If specified, this must be a valid port number, 0 < x < 65536.
+                            If HostNetwork is specified, this must match ContainerPort.
+                            Most containers do not need this.
+                          format: int32
+                          type: integer
+                        name:
+                          description: |-
+                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                            named port in a pod must have a unique name. Name for the port that can be
+                            referred to by services.
+                          type: string
+                        protocol:
+                          default: TCP
+                          description: |-
+                            Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                      required:
+                      - containerPort
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerPort
+                    - protocol
+                    x-kubernetes-list-type: map
+                  readinessProbe:
+                    description: |-
+                      Periodic probe of container service readiness.
+                      Container will be removed from service endpoints if the probe fails.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  resizePolicy:
+                    description: Resources resize policy for the container.
+                    items:
+                      description: ContainerResizePolicy represents resource resize
+                        policy for the container.
+                      properties:
+                        resourceName:
+                          description: |-
+                            Name of the resource to which this resource resize policy applies.
+                            Supported values: cpu, memory.
+                          type: string
+                        restartPolicy:
+                          description: |-
+                            Restart policy to apply when specified resource is resized.
+                            If not specified, it defaults to NotRequired.
+                          type: string
+                      required:
+                      - resourceName
+                      - restartPolicy
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resources:
+                    description: |-
+                      Compute Resources required by this container.
+                      Cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  restartPolicy:
+                    description: |-
+                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                      This field may only be set for init containers, and the only allowed value is "Always".
+                      For non-init containers or when this field is not specified,
+                      the restart behavior is defined by the Pod's restart policy and the container type.
+                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                      this init container will be continually restarted on
+                      exit until all regular containers have terminated. Once all regular
+                      containers have completed, all init containers with restartPolicy "Always"
+                      will be shut down. This lifecycle differs from normal init containers and
+                      is often referred to as a "sidecar" container. Although this init
+                      container still starts in the init container sequence, it does not wait
+                      for the container to complete before proceeding to the next init
+                      container. Instead, the next init container starts immediately after this
+                      init container is started, or after any startupProbe has successfully
+                      completed.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext defines the security options the container should be run with.
+                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default is DefaultProcMount which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  startupProbe:
+                    description: |-
+                      StartupProbe indicates that the Pod has successfully initialized.
+                      If specified, no other probes are executed until this completes successfully.
+                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                      This cannot be updated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                              a shell, you need to explicitly call out to that shell.
+                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: |-
+                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                          Defaults to 3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: |-
+                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                              If this is not specified, the default behavior is defined by gRPC.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: |-
+                          Number of seconds after the container has started before liveness probes are initiated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: |-
+                          How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: |-
+                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                          value overrides the value provided by the pod spec.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: |-
+                          Number of seconds after which the probe times out.
+                          Defaults to 1 second. Minimum value is 1.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        format: int32
+                        type: integer
+                    type: object
+                  stdin:
+                    description: |-
+                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                      is not set, reads from stdin in the container will always result in EOF.
+                      Default is false.
+                    type: boolean
+                  stdinOnce:
+                    description: |-
+                      Whether the container runtime should close the stdin channel after it has been opened by
+                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container is restarted. If this
+                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                      Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: |-
+                      Optional: Path at which the file to which the container's termination message
+                      will be written is mounted into the container's filesystem.
+                      Message written is intended to be brief final status, such as an assertion failure message.
+                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb.
+                      Defaults to /dev/termination-log.
+                      Cannot be updated.
+                    type: string
+                  terminationMessagePolicy:
+                    description: |-
+                      Indicate how the termination message should be populated. File will use the contents of
+                      terminationMessagePath to populate the container status message on both success and failure.
+                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                      Defaults to File.
+                      Cannot be updated.
+                    type: string
+                  tty:
+                    description: |-
+                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                      Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container.
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                      required:
+                      - devicePath
+                      - name
+                      type: object
+                    type: array
+                  volumeMounts:
+                    description: |-
+                      Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  workingDir:
+                    description: |-
+                      Container's working directory.
+                      If not specified, the container runtime's default will be used, which
+                      might be configured in the container image.
+                      Cannot be updated.
+                    type: string
+                required:
+                - name
+                type: object
+              deno:
+                description: Deno contains the definition for the Deno function that
+                  is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              function:
+                description: |-
+                  Deprecated
+                  Function contains the definition for the function that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              imagePullSecrets:
+                description: ImagePullSecrets is an optional field to specify the
+                  names of secrets to use for pulling container images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              python:
+                description: Python contains the definition for the python function
+                  that is to be executed in KeptnTasks.
+                properties:
+                  cmdParameters:
+                    description: CmdParameters contains parameters that will be passed
+                      to the command
+                    type: string
+                  configMapRef:
+                    description: |-
+                      ConfigMapReference allows to reference a ConfigMap containing the code of the function.
+                      When referencing a ConfigMap, the code of the function must be available as a value of the 'code' key
+                      of the referenced ConfigMap.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced ConfigMap.
+                        type: string
+                    type: object
+                  functionRef:
+                    description: |-
+                      FunctionReference allows to reference another KeptnTaskDefinition which contains the source code of the
+                      function to be executes for KeptnTasks based on this KeptnTaskDefinition. This can be useful when you have
+                      multiple KeptnTaskDefinitions that should execute the same logic, but each with different parameters.
+                    properties:
+                      name:
+                        description: Name is the name of the referenced KeptnTaskDefinition.
+                        type: string
+                    type: object
+                  httpRef:
+                    description: HttpReference allows to point to an HTTP URL containing
+                      the code of the function.
+                    properties:
+                      url:
+                        description: Url is the URL containing the code of the function.
+                        type: string
+                    type: object
+                  inline:
+                    description: |-
+                      Inline allows to specify the code that should be executed directly in the KeptnTaskDefinition, as a multi-line
+                      string.
+                    properties:
+                      code:
+                        description: Code contains the code of the function.
+                        type: string
+                    type: object
+                  parameters:
+                    description: Parameters contains parameters that will be passed
+                      to the job that executes the task as env variables.
+                    properties:
+                      map:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Inline contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'DATA' environment variable.
+                          The 'DATA'  environment variable's content will be a json
+                          encoded string containing all properties of the map provided.
+                        type: object
+                    type: object
+                  secureParameters:
+                    description: |-
+                      SecureParameters contains secure parameters that will be passed to the job that executes the task.
+                      These will be stored and accessed as secrets in the cluster.
+                    properties:
+                      secret:
+                        description: |-
+                          Secret contains the parameters that will be made available to the job
+                          executing the KeptnTask via the 'SECRET_DATA' environment variable.
+                          The 'SECRET_DATA'  environment variable's content will the same as value of the 'SECRET_DATA'
+                          key of the referenced secret.
+                        type: string
+                    type: object
+                type: object
+              retries:
+                default: 10
+                description: |-
+                  Retries specifies how many times a job executing the KeptnTaskDefinition should be restarted in the case
+                  of an unsuccessful attempt.
+                format: int32
+                type: integer
+              serviceAccount:
+                description: ServiceAccount specifies the service account to be used
+                  in jobs to authenticate with the Kubernetes API and access cluster
+                  resources.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              timeout:
+                default: 5m
+                description: |-
+                  Timeout specifies the maximum time to wait for the task to be completed successfully.
+                  If the task does not complete successfully within this time frame, it will be
+                  considered to be failed.
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                type: string
+              ttlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  TTLSecondsAfterFinished controller makes a job eligible to be cleaned up after it is finished.
+                  The timer starts when the status shows up to be Complete or Failed.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status describes the current state of the KeptnTaskDefinition.
+            properties:
+              function:
+                description: Function contains status information of the function
+                  definition for the task.
+                properties:
+                  configMap:
+                    description: ConfigMap indicates the ConfigMap in which the function
+                      code is stored.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnworkload-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnworkloads.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnWorkload
+    listKind: KeptnWorkloadList
+    plural: keptnworkloads
+    singular: keptnworkload
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: ResourceReference represents the parent resource of Workload
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnWorkloadSpec defines the desired state of KeptnWorkload
+            properties:
+              app:
+                type: string
+              postDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: ResourceReference represents the parent resource of Workload
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: KeptnWorkloadStatus defines the observed state of KeptnWorkload
+            properties:
+              currentVersion:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkload.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkload.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkload is the Schema for the keptnworkloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkload.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkload.
+            properties:
+              currentVersion:
+                description: CurrentVersion indicates the version that is currently
+                  deployed or being reconciled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptnworkloadversion-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnworkloadversions.lifecycle.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: lifecycle.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  group: lifecycle.keptn.sh
+  names:
+    kind: KeptnWorkloadVersion
+    listKind: KeptnWorkloadVersionList
+    plural: keptnworkloadversions
+    shortNames:
+    - kwv
+    singular: keptnworkloadversion
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadVersion is the Schema for the keptnworkloadversions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkloadVersion.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnWorkload that
+                  has been deployed prior to this version.
+                type: string
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+              workloadName:
+                description: WorkloadName is the name of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkloadVersion.
+            properties:
+              currentPhase:
+                description: |-
+                  CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:
+                  - PreDeploymentTasks
+                  - PreDeploymentEvaluations
+                  - Deployment
+                  - PostDeploymentTasks
+                  - PostDeploymentEvaluations
+                type: string
+              deploymentStatus:
+                default: Pending
+                description: DeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's Deployment phase.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnWorkloadVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnWorkloadVersion
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnWorkloadVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnWorkloadVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Cancelled)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnWorkloadVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnWorkloadVersion.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.app
+      name: AppName
+      type: string
+    - jsonPath: .spec.workloadName
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.version
+      name: WorkloadVersion
+      type: string
+    - jsonPath: .status.currentPhase
+      name: Phase
+      type: string
+    - jsonPath: .status.preDeploymentStatus
+      name: PreDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.preDeploymentEvaluationStatus
+      name: PreDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.deploymentStatus
+      name: DeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentStatus
+      name: PostDeploymentStatus
+      priority: 1
+      type: string
+    - jsonPath: .status.postDeploymentEvaluationStatus
+      name: PostDeploymentEvaluationStatus
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnWorkloadVersion is the Schema for the keptnworkloadversions
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec describes the desired state of the KeptnWorkloadVersion.
+            properties:
+              app:
+                description: AppName is the name of the KeptnApp containing the KeptnWorkload.
+                type: string
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains additional key-value pairs for contextual
+                  information.
+                type: object
+              postDeploymentEvaluations:
+                description: |-
+                  PostDeploymentEvaluations is a list of all evaluations to be performed
+                  during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              postDeploymentTasks:
+                description: |-
+                  PostDeploymentTasks is a list of all tasks to be performed during the post-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentEvaluations:
+                description: |-
+                  PreDeploymentEvaluations is a list of all evaluations to be performed
+                  during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnEvaluationDefinitions
+                  located in the same namespace as the KeptnWorkload, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              preDeploymentTasks:
+                description: |-
+                  PreDeploymentTasks is a list of all tasks to be performed during the pre-deployment phase of the KeptnWorkload.
+                  The items of this list refer to the names of KeptnTaskDefinitions
+                  located in the same namespace as the KeptnApp, or in the Keptn namespace.
+                items:
+                  type: string
+                type: array
+              previousVersion:
+                description: PreviousVersion is the version of the KeptnWorkload that
+                  has been deployed prior to this version.
+                type: string
+              resourceReference:
+                description: |-
+                  ResourceReference is a reference to the Kubernetes resource
+                  (Deployment, DaemonSet, StatefulSet or ReplicaSet) the KeptnWorkload is representing.
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  uid:
+                    description: |-
+                      UID is a type that holds unique ID values, including UUIDs.  Because we
+                      don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                      intent and helps make sure that UIDs and names do not get conflated.
+                    type: string
+                required:
+                - kind
+                - name
+                - uid
+                type: object
+              traceId:
+                additionalProperties:
+                  type: string
+                description: TraceId contains the OpenTelemetry trace ID.
+                type: object
+              version:
+                description: Version defines the version of the KeptnWorkload.
+                type: string
+              workloadName:
+                description: WorkloadName is the name of the KeptnWorkload.
+                type: string
+            required:
+            - app
+            - resourceReference
+            - version
+            - workloadName
+            type: object
+          status:
+            description: Status describes the current state of the KeptnWorkloadVersion.
+            properties:
+              appContextMetadata:
+                additionalProperties:
+                  type: string
+                description: AppContextMetadata contains metadata from the related
+                  KeptnAppVersion.
+                type: object
+              currentPhase:
+                description: |-
+                  CurrentPhase indicates the current phase of the KeptnWorkloadVersion. This can be:
+                  - PreDeploymentTasks
+                  - PreDeploymentEvaluations
+                  - Deployment
+                  - PostDeploymentTasks
+                  - PostDeploymentEvaluations
+                type: string
+              deploymentStartTime:
+                description: DeploymentStartTime represents the start time of the
+                  deployment phase
+                format: date-time
+                type: string
+              deploymentStatus:
+                default: Pending
+                description: DeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's Deployment phase.
+                type: string
+              endTime:
+                description: EndTime represents the time at which the deployment of
+                  the KeptnWorkloadVersion finished.
+                format: date-time
+                type: string
+              phaseTraceIDs:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    MapCarrier is a TextMapCarrier that uses a map held in memory as a storage
+                    medium for propagated key-value pairs.
+                  type: object
+                description: PhaseTraceIDs contains the trace IDs of the OpenTelemetry
+                  spans of each phase of the KeptnWorkloadVersion
+                type: object
+              postDeploymentEvaluationStatus:
+                default: Pending
+                description: PostDeploymentEvaluationStatus indicates the current
+                  status of the KeptnWorkloadVersion's PostDeploymentEvaluation phase.
+                type: string
+              postDeploymentEvaluationTaskStatus:
+                description: PostDeploymentEvaluationTaskStatus indicates the current
+                  state of each postDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              postDeploymentStatus:
+                default: Pending
+                description: PostDeploymentStatus indicates the current status of
+                  the KeptnWorkloadVersion's PostDeployment phase.
+                type: string
+              postDeploymentTaskStatus:
+                description: PostDeploymentTaskStatus indicates the current state
+                  of each postDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentEvaluationStatus:
+                default: Pending
+                description: PreDeploymentEvaluationStatus indicates the current status
+                  of the KeptnWorkloadVersion's PreDeploymentEvaluation phase.
+                type: string
+              preDeploymentEvaluationTaskStatus:
+                description: PreDeploymentEvaluationTaskStatus indicates the current
+                  state of each preDeploymentEvaluation of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              preDeploymentStatus:
+                default: Pending
+                description: PreDeploymentStatus indicates the current status of the
+                  KeptnWorkloadVersion's PreDeployment phase.
+                type: string
+              preDeploymentTaskStatus:
+                description: PreDeploymentTaskStatus indicates the current state of
+                  each preDeploymentTask of the KeptnWorkloadVersion.
+                items:
+                  properties:
+                    definitionName:
+                      description: DefinitionName is the name of the EvaluationDefinition/TaskDefinition
+                      type: string
+                    endTime:
+                      description: EndTime represents the time at which the Item (Evaluation/Task)
+                        started.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Evaluation/Task
+                      type: string
+                    startTime:
+                      description: StartTime represents the time at which the Item
+                        (Evaluation/Task) started.
+                      format: date-time
+                      type: string
+                    status:
+                      default: Pending
+                      description: KeptnState  is a string containing current Phase
+                        state  (Progressing/Succeeded/Failed/Unknown/Pending/Deprecated/Warning)
+                      type: string
+                  type: object
+                type: array
+              startTime:
+                description: StartTime represents the time at which the deployment
+                  of the KeptnWorkloadVersion started.
+                format: date-time
+                type: string
+              status:
+                default: Pending
+                description: Status represents the overall status of the KeptnWorkloadVersion.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/metricsOperator/templates/analysis-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: analyses.metrics.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: metrics.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: metrics.keptn.sh
+  names:
+    kind: Analysis
+    listKind: AnalysisList
+    plural: analyses
+    singular: analysis
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.analysisDefinition.name
+      name: AnalysisDefinition
+      type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .status.warning
+      name: Warning
+      type: string
+    - jsonPath: .status.pass
+      name: Pass
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Analysis is the Schema for the analyses API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AnalysisSpec defines the desired state of Analysis
+            properties:
+              analysisDefinition:
+                description: AnalysisDefinition refers to the AnalysisDefinition,
+                  a CRD that stores the AnalysisValuesTemplates
+                properties:
+                  name:
+                    description: Name defines the name of the referenced object
+                    type: string
+                  namespace:
+                    description: Namespace defines the namespace of the referenced
+                      object
+                    type: string
+                required:
+                - name
+                type: object
+              args:
+                additionalProperties:
+                  type: string
+                description: Args corresponds to a map of key/value pairs that can
+                  be used to substitute placeholders in the AnalysisValueTemplate
+                  query. i.e. for args foo:bar the query could be "query:percentile(95)?scope=tag(my_foo_label:)".
+                type: object
+              timeframe:
+                description: |-
+                  Timeframe specifies the range for the corresponding query in the AnalysisValueTemplate. Please note that either
+                  a combination of 'from' and 'to' or the 'recent' property may be set. If neither is set, the Analysis can
+                  not be added to the cluster.
+                properties:
+                  from:
+                    description: From is the time of start for the query. This field
+                      follows RFC3339 time format
+                    format: date-time
+                    type: string
+                  recent:
+                    description: |-
+                      Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis
+                      for the last five minutes
+                    pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  to:
+                    description: To is the time of end for the query. This field follows
+                      RFC3339 time format
+                    format: date-time
+                    type: string
+                type: object
+            required:
+            - analysisDefinition
+            - timeframe
+            type: object
+          status:
+            description: AnalysisStatus stores the status of the overall analysis
+              returns also pass or warnings
+            properties:
+              pass:
+                description: Pass returns whether the SLO is satisfied
+                type: boolean
+              raw:
+                description: Raw contains the raw result of the SLO computation
+                type: string
+              state:
+                description: State describes the current state of the Analysis (Pending/Progressing/Completed)
+                type: string
+              storedValues:
+                additionalProperties:
+                  description: ProviderResult stores reference of already collected
+                    provider query associated to its objective template
+                  properties:
+                    errMsg:
+                      description: ErrMsg stores any possible error at retrieval time
+                      type: string
+                    objectiveReference:
+                      description: Objective store reference to corresponding objective
+                        template
+                      properties:
+                        name:
+                          description: Name defines the name of the referenced object
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            object
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    query:
+                      description: Query represents the executed query
+                      type: string
+                    value:
+                      description: Value is the value the provider returned
+                      type: string
+                  type: object
+                description: StoredValues contains all analysis values that have already
+                  been retrieved successfully
+                type: object
+              timeframe:
+                description: Timeframe describes the time frame which is evaluated
+                  by the Analysis
+                properties:
+                  from:
+                    description: From is the time of start for the query. This field
+                      follows RFC3339 time format
+                    format: date-time
+                    type: string
+                  recent:
+                    description: |-
+                      Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis
+                      for the last five minutes
+                    pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  to:
+                    description: To is the time of end for the query. This field follows
+                      RFC3339 time format
+                    format: date-time
+                    type: string
+                type: object
+              warning:
+                description: Warning returns whether the analysis returned a warning
+                type: boolean
+            required:
+            - state
+            - timeframe
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.analysisDefinition.name
+      name: AnalysisDefinition
+      type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .status.warning
+      name: Warning
+      type: string
+    - jsonPath: .status.pass
+      name: Pass
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Analysis is the Schema for the analyses API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AnalysisSpec defines the desired state of Analysis
+            properties:
+              analysisDefinition:
+                description: AnalysisDefinition refers to the AnalysisDefinition,
+                  a CRD that stores the AnalysisValuesTemplates
+                properties:
+                  name:
+                    description: Name defines the name of the referenced object
+                    type: string
+                  namespace:
+                    description: Namespace defines the namespace of the referenced
+                      object
+                    type: string
+                required:
+                - name
+                type: object
+              args:
+                additionalProperties:
+                  type: string
+                description: Args corresponds to a map of key/value pairs that can
+                  be used to substitute placeholders in the AnalysisValueTemplate
+                  query. i.e. for args foo:bar the query could be "query:percentile(95)?scope=tag(my_foo_label:)".
+                type: object
+              timeframe:
+                description: |-
+                  Timeframe specifies the range for the corresponding query in the AnalysisValueTemplate. Please note that either
+                  a combination of 'from' and 'to' or the 'recent' property may be set. If neither is set, the Analysis can
+                  not be added to the cluster.
+                properties:
+                  from:
+                    description: From is the time of start for the query. This field
+                      follows RFC3339 time format
+                    format: date-time
+                    type: string
+                  recent:
+                    description: |-
+                      Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis
+                      for the last five minutes
+                    pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  to:
+                    description: To is the time of end for the query. This field follows
+                      RFC3339 time format
+                    format: date-time
+                    type: string
+                type: object
+            required:
+            - analysisDefinition
+            - timeframe
+            type: object
+          status:
+            description: AnalysisStatus stores the status of the overall analysis
+              returns also pass or warnings
+            properties:
+              pass:
+                description: Pass returns whether the SLO is satisfied
+                type: boolean
+              raw:
+                description: Raw contains the raw result of the SLO computation
+                type: string
+              state:
+                description: State describes the current state of the Analysis (Pending/Progressing/Completed)
+                type: string
+              storedValues:
+                additionalProperties:
+                  description: ProviderResult stores reference of already collected
+                    provider query associated to its objective template
+                  properties:
+                    errMsg:
+                      description: ErrMsg stores any possible error at retrieval time
+                      type: string
+                    objectiveReference:
+                      description: Objective store reference to corresponding objective
+                        template
+                      properties:
+                        name:
+                          description: Name defines the name of the referenced object
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            object
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    query:
+                      description: Query represents the executed query
+                      type: string
+                    value:
+                      description: Value is the value the provider returned
+                      type: string
+                  type: object
+                description: StoredValues contains all analysis values that have already
+                  been retrieved successfully
+                type: object
+              timeframe:
+                description: Timeframe describes the time frame which is evaluated
+                  by the Analysis
+                properties:
+                  from:
+                    description: From is the time of start for the query. This field
+                      follows RFC3339 time format
+                    format: date-time
+                    type: string
+                  recent:
+                    description: |-
+                      Recent describes a recent timeframe using a duration string. E.g. Setting this to '5m' provides an Analysis
+                      for the last five minutes
+                    pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  to:
+                    description: To is the time of end for the query. This field follows
+                      RFC3339 time format
+                    format: date-time
+                    type: string
+                type: object
+              warning:
+                description: Warning returns whether the analysis returned a warning
+                type: boolean
+            required:
+            - state
+            - timeframe
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/metricsOperator/templates/analysisdefinition-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: analysisdefinitions.metrics.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: metrics.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: metrics.keptn.sh
+  names:
+    kind: AnalysisDefinition
+    listKind: AnalysisDefinitionList
+    plural: analysisdefinitions
+    singular: analysisdefinition
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AnalysisDefinition is the Schema for the analysisdefinitions
+          APIs
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AnalysisDefinitionSpec defines the desired state of AnalysisDefinition
+            properties:
+              objectives:
+                description: Objectives defines a list of objectives to evaluate for
+                  an analysis
+                items:
+                  description: Objective defines an objective for analysis
+                  properties:
+                    analysisValueTemplateRef:
+                      description: AnalysisValueTemplateRef refers to the appropriate
+                        AnalysisValueTemplate
+                      properties:
+                        name:
+                          description: Name defines the name of the referenced object
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            object
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    keyObjective:
+                      default: false
+                      description: KeyObjective defines whether the whole analysis
+                        fails when this objective's target is not met
+                      type: boolean
+                    target:
+                      description: Target defines failure or warning criteria
+                      properties:
+                        failure:
+                          description: Failure defines limits up to which an analysis
+                            fails
+                          properties:
+                            equalTo:
+                              description: EqualTo represents '==' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThan:
+                              description: GreaterThan represents '>' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThanOrEqual:
+                              description: GreaterThanOrEqual represents '>=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            inRange:
+                              description: InRange represents operator checking the
+                                value is inclusively in the defined range, e.g. 2
+                                <= x <= 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                            lessThan:
+                              description: LessThan represents '<' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            lessThanOrEqual:
+                              description: LessThanOrEqual represents '<=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            notInRange:
+                              description: NotInRange represents operator checking
+                                the value is exclusively out of the defined range,
+                                e.g. x < 2 AND x > 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                          type: object
+                        warning:
+                          description: Warning defines limits where the result does
+                            not pass or fail
+                          properties:
+                            equalTo:
+                              description: EqualTo represents '==' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThan:
+                              description: GreaterThan represents '>' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThanOrEqual:
+                              description: GreaterThanOrEqual represents '>=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            inRange:
+                              description: InRange represents operator checking the
+                                value is inclusively in the defined range, e.g. 2
+                                <= x <= 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                            lessThan:
+                              description: LessThan represents '<' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            lessThanOrEqual:
+                              description: LessThanOrEqual represents '<=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            notInRange:
+                              description: NotInRange represents operator checking
+                                the value is exclusively out of the defined range,
+                                e.g. x < 2 AND x > 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                          type: object
+                      type: object
+                    weight:
+                      default: 1
+                      description: Weight can be used to emphasize the importance
+                        of one Objective over the others
+                      type: integer
+                  required:
+                  - analysisValueTemplateRef
+                  type: object
+                type: array
+              totalScore:
+                description: TotalScore defines the required score for an analysis
+                  to be successful
+                properties:
+                  passPercentage:
+                    description: PassPercentage defines the threshold to reach for
+                      an analysis to pass
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  warningPercentage:
+                    description: WarningPercentage defines the threshold to reach
+                      for an analysis to pass with a 'warning' status
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                required:
+                - passPercentage
+                - warningPercentage
+                type: object
+            required:
+            - totalScore
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: AnalysisDefinition is the Schema for the analysisdefinitions
+          APIs
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AnalysisDefinitionSpec defines the desired state of AnalysisDefinition
+            properties:
+              objectives:
+                description: Objectives defines a list of objectives to evaluate for
+                  an analysis
+                items:
+                  description: Objective defines an objective for analysis
+                  properties:
+                    analysisValueTemplateRef:
+                      description: AnalysisValueTemplateRef refers to the appropriate
+                        AnalysisValueTemplate
+                      properties:
+                        name:
+                          description: Name defines the name of the referenced object
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            object
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    keyObjective:
+                      default: false
+                      description: KeyObjective defines whether the whole analysis
+                        fails when this objective's target is not met
+                      type: boolean
+                    target:
+                      description: Target defines failure or warning criteria
+                      properties:
+                        failure:
+                          description: Failure defines limits up to which an analysis
+                            fails
+                          properties:
+                            equalTo:
+                              description: EqualTo represents '==' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThan:
+                              description: GreaterThan represents '>' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThanOrEqual:
+                              description: GreaterThanOrEqual represents '>=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            inRange:
+                              description: InRange represents operator checking the
+                                value is inclusively in the defined range, e.g. 2
+                                <= x <= 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                            lessThan:
+                              description: LessThan represents '<' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            lessThanOrEqual:
+                              description: LessThanOrEqual represents '<=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            notInRange:
+                              description: NotInRange represents operator checking
+                                the value is exclusively out of the defined range,
+                                e.g. x < 2 AND x > 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                          type: object
+                        warning:
+                          description: Warning defines limits where the result does
+                            not pass or fail
+                          properties:
+                            equalTo:
+                              description: EqualTo represents '==' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThan:
+                              description: GreaterThan represents '>' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            greaterThanOrEqual:
+                              description: GreaterThanOrEqual represents '>=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            inRange:
+                              description: InRange represents operator checking the
+                                value is inclusively in the defined range, e.g. 2
+                                <= x <= 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                            lessThan:
+                              description: LessThan represents '<' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            lessThanOrEqual:
+                              description: LessThanOrEqual represents '<=' operator
+                              properties:
+                                fixedValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: FixedValue defines the value for comparison
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - fixedValue
+                              type: object
+                            notInRange:
+                              description: NotInRange represents operator checking
+                                the value is exclusively out of the defined range,
+                                e.g. x < 2 AND x > 5
+                              properties:
+                                highBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: HighBound defines the higher bound
+                                    of the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lowBound:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: LowBound defines the lower bound of
+                                    the range
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - highBound
+                              - lowBound
+                              type: object
+                          type: object
+                      type: object
+                    weight:
+                      default: 1
+                      description: Weight can be used to emphasize the importance
+                        of one Objective over the others
+                      type: integer
+                  required:
+                  - analysisValueTemplateRef
+                  type: object
+                type: array
+              totalScore:
+                description: TotalScore defines the required score for an analysis
+                  to be successful
+                properties:
+                  passPercentage:
+                    description: PassPercentage defines the threshold to reach for
+                      an analysis to pass
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  warningPercentage:
+                    description: WarningPercentage defines the threshold to reach
+                      for an analysis to pass with a 'warning' status
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                required:
+                - passPercentage
+                - warningPercentage
+                type: object
+            required:
+            - totalScore
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/metricsOperator/templates/analysisvaluetemplate-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: analysisvaluetemplates.metrics.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: metrics.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: metrics.keptn.sh
+  names:
+    kind: AnalysisValueTemplate
+    listKind: AnalysisValueTemplateList
+    plural: analysisvaluetemplates
+    singular: analysisvaluetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: AnalysisValueTemplate is the Schema for the analysisvaluetemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the specification for the AnalysisValueTemplate
+            properties:
+              provider:
+                description: Provider refers to the KeptnMetricsProvider which should
+                  be used to retrieve the data
+                properties:
+                  name:
+                    description: Name defines the name of the referenced object
+                    type: string
+                  namespace:
+                    description: Namespace defines the namespace of the referenced
+                      object
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: |-
+                  Query represents the query to be run. It can include placeholders that are defined using the go template
+                  syntax. More info on go templating - https://pkg.go.dev/text/template
+                type: string
+            required:
+            - provider
+            - query
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: AnalysisValueTemplate is the Schema for the analysisvaluetemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the specification for the AnalysisValueTemplate
+            properties:
+              provider:
+                description: Provider refers to the KeptnMetricsProvider which should
+                  be used to retrieve the data
+                properties:
+                  name:
+                    description: Name defines the name of the referenced object
+                    type: string
+                  namespace:
+                    description: Namespace defines the namespace of the referenced
+                      object
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: |-
+                  Query represents the query to be run. It can include placeholders that are defined using the go template
+                  syntax. More info on go templating - https://pkg.go.dev/text/template
+                type: string
+            required:
+            - provider
+            - query
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/metricsOperator/templates/keptnmetric-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnmetrics.metrics.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: metrics.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: metrics.keptn.sh
+  names:
+    kind: KeptnMetric
+    listKind: KeptnMetricList
+    plural: keptnmetrics
+    singular: keptnmetric
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    - jsonPath: .spec.query
+      name: Query
+      type: string
+    - jsonPath: .status.value
+      name: Value
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetric is the Schema for the keptnmetrics API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricSpec defines the desired state of KeptnMetric
+            properties:
+              fetchIntervalSeconds:
+                description: FetchIntervalSeconds represents the update frequency
+                  in seconds that is used to update the metric
+                type: integer
+              provider:
+                description: Provider represents the provider object
+                properties:
+                  name:
+                    description: Name of the provider
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: Query represents the query to be run
+                type: string
+            required:
+            - fetchIntervalSeconds
+            - provider
+            - query
+            type: object
+          status:
+            description: KeptnMetricStatus defines the observed state of KeptnMetric
+            properties:
+              lastUpdated:
+                description: LastUpdated represents the time when the status data
+                  was last updated
+                format: date-time
+                type: string
+              rawValue:
+                description: RawValue represents the resulting value in raw format
+                format: byte
+                type: string
+              value:
+                description: Value represents the resulting value
+                type: string
+            required:
+            - lastUpdated
+            - rawValue
+            - value
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    - jsonPath: .spec.query
+      name: Query
+      type: string
+    - jsonPath: .status.value
+      name: Value
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetric is the Schema for the keptnmetrics API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricSpec defines the desired state of KeptnMetric
+            properties:
+              fetchIntervalSeconds:
+                description: FetchIntervalSeconds represents the update frequency
+                  in seconds that is used to update the metric
+                type: integer
+              provider:
+                description: Provider represents the provider object
+                properties:
+                  name:
+                    description: Name of the provider
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: Query represents the query to be run
+                type: string
+            required:
+            - fetchIntervalSeconds
+            - provider
+            - query
+            type: object
+          status:
+            description: KeptnMetricStatus defines the observed state of KeptnMetric
+            properties:
+              lastUpdated:
+                description: LastUpdated represents the time when the status data
+                  was last updated
+                format: date-time
+                type: string
+              rawValue:
+                description: RawValue represents the resulting value in raw format
+                format: byte
+                type: string
+              value:
+                description: Value represents the resulting value
+                type: string
+            required:
+            - lastUpdated
+            - rawValue
+            - value
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    - jsonPath: .spec.query
+      name: Query
+      type: string
+    - jsonPath: .spec.range.interval
+      name: Interval
+      type: string
+    - jsonPath: .status.value
+      name: Value
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetric is the Schema for the keptnmetrics API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricSpec defines the desired state of KeptnMetric
+            properties:
+              fetchIntervalSeconds:
+                description: FetchIntervalSeconds represents the update frequency
+                  in seconds that is used to update the metric
+                type: integer
+              provider:
+                description: Provider represents the provider object
+                properties:
+                  name:
+                    description: Name of the provider
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: Query represents the query to be run
+                type: string
+              range:
+                description: Range represents the time range for which data is to
+                  be queried
+                properties:
+                  aggregation:
+                    description: 'Aggregation defines the type of aggregation function
+                      to be applied on the data. Accepted values: p90, p95, p99, max,
+                      min, avg, median'
+                    enum:
+                    - p90
+                    - p95
+                    - p99
+                    - max
+                    - min
+                    - avg
+                    - median
+                    type: string
+                  interval:
+                    default: 5m
+                    description: Interval specifies the duration of the time interval
+                      for the data query
+                    type: string
+                  step:
+                    description: Step represents the query resolution step width for
+                      the data query
+                    type: string
+                  storedResults:
+                    description: StoredResults indicates the upper limit of how many
+                      past results should be stored in the status of a KeptnMetric
+                    maximum: 255
+                    type: integer
+                type: object
+            required:
+            - fetchIntervalSeconds
+            - provider
+            - query
+            type: object
+          status:
+            description: KeptnMetricStatus defines the observed state of KeptnMetric
+            properties:
+              errMsg:
+                description: ErrMsg represents the error details when the query could
+                  not be evaluated
+                type: string
+              intervalResults:
+                description: IntervalResults contain a slice of all the interval results
+                items:
+                  properties:
+                    errMsg:
+                      description: ErrMsg represents the error details when the query
+                        could not be evaluated
+                      type: string
+                    lastUpdated:
+                      description: LastUpdated represents the time when the status
+                        data was last updated
+                      format: date-time
+                      type: string
+                    range:
+                      description: Range represents the time range for which this
+                        data was queried
+                      properties:
+                        aggregation:
+                          description: 'Aggregation defines the type of aggregation
+                            function to be applied on the data. Accepted values: p90,
+                            p95, p99, max, min, avg, median'
+                          enum:
+                          - p90
+                          - p95
+                          - p99
+                          - max
+                          - min
+                          - avg
+                          - median
+                          type: string
+                        interval:
+                          default: 5m
+                          description: Interval specifies the duration of the time
+                            interval for the data query
+                          type: string
+                        step:
+                          description: Step represents the query resolution step width
+                            for the data query
+                          type: string
+                        storedResults:
+                          description: StoredResults indicates the upper limit of
+                            how many past results should be stored in the status of
+                            a KeptnMetric
+                          maximum: 255
+                          type: integer
+                      type: object
+                    value:
+                      description: Value represents the resulting value
+                      type: string
+                  required:
+                  - lastUpdated
+                  - range
+                  - value
+                  type: object
+                type: array
+              lastUpdated:
+                description: LastUpdated represents the time when the status data
+                  was last updated
+                format: date-time
+                type: string
+              rawValue:
+                description: RawValue represents the resulting value in raw format
+                format: byte
+                type: string
+              value:
+                description: Value represents the resulting value
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.name
+      name: Provider
+      type: string
+    - jsonPath: .spec.query
+      name: Query
+      type: string
+    - jsonPath: .spec.range.interval
+      name: Interval
+      type: string
+    - jsonPath: .status.value
+      name: Value
+      type: string
+    - jsonPath: .spec.range.step
+      name: Step
+      type: string
+    - jsonPath: .spec.range.aggregation
+      name: Aggregation
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetric is the Schema for the keptnmetrics API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricSpec defines the desired state of KeptnMetric
+            properties:
+              fetchIntervalSeconds:
+                description: FetchIntervalSeconds represents the update frequency
+                  in seconds that is used to update the metric
+                type: integer
+              provider:
+                description: Provider represents the provider object
+                properties:
+                  name:
+                    description: Name of the provider
+                    type: string
+                required:
+                - name
+                type: object
+              query:
+                description: Query represents the query to be run
+                type: string
+              range:
+                description: Range represents the time range for which data is to
+                  be queried
+                properties:
+                  aggregation:
+                    description: 'Aggregation defines the type of aggregation function
+                      to be applied on the data. Accepted values: p90, p95, p99, max,
+                      min, avg, median'
+                    enum:
+                    - p90
+                    - p95
+                    - p99
+                    - max
+                    - min
+                    - avg
+                    - median
+                    type: string
+                  interval:
+                    default: 5m
+                    description: Interval specifies the duration of the time interval
+                      for the data query
+                    type: string
+                  step:
+                    description: Step represents the query resolution step width for
+                      the data query
+                    type: string
+                  storedResults:
+                    description: StoredResults indicates the upper limit of how many
+                      past results should be stored in the status of a KeptnMetric
+                    maximum: 255
+                    type: integer
+                type: object
+            required:
+            - fetchIntervalSeconds
+            - provider
+            - query
+            type: object
+          status:
+            description: KeptnMetricStatus defines the observed state of KeptnMetric
+            properties:
+              errMsg:
+                description: ErrMsg represents the error details when the query could
+                  not be evaluated
+                type: string
+              intervalResults:
+                description: IntervalResults contain a slice of all the interval results
+                items:
+                  properties:
+                    errMsg:
+                      description: ErrMsg represents the error details when the query
+                        could not be evaluated
+                      type: string
+                    lastUpdated:
+                      description: LastUpdated represents the time when the status
+                        data was last updated
+                      format: date-time
+                      type: string
+                    range:
+                      description: Range represents the time range for which this
+                        data was queried
+                      properties:
+                        aggregation:
+                          description: 'Aggregation defines the type of aggregation
+                            function to be applied on the data. Accepted values: p90,
+                            p95, p99, max, min, avg, median'
+                          enum:
+                          - p90
+                          - p95
+                          - p99
+                          - max
+                          - min
+                          - avg
+                          - median
+                          type: string
+                        interval:
+                          default: 5m
+                          description: Interval specifies the duration of the time
+                            interval for the data query
+                          type: string
+                        step:
+                          description: Step represents the query resolution step width
+                            for the data query
+                          type: string
+                        storedResults:
+                          description: StoredResults indicates the upper limit of
+                            how many past results should be stored in the status of
+                            a KeptnMetric
+                          maximum: 255
+                          type: integer
+                      type: object
+                    value:
+                      description: Value represents the resulting value
+                      type: string
+                  required:
+                  - lastUpdated
+                  - range
+                  - value
+                  type: object
+                type: array
+              lastUpdated:
+                description: LastUpdated represents the time when the status data
+                  was last updated
+                format: date-time
+                type: string
+              rawValue:
+                description: RawValue represents the resulting value in raw format
+                format: byte
+                type: string
+              value:
+                description: Value represents the resulting value
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/metricsOperator/templates/keptnmetricsprovider-crd.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keptnmetricsproviders.metrics.keptn.sh
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    app.kubernetes.io/part-of: keptn
+    crdGroup: metrics.keptn.sh
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: metrics.keptn.sh
+  names:
+    kind: KeptnMetricsProvider
+    listKind: KeptnMetricsProviderList
+    plural: keptnmetricsproviders
+    shortNames:
+    - kmp
+    singular: keptnmetricsprovider
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetricsProvider is the Schema for the keptnmetricsproviders
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
+            properties:
+              secretKeyRef:
+                description: SecretKeySelector selects a key of a Secret.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              targetServer:
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetricsProvider is the Schema for the keptnmetricsproviders
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
+            properties:
+              secretKeyRef:
+                description: SecretKeyRef defines an optional secret for access credentials
+                  to the metrics provider.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              targetServer:
+                description: TargetServer defined the URL at which the metrics provider
+                  is reachable with included port and protocol.
+                type: string
+              type:
+                description: Type represents the provider type. This can be one of
+                  prometheus, dynatrace, datadog, dql.
+                pattern: prometheus|dynatrace|datadog|dql
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KeptnMetricsProvider is the Schema for the keptnmetricsproviders
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
+            properties:
+              secretKeyRef:
+                description: SecretKeyRef defines an optional secret for access credentials
+                  to the metrics provider.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              targetServer:
+                description: TargetServer defines URL (including port and protocol)
+                  at which the metrics provider is reachable.
+                type: string
+              type:
+                description: Type represents the provider type. This can be one of
+                  prometheus, dynatrace, datadog, dql.
+                pattern: prometheus|dynatrace|datadog|dql
+                type: string
+            required:
+            - targetServer
+            type: object
+          status:
+            description: unused field
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: keptn/charts/certManager/templates/certificate-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: certificate-operator-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptn-scheduler-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keptn-scheduler
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - kube-scheduler
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - kube-scheduler
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - pods/binding
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  - storageclasses
+  - csidrivers
+  - csistoragecapacities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.sigs.k8s.io
+  resources:
+  - podgroups
+  - elasticquotas
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lifecycle-operator-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcontexts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappcreationrequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnapps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversion/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnappversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluationdefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnevaluations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntaskdefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptntasks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloadversions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lifecycle.keptn.sh
+  resources:
+  - keptnworkloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - metrics.keptn.sh
+  resources:
+  - keptnmetrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - options.keptn.sh
+  resources:
+  - keptnconfigs/status
+  verbs:
+  - get
+---
+# Source: keptn/charts/lifecycleOperator/templates/server-resources-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keptn-test-lifecycleOperator-server-resources
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-operator-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - analyses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - analyses/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - analyses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - analysisdefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - analysisvaluetemplates
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - keptnmetrics
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - keptnmetrics/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - keptnmetrics/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - keptnmetricsproviders
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.keptn.sh
+    resources:
+      - providers
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-server-resources-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-operator-server-resources
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: keptn/charts/certManager/templates/certificate-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: certificate-operator-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: certificate-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'certificate-operator-role'
+subjects:
+- kind: ServiceAccount
+  name: 'certificate-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/lifecycleOperator/templates/keptn-scheduler-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keptn-scheduler
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'keptn-scheduler'
+subjects:
+- kind: ServiceAccount
+  name: 'keptn-scheduler'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lifecycle-operator-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'lifecycle-operator-role'
+subjects:
+- kind: ServiceAccount
+  name: 'lifecycle-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-hpa-controller-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-operator-hpa-controller
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'metrics-operator-server-resources'
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-operator-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'metrics-operator-role'
+subjects:
+  - kind: ServiceAccount
+    name: 'metrics-operator'
+    namespace: 'helmtests'
+---
+# Source: keptn/charts/metricsOperator/templates/system-auth-delegator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-auth-delegator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: 'metrics-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/certManager/templates/certificate-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: certificate-operator-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - keptn-certs
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+  - update
+---
+# Source: keptn/charts/lifecycleOperator/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: certificate-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lifecycle-operator-leader-election-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metrics-operator-leader-election-role
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: keptn/charts/certManager/templates/certificate-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: certificate-operator-leader-election-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: certificate-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'certificate-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/certManager/templates/certificate-operator-role-binding-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: certificate-operator-role-binding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: certificate-operator
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'certificate-operator-role'
+subjects:
+- kind: ServiceAccount
+  name: 'certificate-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/lifecycleOperator/templates/extension-apiserver-authentication-reader-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extension-apiserver-authentication-reader
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'extension-apiserver-authentication-reader'
+subjects:
+- kind: ServiceAccount
+  name: 'keptn-scheduler'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lifecycle-operator-leader-election-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'lifecycle-operator-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'lifecycle-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lifecycle-operator-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'lifecycle-operator-role'
+subjects:
+- kind: ServiceAccount
+  name: 'lifecycle-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-operator-leader-election-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'metrics-operator-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'metrics-operator'
+  namespace: 'helmtests'
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-operator-rolebinding
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'metrics-operator-role'
+subjects:
+  - kind: ServiceAccount
+    name: 'metrics-operator'
+    namespace: 'helmtests'
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-operator-metrics-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lifecycle-operator-metrics-service
+  namespace: "helmtests"
+  labels:
+    control-plane: lifecycle-operator
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: lifecycle-operator
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/instance: keptn-test
+  ports:
+  - name: metrics
+    port: 2222
+    protocol: TCP
+    targetPort: metrics
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lifecycle-webhook-service
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: lifecycle-operator
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/instance: keptn-test
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-operator-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-operator-service
+  namespace: "helmtests"
+  labels:
+    control-plane: metrics-operator
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: metrics-operator
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/instance: keptn-test
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  - name: custom-metrics
+    port: 443
+    targetPort: custom-metrics
+  - name: metrics
+    port: 9999
+    protocol: TCP
+    targetPort: metrics
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-webhook-service
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: metrics-operator
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/instance: keptn-test
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+---
+# Source: keptn/charts/certManager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: certificate-operator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/component: keptn-cert-manager
+    app.kubernetes.io/part-of: keptn
+    control-plane: certificate-operator
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/version: v2.1.0
+    helm.sh/chart: cert-manager-0.2.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: certificate-operator
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: keptn-test
+  template:
+    metadata:
+      labels:
+        control-plane: certificate-operator
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/instance: keptn-test
+      annotations:
+        kubectl.kubernetes.io/default-container: certificate-operator
+    spec:
+      containers:
+        - args:
+            - --leader-elect
+          command:
+            - /manager
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LABEL_SELECTOR_KEY
+              value: "keptn.sh/inject-cert"
+            - name: LABEL_SELECTOR_VALUE
+              value: "true"
+            - name: KUBERNETES_CLUSTER_DOMAIN
+              value: cluster.local
+          image: global-registry.io/keptn/certificate-operator:v2.1.0
+          imagePullPolicy: IfNotPresent
+          name: certificate-operator
+          resources:
+            limits:
+              cpu: 25m
+              memory: 64Mi
+            requests:
+              cpu: 5m
+              memory: 16Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      imagePullSecrets: []
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: certificate-operator
+      terminationGracePeriodSeconds: 10
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lifecycle-operator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/part-of: keptn
+    control-plane: lifecycle-operator
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: lifecycle-operator
+      app.kubernetes.io/name: lifecycle-operator
+      app.kubernetes.io/instance: keptn-test
+  template:
+    metadata:
+      labels:
+        control-plane: lifecycle-operator
+        app.kubernetes.io/name: lifecycle-operator
+        app.kubernetes.io/instance: keptn-test
+      annotations:
+        kubectl.kubernetes.io/default-container: lifecycle-operator
+        metrics.dynatrace.com/port: "2222"
+        metrics.dynatrace.com/scrape: "true"
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: FUNCTION_RUNNER_IMAGE
+          value: "ghcr.io/keptn/deno-runtime:v2.0.2"
+        - name: PYTHON_RUNNER_IMAGE
+          value: "ghcr.io/keptn/python-runtime:v1.0.3"
+        - name: KEPTN_APP_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_APP_CREATION_REQUEST_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_APP_VERSION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_EVALUATION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_TASK_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_TASK_DEFINITION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_WORKLOAD_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_WORKLOAD_VERSION_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KEPTN_DORA_METRICS_PORT
+          value: "2222"
+        - name: OPTIONS_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: SCHEDULING_GATES_ENABLED
+          value: "false"
+        - name: PROMOTION_TASKS_ENABLED
+          value: "false"
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        - name: CERT_MANAGER_ENABLED
+          value: "true"
+        image: global-registry.io/keptn/lifecycle-operator:v0.9.1
+        imagePullPolicy: IfNotPresent
+        name: lifecycle-operator
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 2222
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - name: keptn-certs
+          mountPath: /tmp/webhook/certs/
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      imagePullSecrets: []
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: lifecycle-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: keptn-certs
+        secret:
+          secretName: keptn-certs
+---
+# Source: keptn/charts/lifecycleOperator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scheduler
+  namespace: "helmtests"
+  labels:
+    component: scheduler
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: scheduler
+      app.kubernetes.io/name: lifecycle-operator
+      app.kubernetes.io/instance: keptn-test
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        app.kubernetes.io/name: lifecycle-operator
+        app.kubernetes.io/instance: keptn-test
+    spec:
+      containers:
+      - command:
+        - /bin/kube-scheduler
+        - --config=/etc/kubernetes/scheduler-config.yaml
+        env:
+        - name: OTEL_COLLECTOR_URL
+          value: "otel-collector:4317"
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: global-registry.io/keptn/scheduler:v0.9.1
+        imagePullPolicy: IfNotPresent
+        name: scheduler
+        resources:
+          limits:
+            cpu: 300m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: scheduler-config
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+          initialDelaySeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10259
+            scheme: HTTPS
+      imagePullSecrets: []
+      serviceAccountName: keptn-scheduler
+      volumes:
+      - configMap:
+          name: scheduler-config
+        name: scheduler-config
+---
+# Source: keptn/charts/metricsOperator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-operator
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/part-of: keptn
+    app.kubernetes.io/component: metrics-operator
+    control-plane: metrics-operator
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: metrics-operator
+      app.kubernetes.io/name: metrics-operator
+      app.kubernetes.io/instance: keptn-test
+  template:
+    metadata:
+      labels:
+        control-plane: metrics-operator
+        app.kubernetes.io/name: metrics-operator
+        app.kubernetes.io/instance: keptn-test
+      annotations:
+        kubectl.kubernetes.io/default-container: metrics-operator
+    spec:
+      containers:
+      - args:
+        - webhook-server
+        - --leader-elect
+        - --adapter-port=6443
+        - --adapter-certs-dir=/tmp/metrics-adapter/serving-certs
+        - --v=10
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: EXPOSE_KEPTN_METRICS
+          value: "true"
+        - name: ENABLE_CUSTOM_METRICS_API_SERVICE
+          value: "true"
+        - name: METRICS_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: ANALYSIS_CONTROLLER_LOG_LEVEL
+          value: "0"
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        - name: CERT_MANAGER_ENABLED
+          value: "true"
+        image: global-registry.io/keptn/metrics-operator:v0.9.2
+        imagePullPolicy: IfNotPresent
+        name: metrics-operator
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9999
+          name: metrics
+          protocol: TCP
+        - containerPort: 6443
+          name: custom-metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp/metrics-adapter/serving-certs
+          name: adapter-certs-dir
+        - name: keptn-certs
+          mountPath: /tmp/webhook/certs/
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      imagePullSecrets: []
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: metrics-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - emptyDir: {}
+        name: adapter-certs-dir
+      - name: keptn-certs
+        secret:
+          secretName: keptn-certs
+---
+# Source: keptn/charts/metricsOperator/templates/v1beta1.custom.metrics.k8s.io.yaml
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: 'metrics-operator-service'
+    namespace: 'helmtests'
+  version: v1beta1
+  versionPriority: 100
+---
+# Source: keptn/charts/metricsOperator/templates/v1beta2.custom.metrics.k8s.io.yaml
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta2.custom.metrics.k8s.io
+  namespace: "helmtests"
+  labels:
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: 'metrics-operator-service'
+    namespace: 'helmtests'
+  version: v1beta2
+  versionPriority: 200
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-mutating-webhook-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: lifecycle-mutating-webhook-configuration
+  labels:
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/part-of: "keptn"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: 'lifecycle-webhook-service'
+      namespace: 'helmtests'
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.keptn.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: NotIn
+      values:
+      - lifecycle-operator
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:  ["cert-manager","keptn-system","observability","monitoring"]
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - 'helmtests'
+      - kube-system
+      - kube-public
+      - kube-node-lease
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+---
+# Source: keptn/charts/lifecycleOperator/templates/lifecycle-validating-webhook-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: lifecycle-validating-webhook-configuration
+  labels:
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: lifecycle-operator
+    app.kubernetes.io/version: v0.9.1
+    helm.sh/chart: lifecycle-operator-0.2.2
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: 'lifecycle-webhook-service'
+      namespace: 'helmtests'
+      path: /validate-lifecycle-keptn-sh-v1beta1-keptntaskdefinition
+  failurePolicy: Fail
+  name: vkeptntaskdefinition.kb.io
+  rules:
+  - apiGroups:
+    - lifecycle.keptn.sh
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keptntaskdefinitions
+  sideEffects: None
+---
+# Source: keptn/charts/metricsOperator/templates/metrics-validating-webhook-configuration.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: metrics-validating-webhook-configuration
+  labels:
+    keptn.sh/inject-cert: "true"
+    app.kubernetes.io/instance: keptn-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: metrics-operator
+    app.kubernetes.io/version: v0.9.2
+    helm.sh/chart: metrics-operator-0.1.3
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: 'metrics-webhook-service'
+      namespace: 'helmtests'
+      path: /validate-metrics-keptn-sh-v1beta1-keptnmetric
+  failurePolicy: Fail
+  name: vkeptnmetric.kb.io
+  rules:
+  - apiGroups:
+    - metrics.keptn.sh
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - keptnmetrics
+  sideEffects: None
+- admissionReviewVersions:
+    - v1
+  clientConfig:
+    service:
+      name: 'metrics-webhook-service'
+      namespace: 'helmtests'
+      path: /validate-metrics-keptn-sh-v1beta1-analysis
+  failurePolicy: Fail
+  name: vanalysis.kb.io
+  rules:
+    - apiGroups:
+        - metrics.keptn.sh
+      apiVersions:
+        - v1beta1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - analyses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: 'metrics-webhook-service'
+      namespace: 'helmtests'
+      path: /validate-metrics-keptn-sh-v1beta1-analysisdefinition
+  failurePolicy: Fail
+  name: vanalysisdefinition.kb.io
+  rules:
+  - apiGroups:
+    - metrics.keptn.sh
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - analysisdefinitions
+  sideEffects: None

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -11639,7 +11639,7 @@ spec:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
           image: local-registry.io/keptn/certificate-operator:v2.1.0
-          imagePullPolicy: Never
+          imagePullPolicy: Always
           name: certificate-operator
           resources:
             limits:
@@ -11672,6 +11672,7 @@ spec:
             periodSeconds: 10
       imagePullSecrets:
         - name: registry-secret
+        - name: second-secret
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -11805,6 +11806,7 @@ spec:
           periodSeconds: 10
       imagePullSecrets:
         - name: registry-secret
+        - name: second-secret
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -11892,6 +11894,7 @@ spec:
             scheme: HTTPS
       imagePullSecrets:
         - name: registry-secret
+        - name: second-secret
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:
@@ -12015,6 +12018,7 @@ spec:
           periodSeconds: 10
       imagePullSecrets:
         - name: registry-secret
+        - name: second-secret
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -171,7 +171,7 @@ metadata:
   name: keptnapps.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -653,7 +653,7 @@ metadata:
   name: keptnappcreationrequests.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -766,7 +766,7 @@ metadata:
   name: keptnappversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -2042,7 +2042,7 @@ metadata:
   name: keptnconfigs.options.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -2135,7 +2135,7 @@ metadata:
   name: keptnevaluations.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -2700,7 +2700,7 @@ metadata:
   name: keptnevaluationdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -2992,7 +2992,7 @@ metadata:
   name: keptntasks.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -3595,7 +3595,7 @@ metadata:
   name: keptntaskdefinitions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -7040,7 +7040,7 @@ metadata:
   name: keptnworkloads.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -7469,7 +7469,7 @@ metadata:
   name: keptnworkloadversions.lifecycle.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -8153,7 +8153,7 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -8512,7 +8512,7 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -9213,7 +9213,7 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -9366,7 +9366,7 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -9907,7 +9907,7 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    caAnnotation1: bla
+    caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
   labels:
@@ -12088,7 +12088,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
-    caAnnotation1: bla
+    caAnnotation1: hi
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/part-of: "keptn"
@@ -12145,7 +12145,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
-    caAnnotation1: bla
+    caAnnotation1: hi
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
@@ -12185,7 +12185,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
-    caAnnotation1: bla
+    caAnnotation1: hi
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -11638,7 +11638,7 @@ spec:
               value: "true"
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
-          image: global-registry.io/keptn/certificate-operator:v2.1.0
+          image: local-registry.io/keptn/certificate-operator:v2.1.0
           imagePullPolicy: Never
           name: certificate-operator
           resources:
@@ -11759,7 +11759,7 @@ spec:
           value: cluster.local
         - name: CERT_MANAGER_ENABLED
           value: "true"
-        image: global-registry.io/keptn/lifecycle-operator:v0.9.1
+        image: local-registry.io/keptn/lifecycle-operator:v0.9.1
         imagePullPolicy: Never
         name: lifecycle-operator
         ports:
@@ -11852,7 +11852,7 @@ spec:
           value: "otel-collector:4317"
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: global-registry.io/keptn/scheduler:v0.9.1
+        image: local-registry.io/keptn/scheduler:v0.9.1
         imagePullPolicy: Never
         name: scheduler
         resources:
@@ -11962,7 +11962,7 @@ spec:
           value: cluster.local
         - name: CERT_MANAGER_ENABLED
           value: "true"
-        image: global-registry.io/keptn/metrics-operator:v0.9.2
+        image: local-registry.io/keptn/metrics-operator:v0.9.2
         imagePullPolicy: Never
         name: metrics-operator
         ports:

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/part-of: keptn
@@ -28,6 +29,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -53,6 +55,7 @@ metadata:
     helm.sh/chart: lifecycle-operator-0.2.2
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-operator-service-account.yaml
 apiVersion: v1
@@ -63,6 +66,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -81,6 +85,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -112,6 +117,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -142,6 +148,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -174,6 +181,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -532,6 +540,7 @@ metadata:
     cert-manager.io/inject-ca-from: 'helmtests/keptn-certs'
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -656,6 +665,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -769,6 +779,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2045,6 +2056,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2138,6 +2150,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2703,6 +2716,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -2995,6 +3009,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -3598,6 +3613,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -7043,6 +7059,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -7472,6 +7489,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: lifecycle.keptn.sh
@@ -8156,6 +8174,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -8515,6 +8534,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9216,6 +9236,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9369,6 +9390,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -9910,6 +9932,7 @@ metadata:
     caAnnotation1: hi
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -10135,6 +10158,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10192,6 +10216,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10388,6 +10413,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10768,6 +10794,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10793,6 +10820,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10906,6 +10934,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10933,6 +10962,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -10962,6 +10992,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -10988,6 +11019,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11014,6 +11046,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11040,6 +11073,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11066,6 +11100,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11092,6 +11127,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11129,6 +11165,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -11182,6 +11219,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11232,6 +11270,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11282,6 +11321,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -11295,6 +11335,7 @@ metadata:
     helm.sh/chart: cert-manager-0.2.2
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11313,6 +11354,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: certificate-operator
@@ -11342,6 +11384,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11368,6 +11411,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11394,6 +11438,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11420,6 +11465,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11446,6 +11492,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11472,6 +11519,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     control-plane: lifecycle-operator
     app.kubernetes.io/instance: keptn-test
@@ -11502,6 +11550,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11530,6 +11579,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     control-plane: metrics-operator
     app.kubernetes.io/instance: keptn-test
@@ -11567,6 +11617,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -11595,6 +11646,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/component: keptn-cert-manager
     app.kubernetes.io/part-of: keptn
@@ -11697,6 +11749,7 @@ metadata:
     helm.sh/chart: lifecycle-operator-0.2.2
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
 spec:
   replicas: 1
   selector:
@@ -11833,6 +11886,7 @@ metadata:
     helm.sh/chart: lifecycle-operator-0.2.2
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
 spec:
   replicas: 1
   selector:
@@ -11910,6 +11964,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/part-of: keptn
     app.kubernetes.io/component: metrics-operator
@@ -12039,6 +12094,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -12066,6 +12122,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
@@ -12092,6 +12149,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
     caAnnotation1: hi
   labels:
     keptn.sh/inject-cert: "true"
@@ -12149,6 +12207,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
     caAnnotation1: hi
   labels:
     keptn.sh/inject-cert: "true"
@@ -12189,6 +12248,7 @@ metadata:
   annotations:
     globalAnnotation1: test1
     globalAnnotation2: test2
+    test-annotation: local
     caAnnotation1: hi
   labels:
     keptn.sh/inject-cert: "true"

--- a/.github/scripts/.helm-tests/local-global-precedence/values.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/values.yaml
@@ -1,0 +1,17 @@
+lifecycleOperator:
+  lifecycleOperator:
+    image:
+      registry: "local-registry.io"
+metricsOperator:
+  image:
+    registry: "local-registry.io"
+certManager:
+  image:
+    registry: "local-registry.io"
+global:
+  imageRegistry: "global-registry.io"
+  imagePullSecrets: []
+  imagePullPolicy: IfNotPresent
+  commonLabels: {}
+  commonAnnotations: {}
+  caInjectionAnnotations: {}

--- a/.github/scripts/.helm-tests/local-global-precedence/values.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/values.yaml
@@ -1,4 +1,6 @@
 lifecycleOperator:
+  annotations:
+    test-annotation: "local" # will be used
   lifecycleOperator:
     image:
       registry: "local-registry.io" # will be used
@@ -8,10 +10,14 @@ lifecycleOperator:
       registry: "local-registry.io" # will be used
       imagePullPolicy: Never # will be used
 metricsOperator:
+  annotations:
+    test-annotation: "local" # will be used
   image:
     registry: "local-registry.io" # will be used
     imagePullPolicy: Never # will be used
 certManager:
+  annotations:
+    test-annotation: "local" # will be used
   image:
     registry: "local-registry.io" # will be used
 global:
@@ -26,5 +32,6 @@ global:
   commonAnnotations:
     globalAnnotation1: test1 # will be used
     globalAnnotation2: test2 # will be used
+    test-annotation: "global" # will not be used
   caInjectionAnnotations:
     caAnnotation1: hi # will be used

--- a/.github/scripts/.helm-tests/local-global-precedence/values.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/values.yaml
@@ -27,4 +27,4 @@ global:
     globalAnnotation1: test1 # will be used
     globalAnnotation2: test2 # will be used
   caInjectionAnnotations:
-    caAnnotation1: bla # will be used
+    caAnnotation1: hi # will be used

--- a/.github/scripts/.helm-tests/local-global-precedence/values.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/values.yaml
@@ -1,22 +1,22 @@
 lifecycleOperator:
   lifecycleOperator:
     image:
-      registry: "local-registry.io" # will not be used
+      registry: "local-registry.io" # will be used
       imagePullPolicy: Never # will be used
   scheduler:
     image:
-      registry: "local-registry.io" # will not be used
+      registry: "local-registry.io" # will be used
       imagePullPolicy: Never # will be used
 metricsOperator:
   image:
-    registry: "local-registry.io" # will not be used
+    registry: "local-registry.io" # will be used
     imagePullPolicy: Never # will be used
 certManager:
   image:
-    registry: "local-registry.io" # will not be used
+    registry: "local-registry.io" # will be used
     imagePullPolicy: Never # will be used
 global:
-  imageRegistry: "global-registry.io" # will be used
+  imageRegistry: "global-registry.io" # will not be used
   imagePullSecrets:
     - name: registry-secret
   imagePullPolicy: Always # will not be used

--- a/.github/scripts/.helm-tests/local-global-precedence/values.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/values.yaml
@@ -1,17 +1,30 @@
 lifecycleOperator:
   lifecycleOperator:
     image:
-      registry: "local-registry.io"
+      registry: "local-registry.io" # will not be used
+      imagePullPolicy: Never # will be used
+  scheduler:
+    image:
+      registry: "local-registry.io" # will not be used
+      imagePullPolicy: Never # will be used
 metricsOperator:
   image:
-    registry: "local-registry.io"
+    registry: "local-registry.io" # will not be used
+    imagePullPolicy: Never # will be used
 certManager:
   image:
-    registry: "local-registry.io"
+    registry: "local-registry.io" # will not be used
+    imagePullPolicy: Never # will be used
 global:
-  imageRegistry: "global-registry.io"
-  imagePullSecrets: []
-  imagePullPolicy: IfNotPresent
-  commonLabels: {}
-  commonAnnotations: {}
-  caInjectionAnnotations: {}
+  imageRegistry: "global-registry.io" # will be used
+  imagePullSecrets:
+    - name: registry-secret
+  imagePullPolicy: Always # will not be used
+  commonLabels:
+    globalLabel1: test1 # will be used
+    globalLabel2: test2 # will be used
+  commonAnnotations:
+    globalAnnotation1: test1 # will be used
+    globalAnnotation2: test2 # will be used
+  caInjectionAnnotations:
+    caAnnotation1: bla # will be used

--- a/.github/scripts/.helm-tests/local-global-precedence/values.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/values.yaml
@@ -14,11 +14,11 @@ metricsOperator:
 certManager:
   image:
     registry: "local-registry.io" # will be used
-    imagePullPolicy: Never # will be used
 global:
   imageRegistry: "global-registry.io" # will not be used
   imagePullSecrets:
     - name: registry-secret
+    - second-secret
   imagePullPolicy: Always # will not be used
   commonLabels:
     globalLabel1: test1 # will be used

--- a/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
@@ -2451,7 +2451,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
@@ -5,13 +5,11 @@ kind: ServiceAccount
 metadata:
   name: metrics-operator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-manager-config.yaml
@@ -20,13 +18,11 @@ kind: ConfigMap
 metadata:
   name: metrics-operator-config
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 data:
   controller_manager_config.yaml: |
@@ -49,8 +45,6 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -58,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -405,8 +399,6 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -414,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1103,8 +1095,6 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1112,7 +1102,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1253,8 +1243,6 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1262,7 +1250,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1791,8 +1779,6 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1800,7 +1786,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -2013,13 +1999,11 @@ kind: ClusterRole
 metadata:
   name: metrics-operator-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
   - apiGroups:
@@ -2123,13 +2107,11 @@ kind: ClusterRole
 metadata:
   name: metrics-operator-server-resources
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -2147,13 +2129,11 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2170,13 +2150,11 @@ kind: ClusterRoleBinding
 metadata:
   name: system-auth-delegator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2193,13 +2171,11 @@ kind: Role
 metadata:
   name: metrics-operator-leader-election-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -2240,13 +2216,11 @@ kind: RoleBinding
 metadata:
   name: metrics-operator-leader-election-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2263,13 +2237,11 @@ kind: RoleBinding
 metadata:
   name: metrics-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2286,14 +2258,12 @@ kind: Service
 metadata:
   name: metrics-operator-service
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     control-plane: metrics-operator
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -2320,13 +2290,11 @@ kind: Service
 metadata:
   name: metrics-webhook-service
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -2345,8 +2313,6 @@ kind: Deployment
 metadata:
   name: metrics-operator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     app.kubernetes.io/component: metrics-operator
@@ -2355,7 +2321,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   replicas: 1
@@ -2451,7 +2417,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator
@@ -2468,15 +2434,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: metrics-validating-webhook-configuration
-  annotations:
-    test/jj: test
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/values.yaml
+++ b/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/values.yaml
@@ -10,9 +10,3 @@ metricsOperator:
 
 global:
   certManagerEnabled: false
-  commonLabels:
-    app.kubernetes.io/version: vmyversion
-  caInjectionAnnotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-  commonAnnotations:
-    test/jj: test

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -5,13 +5,11 @@ kind: ServiceAccount
 metadata:
   name: metrics-operator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-manager-config.yaml
@@ -20,13 +18,11 @@ kind: ConfigMap
 metadata:
   name: metrics-operator-config
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 data:
   controller_manager_config.yaml: |
@@ -49,8 +45,6 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -58,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -405,8 +399,6 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -414,7 +406,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1103,8 +1095,6 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1112,7 +1102,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1253,8 +1243,6 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1262,7 +1250,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1791,8 +1779,6 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1800,7 +1786,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -2013,13 +1999,11 @@ kind: ClusterRole
 metadata:
   name: metrics-operator-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
   - apiGroups:
@@ -2123,13 +2107,11 @@ kind: ClusterRole
 metadata:
   name: metrics-operator-server-resources
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -2147,13 +2129,11 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-operator-hpa-controller
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2170,13 +2150,11 @@ kind: ClusterRoleBinding
 metadata:
   name: metrics-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2193,13 +2171,11 @@ kind: ClusterRoleBinding
 metadata:
   name: system-auth-delegator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2216,13 +2192,11 @@ kind: Role
 metadata:
   name: metrics-operator-leader-election-role
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -2263,13 +2237,11 @@ kind: RoleBinding
 metadata:
   name: metrics-operator-leader-election-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2286,13 +2258,11 @@ kind: RoleBinding
 metadata:
   name: metrics-operator-rolebinding
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2309,14 +2279,12 @@ kind: Service
 metadata:
   name: metrics-operator-service
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     control-plane: metrics-operator
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -2343,13 +2311,11 @@ kind: Service
 metadata:
   name: metrics-webhook-service
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -2368,8 +2334,6 @@ kind: Deployment
 metadata:
   name: metrics-operator
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/part-of: keptn
     app.kubernetes.io/component: metrics-operator
@@ -2378,7 +2342,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   replicas: 1
@@ -2474,7 +2438,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator
@@ -2492,13 +2456,11 @@ kind: APIService
 metadata:
   name: v1beta1.custom.metrics.k8s.io
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -2516,13 +2478,11 @@ kind: APIService
 metadata:
   name: v1beta2.custom.metrics.k8s.io
   namespace: "helmtests"
-  annotations:
-    test/jj: test
   labels:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -2539,15 +2499,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: metrics-validating-webhook-configuration
-  annotations:
-    test/jj: test
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -2474,7 +2474,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/.github/scripts/.helm-tests/metrics-only/values.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/values.yaml
@@ -7,9 +7,3 @@ metricsOperator:
 
 global:
   certManagerEnabled: false
-  commonLabels:
-    app.kubernetes.io/version: vmyversion
-  caInjectionAnnotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
-  commonAnnotations:
-    test/jj: test

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -2583,7 +2583,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -2699,7 +2699,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-      imagePullSecrets: []
+
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-operator-service-account.yaml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 ---
 # Source: keptn/charts/metricsOperator/templates/metrics-manager-config.yaml
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 data:
   controller_manager_config.yaml: |
@@ -60,7 +60,6 @@ metadata:
   name: analyses.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -68,7 +67,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -415,7 +414,6 @@ metadata:
   name: analysisdefinitions.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -423,7 +421,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1112,7 +1110,6 @@ metadata:
   name: analysisvaluetemplates.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1120,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1261,7 +1258,6 @@ metadata:
   name: keptnmetrics.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1269,7 +1265,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -1798,7 +1794,6 @@ metadata:
   name: keptnmetricsproviders.metrics.keptn.sh
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     app.kubernetes.io/part-of: keptn
     crdGroup: metrics.keptn.sh
@@ -1806,7 +1801,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: metrics.keptn.sh
@@ -2023,7 +2018,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -2075,7 +2070,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
   - apiGroups:
@@ -2183,7 +2178,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -2208,7 +2203,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2229,7 +2224,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2250,7 +2245,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2271,7 +2266,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2292,7 +2287,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 rules:
 - apiGroups:
@@ -2324,7 +2319,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 rules:
 - apiGroups:
@@ -2372,7 +2367,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2396,7 +2391,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2417,7 +2412,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2438,7 +2433,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2460,7 +2455,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -2491,7 +2486,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   type: ClusterIP
@@ -2517,7 +2512,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v2.1.0
     helm.sh/chart: cert-manager-0.2.2
 spec:
   replicas: 1
@@ -2552,7 +2547,7 @@ spec:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: cluster.local
           image: ghcr.io/keptn/certificate-operator:v0.0.0
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent
           name: certificate-operator
           resources:
             limits:
@@ -2583,7 +2578,7 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator
@@ -2603,7 +2598,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   replicas: 1
@@ -2652,7 +2647,7 @@ spec:
         - name: CERT_MANAGER_ENABLED
           value: "true"
         image: ghcr.io/keptn/metrics-operator:v0.0.0
-        imagePullPolicy: Never
+        imagePullPolicy: IfNotPresent
         name: metrics-operator
         ports:
         - containerPort: 9443
@@ -2699,7 +2694,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-
+      
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator
@@ -2721,7 +2716,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -2743,7 +2738,7 @@ metadata:
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 spec:
   group: custom.metrics.k8s.io
@@ -2760,14 +2755,12 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: metrics-validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs
   labels:
     keptn.sh/inject-cert: "true"
     app.kubernetes.io/instance: keptn-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-operator
-    app.kubernetes.io/version: vmyversion
+    app.kubernetes.io/version: v0.9.2
     helm.sh/chart: metrics-operator-0.1.3
 webhooks:
 - admissionReviewVersions:

--- a/.github/scripts/.helm-tests/metrics-with-certs/values.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/values.yaml
@@ -7,11 +7,3 @@ metricsOperator:
   enabled: true
   image:
     tag: v0.0.0
-
-global:
-  certManagerEnabled: true
-  commonLabels:
-    app.kubernetes.io/version: vmyversion
-  imagePullPolicy: Never
-  caInjectionAnnotations:
-    cert-manager.io/inject-ca-from: helmtests/keptn-certs

--- a/.github/scripts/helm-test.sh
+++ b/.github/scripts/helm-test.sh
@@ -22,8 +22,8 @@ echo "running Helm tests"
         # shellcheck disable=SC2164
         cd "$chart_dir"
         echo "updating charts for" $chart_dir
-#        helm dependency update
-#        helm dependency build
+        helm dependency update
+        helm dependency build
         # shellcheck disable=SC2164
         cd -  # Return to the previous directory
     done

--- a/.github/scripts/helm-test.sh
+++ b/.github/scripts/helm-test.sh
@@ -22,8 +22,8 @@ echo "running Helm tests"
         # shellcheck disable=SC2164
         cd "$chart_dir"
         echo "updating charts for" $chart_dir
-        helm dependency update
-        helm dependency build
+#        helm dependency update
+#        helm dependency build
         # shellcheck disable=SC2164
         cd -  # Return to the previous directory
     done

--- a/chart/README.md
+++ b/chart/README.md
@@ -16,12 +16,12 @@ metrics, observability, health checks, with pre- and post-deployment evaluations
 
 ### Global parameters
 
-| Name                            | Description                                                               | Value  |
-| ------------------------------- | ------------------------------------------------------------------------- | ------ |
-| `global.certManagerEnabled`     | Enable this value to install Keptn Certificate Manager                    | `true` |
-| `global.imageRegistry`          | Global Docker image registry                                              | `""`   |
-| `global.imagePullSecrets`       | Global Docker registry secret names as an array                           | `[]`   |
-| `global.imagePullPolicy`        | Policy for pulling Docker images. Options: Always, IfNotPresent, Never    | `""`   |
-| `global.commonLabels`           | Common labels to add to all Keptn resources. Evaluated as a template      | `{}`   |
-| `global.commonAnnotations`      | Common annotations to add to all Keptn resources. Evaluated as a template | `{}`   |
-| `global.caInjectionAnnotations` | CA injection annotations for cert-manager.io configuration                | `{}`   |
+| Name                            | Description                                                               | Value     |
+| ------------------------------- | ------------------------------------------------------------------------- | --------- |
+| `global.certManagerEnabled`     | Enable this value to install Keptn Certificate Manager                    | `true`    |
+| `global.imageRegistry`          | Global Docker image registry                                              | `ghcr.io` |
+| `global.imagePullSecrets`       | Global Docker registry secret names as an array                           | `[]`      |
+| `global.imagePullPolicy`        | Policy for pulling Docker images. Options: Always, IfNotPresent, Never    | `""`      |
+| `global.commonLabels`           | Common labels to add to all Keptn resources. Evaluated as a template      | `{}`      |
+| `global.commonAnnotations`      | Common annotations to add to all Keptn resources. Evaluated as a template | `{}`      |
+| `global.caInjectionAnnotations` | CA injection annotations for cert-manager.io configuration                | `{}`      |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,7 +15,7 @@ global:
   ## @param global.certManagerEnabled Enable this value to install Keptn Certificate Manager
   certManagerEnabled: true
   ## @param global.imageRegistry Global Docker image registry
-  imageRegistry: ""
+  imageRegistry: "ghcr.io"
 
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
   ## E.g.

--- a/keptn-cert-manager/chart/Chart.lock
+++ b/keptn-cert-manager/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.lifecycle.keptn.sh
-  version: 0.1.4
-digest: sha256:16a2c2b907d0cf88de1e869c5d9d2249c9aeb6a9fd941f77c71f4f58caae7868
-generated: "2024-02-26T10:12:23.997201478Z"
+  version: 0.2.1
+digest: sha256:23cfd1d58cd1cd569753326f7587dc0bf18df6110acffc3cf002479efab46abe
+generated: "2024-03-18T11:11:34.193399+01:00"

--- a/keptn-cert-manager/chart/Chart.yaml
+++ b/keptn-cert-manager/chart/Chart.yaml
@@ -41,4 +41,4 @@ appVersion: "v2.1.0" # x-release-please-version
 dependencies:
   - name: common
     repository: "https://charts.lifecycle.keptn.sh"
-    version: 0.1.4
+    version: 0.2.1

--- a/keptn-cert-manager/chart/README.md
+++ b/keptn-cert-manager/chart/README.md
@@ -8,14 +8,14 @@ resource.
 
 ### Global parameters
 
-| Name                            | Description                                                               | Value |
-| ------------------------------- | ------------------------------------------------------------------------- | ----- |
-| `global.imageRegistry`          | Global container image registry                                           | `""`  |
-| `global.imagePullPolicy`        | select global image pull policy                                           | `""`  |
-| `global.imagePullSecrets`       | Global Docker registry secret names as an array                           | `[]`  |
-| `global.commonLabels`           | Common labels to add to all Keptn resources. Evaluated as a template      | `{}`  |
-| `global.commonAnnotations`      | Common annotations to add to all Keptn resources. Evaluated as a template | `{}`  |
-| `global.caInjectionAnnotations` | CA injection annotations for cert-manager.io configuration                | `{}`  |
+| Name                            | Description                                                               | Value     |
+| ------------------------------- | ------------------------------------------------------------------------- | --------- |
+| `global.imageRegistry`          | Global container image registry                                           | `ghcr.io` |
+| `global.imagePullPolicy`        | select global image pull policy                                           | `""`      |
+| `global.imagePullSecrets`       | Global Docker registry secret names as an array                           | `[]`      |
+| `global.commonLabels`           | Common labels to add to all Keptn resources. Evaluated as a template      | `{}`      |
+| `global.commonAnnotations`      | Common annotations to add to all Keptn resources. Evaluated as a template | `{}`      |
+| `global.caInjectionAnnotations` | CA injection annotations for cert-manager.io configuration                | `{}`      |
 
 ### Keptn Certificate Operator common
 
@@ -36,7 +36,7 @@ resource.
 | `containerSecurityContext` | Sets security context for the cert manager                                |                              |
 | `env.labelSelectorKey`     | specify the label selector to find resources to generate certificates for | `keptn.sh/inject-cert`       |
 | `env.labelSelectorValue`   | specify the value for the label selector                                  | `true`                       |
-| `image.registry`           | specify the container registry for the certificate-operator image         | `ghcr.io`                    |
+| `image.registry`           | specify the container registry for the certificate-operator image         | `""`                         |
 | `image.repository`         | specify repo for manager image                                            | `keptn/certificate-operator` |
 | `image.tag`                | select tag for manager container                                          | `v2.1.0`                     |
 | `image.imagePullPolicy`    | specify pull policy for the manager image. This overrides global values   | `""`                         |

--- a/keptn-cert-manager/chart/templates/_helpers.tpl
+++ b/keptn-cert-manager/chart/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Return the proper Image Registry Secret Names
+*/}}
+{{- define "certManager.imagePullSecrets" -}}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) }}
+{{- end -}}

--- a/keptn-cert-manager/chart/templates/deployment.yaml
+++ b/keptn-cert-manager/chart/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         {{- end }}
-      imagePullSecrets: {{- include "common.images.imagePullSecrets" . }}
+      {{- include "certManager.imagePullSecrets" . | indent 6 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator

--- a/keptn-cert-manager/chart/templates/deployment.yaml
+++ b/keptn-cert-manager/chart/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
         {{- end }}
-      {{- include "certManager.imagePullSecrets" . | indent 6 }}
+      {{- include "certManager.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: certificate-operator

--- a/keptn-cert-manager/chart/values.yaml
+++ b/keptn-cert-manager/chart/values.yaml
@@ -5,7 +5,7 @@
 ##
 global:
   ## @param global.imageRegistry Global container image registry
-  imageRegistry: ""
+  imageRegistry: "ghcr.io"
   ## @param     global.imagePullPolicy select global image pull policy
   imagePullPolicy: ""
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
@@ -65,7 +65,7 @@ env:
   labelSelectorValue: "true"
 image:
 ## @param     image.registry specify the container registry for the certificate-operator image
-  registry: ghcr.io
+  registry: ""
 ## @param     image.repository specify repo for manager image
   repository: keptn/certificate-operator
 ## @param     image.tag select tag for manager container

--- a/lifecycle-operator/chart/Chart.lock
+++ b/lifecycle-operator/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.lifecycle.keptn.sh
-  version: 0.1.4
-digest: sha256:16a2c2b907d0cf88de1e869c5d9d2249c9aeb6a9fd941f77c71f4f58caae7868
-generated: "2024-02-26T10:12:05.459085085Z"
+  version: 0.2.1
+digest: sha256:23cfd1d58cd1cd569753326f7587dc0bf18df6110acffc3cf002479efab46abe
+generated: "2024-03-18T11:11:30.195659+01:00"

--- a/lifecycle-operator/chart/Chart.yaml
+++ b/lifecycle-operator/chart/Chart.yaml
@@ -50,4 +50,4 @@ appVersion: "v0.9.1" # x-release-please-version
 dependencies:
   - name: common
     repository: "https://charts.lifecycle.keptn.sh"
-    version: 0.1.4
+    version: 0.2.1

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -14,7 +14,7 @@ and application health checks
 | Name                                                    | Description                                                                                                                                                   | Value               |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `global.certManagerEnabled`                             | Enable this value to install Keptn Certificate Manager                                                                                                        | `true`              |
-| `global.imageRegistry`                                  | Global container image registry                                                                                                                               | `""`                |
+| `global.imageRegistry`                                  | Global container image registry                                                                                                                               | `ghcr.io`           |
 | `global.imagePullSecrets`                               | Global Docker registry secret names as an array                                                                                                               | `[]`                |
 | `global.imagePullPolicy`                                | select global image pull policy                                                                                                                               | `""`                |
 | `global.commonLabels`                                   | Common labels to add to all Keptn resources. Evaluated as a template                                                                                          | `{}`                |
@@ -55,7 +55,7 @@ and application health checks
 | `lifecycleOperator.env.keptnDoraMetricsPort`                          | sets the port for accessing lifecycle metrics in prometheus format             | `2222`                                |
 | `lifecycleOperator.env.optionsControllerLogLevel`                     | sets the log level of Keptn Options Controller                                 | `0`                                   |
 | `lifecycleOperator.env.pythonRunnerImage`                             | specify image for python task runtime                                          | `ghcr.io/keptn/python-runtime:v1.0.3` |
-| `lifecycleOperator.image.registry`                                    | specify the container registry for the lifecycle-operator image                | `ghcr.io`                             |
+| `lifecycleOperator.image.registry`                                    | specify the container registry for the lifecycle-operator image                | `""`                                  |
 | `lifecycleOperator.image.repository`                                  | specify registry for manager image                                             | `keptn/lifecycle-operator`            |
 | `lifecycleOperator.image.tag`                                         | select tag for manager image                                                   | `v0.9.1`                              |
 | `lifecycleOperator.image.imagePullPolicy`                             | specify pull policy for the manager image. This overrides global values        | `""`                                  |
@@ -88,7 +88,7 @@ and application health checks
 | `scheduler.replicas`                                         | modifies replicas                                                       | `1`                   |
 | `scheduler.containerSecurityContext`                         | Sets security context                                                   |                       |
 | `scheduler.env.otelCollectorUrl`                             | sets url for open telemetry collector                                   | `otel-collector:4317` |
-| `scheduler.image.registry`                                   | specify the container registry for the scheduler image                  | `ghcr.io`             |
+| `scheduler.image.registry`                                   | specify the container registry for the scheduler image                  | `""`                  |
 | `scheduler.image.repository`                                 | set image repository for scheduler                                      | `keptn/scheduler`     |
 | `scheduler.image.tag`                                        | set image tag for scheduler                                             | `v0.9.1`              |
 | `scheduler.image.imagePullPolicy`                            | specify pull policy for the manager image. This overrides global values | `""`                  |

--- a/lifecycle-operator/chart/templates/_helpers.tpl
+++ b/lifecycle-operator/chart/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Return the proper Image Registry Secret Names for lifecycle operator
+*/}}
+{{- define "lifecycleOperator.imagePullSecrets" -}}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.lifecycleOperator.image) "context" $) }}
+{{- end -}}
+
+{{/*
+Return the proper Image Registry Secret Names for scheduler
+*/}}
+{{- define "scheduler.imagePullSecrets" -}}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.scheduler.image) "context" $) }}
+{{- end -}}

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
          initialDelaySeconds: 5
          periodSeconds: 10
         {{- end }}
-      imagePullSecrets: {{- include "common.images.imagePullSecrets" . }}
+      {{- include "lifecycleOperator.imagePullSecrets" . | indent 6 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -250,7 +250,7 @@ spec:
            port: 10259
            scheme: HTTPS
         {{- end }}
-      imagePullSecrets: {{- include "common.images.imagePullSecrets" . }}
+      {{- include "scheduler.imagePullSecrets" . | indent 6 }}
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
          initialDelaySeconds: 5
          periodSeconds: 10
         {{- end }}
-      {{- include "lifecycleOperator.imagePullSecrets" . | indent 6 }}
+      {{- include "lifecycleOperator.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
@@ -250,7 +250,7 @@ spec:
            port: 10259
            scheme: HTTPS
         {{- end }}
-      {{- include "scheduler.imagePullSecrets" . | indent 6 }}
+      {{- include "scheduler.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: keptn-scheduler
       volumes:
       - configMap:

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -7,7 +7,7 @@ global:
   ## @param global.certManagerEnabled Enable this value to install Keptn Certificate Manager
   certManagerEnabled: true
   ## @param global.imageRegistry Global container image registry
-  imageRegistry: ""
+  imageRegistry: "ghcr.io"
 
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
   ## E.g.
@@ -102,7 +102,7 @@ lifecycleOperator:
     pythonRunnerImage: ghcr.io/keptn/python-runtime:v1.0.3
   image:
 ## @param    lifecycleOperator.image.registry specify the container registry for the lifecycle-operator image
-    registry: ghcr.io
+    registry: ""
 ## @param   lifecycleOperator.image.repository specify registry for manager image
     repository: keptn/lifecycle-operator
 ## @param   lifecycleOperator.image.tag  select tag for manager image
@@ -217,7 +217,7 @@ scheduler:
     otelCollectorUrl: otel-collector:4317
   image:
 ## @param     scheduler.image.registry specify the container registry for the scheduler image
-    registry: ghcr.io
+    registry: ""
 ## @param scheduler.image.repository set image repository for scheduler
     repository: keptn/scheduler
 ## @param scheduler.image.tag set image tag for scheduler

--- a/metrics-operator/chart/Chart.lock
+++ b/metrics-operator/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.lifecycle.keptn.sh
-  version: 0.1.4
-digest: sha256:16a2c2b907d0cf88de1e869c5d9d2249c9aeb6a9fd941f77c71f4f58caae7868
-generated: "2024-02-26T10:11:49.108416649Z"
+  version: 0.2.1
+digest: sha256:23cfd1d58cd1cd569753326f7587dc0bf18df6110acffc3cf002479efab46abe
+generated: "2024-03-18T11:11:32.514626+01:00"

--- a/metrics-operator/chart/Chart.yaml
+++ b/metrics-operator/chart/Chart.yaml
@@ -44,4 +44,4 @@ appVersion: "v0.9.2" # x-release-please-version
 dependencies:
   - name: common
     repository: "https://charts.lifecycle.keptn.sh"
-    version: 0.1.4
+    version: 0.2.1

--- a/metrics-operator/chart/README.md
+++ b/metrics-operator/chart/README.md
@@ -13,15 +13,15 @@ Prometheus, Dynatrace, DataDog and K8s metric server...
 
 ### Global parameters
 
-| Name                            | Description                                                               | Value  |
-| ------------------------------- | ------------------------------------------------------------------------- | ------ |
-| `global.certManagerEnabled`     | Enable this value to install Keptn Certificate Manager                    | `true` |
-| `global.imageRegistry`          | Global container image registry                                           | `""`   |
-| `global.imagePullSecrets`       | Global Docker registry secret names as an array                           | `[]`   |
-| `global.imagePullPolicy`        | specify global pull policy                                                | `""`   |
-| `global.commonLabels`           | Common labels to add to all Keptn resources. Evaluated as a template      | `{}`   |
-| `global.commonAnnotations`      | Common annotations to add to all Keptn resources. Evaluated as a template | `{}`   |
-| `global.caInjectionAnnotations` | CA injection annotations for cert-manager.io configuration                | `{}`   |
+| Name                            | Description                                                               | Value     |
+| ------------------------------- | ------------------------------------------------------------------------- | --------- |
+| `global.certManagerEnabled`     | Enable this value to install Keptn Certificate Manager                    | `true`    |
+| `global.imageRegistry`          | Global container image registry                                           | `ghcr.io` |
+| `global.imagePullSecrets`       | Global Docker registry secret names as an array                           | `[]`      |
+| `global.imagePullPolicy`        | specify global pull policy                                                | `""`      |
+| `global.commonLabels`           | Common labels to add to all Keptn resources. Evaluated as a template      | `{}`      |
+| `global.commonAnnotations`      | Common annotations to add to all Keptn resources. Evaluated as a template | `{}`      |
+| `global.caInjectionAnnotations` | CA injection annotations for cert-manager.io configuration                | `{}`      |
 
 ### Keptn Metrics Operator common
 
@@ -76,7 +76,7 @@ Prometheus, Dynatrace, DataDog and K8s metric server...
 | `env.exposeKeptnMetrics`                            | enable metrics exporter                                                 | `true`                   |
 | `env.metricsControllerLogLevel`                     | sets the log level of Metrics Controller                                | `0`                      |
 | `env.analysisControllerLogLevel`                    | sets the log level of Analysis Controller                               | `0`                      |
-| `image.registry`                                    | specify the container registry for the metrics-operator image           | `ghcr.io`                |
+| `image.registry`                                    | specify the container registry for the metrics-operator image           | `""`                     |
 | `image.repository`                                  | specify registry for manager image                                      | `keptn/metrics-operator` |
 | `image.tag`                                         | select tag for manager image                                            | `v0.9.2`                 |
 | `image.imagePullPolicy`                             | specify pull policy for the manager image. This overrides global values | `""`                     |

--- a/metrics-operator/chart/templates/_helpers.tpl
+++ b/metrics-operator/chart/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Return the proper Image Registry Secret Names
+*/}}
+{{- define "metricsOperator.imagePullSecrets" -}}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" $) }}
+{{- end -}}

--- a/metrics-operator/chart/templates/deployment.yaml
+++ b/metrics-operator/chart/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
          initialDelaySeconds: 5
          periodSeconds: 10
         {{- end }}
-      imagePullSecrets: {{- include "common.images.imagePullSecrets" . }}
+      {{- include "metricsOperator.imagePullSecrets" . | indent 6 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/metrics-operator/chart/templates/deployment.yaml
+++ b/metrics-operator/chart/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
           mountPath: /tmp/webhook/certs/ 
         {{- if .Values.livenessProbe }}
         livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.livenessProbe "context" $) | nindent 10 }}
-         {{- else }}
+        {{- else }}
         livenessProbe:
          httpGet:
            path: /healthz
@@ -108,7 +108,7 @@ spec:
         {{- end }}
         {{- if .Values.readinessProbe }}
         readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.readinessProbe "context" $) | nindent 10 }}
-         {{- else }}
+        {{- else }}
         readinessProbe:
          httpGet:
            path: /readyz
@@ -116,7 +116,7 @@ spec:
          initialDelaySeconds: 5
          periodSeconds: 10
         {{- end }}
-      {{- include "metricsOperator.imagePullSecrets" . | indent 6 }}
+        {{- include "metricsOperator.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: metrics-operator

--- a/metrics-operator/chart/values.yaml
+++ b/metrics-operator/chart/values.yaml
@@ -7,7 +7,7 @@ global:
   ## @param global.certManagerEnabled Enable this value to install Keptn Certificate Manager
   certManagerEnabled: true
   ## @param global.imageRegistry Global container image registry
-  imageRegistry: ""
+  imageRegistry: "ghcr.io"
 
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
   ## E.g.
@@ -133,7 +133,7 @@ env:
   analysisControllerLogLevel: "0"
 image:
 ## @param     image.registry specify the container registry for the metrics-operator image
-  registry: ghcr.io
+  registry: ""
 ## @param   image.repository specify registry for manager image
   repository: keptn/metrics-operator
 ## @param   image.tag select tag for manager image


### PR DESCRIPTION
### This PR
- updates the common chart to 0.2.1 to fix some global values bugs
- remove all global values from tests where they are not needed
- introduces new tests for global/local/default value precedence (`.github/scripts/.helm-tests/local-global-precedence`)
- introduces new helper functions for all charts to render imagePullSecrets correctly (`helpers.tpl`)

Fixes #2909