### PR TITLE
docs: add missing span link to example

### DIFF
--- a/docs/docs/guides/assets/multi-stage-delivery/application-production.yaml
+++ b/docs/docs/guides/assets/multi-stage-delivery/application-production.yaml
@@ -49,3 +49,5 @@ metadata:
 spec:
   metadata:
     commitID: {{.Values.commitID}}
+  spanLinks:
+    - {{ .Values.traceParent }} # (1)!

--- a/docs/docs/guides/assets/multi-stage-delivery/application-production.yaml
+++ b/docs/docs/guides/assets/multi-stage-delivery/application-production.yaml
@@ -50,4 +50,4 @@ spec:
   metadata:
     commitID: {{.Values.commitID}}
   spanLinks:
-    - {{ .Values.traceParent }} # (1)!
+    - {{.Values.traceParent}} # (1)!

--- a/docs/docs/guides/multi-stage-application-delivery.md
+++ b/docs/docs/guides/multi-stage-application-delivery.md
@@ -159,6 +159,8 @@ containing the manifests for the `dev` and `production` stage:
     {% include "./assets/multi-stage-delivery/application-production.yaml" %}
     ```
 
+    1. Setting the spanLink here connects deployment traces of this stage with the traces of the dev stage
+
 === "production/Chart.yaml"
 
     The `Chart.yaml` that is required by helm:


### PR DESCRIPTION
The spanLinks attribute was missing in the example, leading to some confusion about how the deployment traces are actually connected with each other