### PR TITLE
fix(python-runtime): bump libexpat to v2.6.2

### DIFF
--- a/docs/docs/contribute/docs/linter-requirements.md
+++ b/docs/docs/contribute/docs/linter-requirements.md
@@ -11,7 +11,7 @@ the following configuration is required.
 ## Golangci-lint
 
 Further information can also be found in
-the [`golangci-lint` documentation](https://golangci-lint.run/usage/integrations/).
+the [`golangci-lint` documentation](https://golangci-lint.run/welcome/integrations/).
 
 ### Visual Studio Code
 

--- a/runtimes/python-runtime/Dockerfile
+++ b/runtimes/python-runtime/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source="https://github.com/keptn/lifecycle-toolki
     org.opencontainers.image.vendor="Keptn" \
     org.opencontainers.image.licenses="Apache-2.0"
 
-RUN apk --no-cache add curl libexpat==2.6.0-r0
+RUN apk --no-cache add curl libexpat==2.6.2-r0
 
 RUN pip install -q --disable-pip-version-check pyyaml GitPython requests
 


### PR DESCRIPTION
security scan: https://github.com/keptn/lifecycle-toolkit/actions/runs/8294452725