### PR TITLE
feat(lifecycle-operator): add namespace to `deploymentduration` metrics

### DIFF
--- a/lifecycle-operator/apis/lifecycle/v1beta1/keptnappversion_types.go
+++ b/lifecycle-operator/apis/lifecycle/v1beta1/keptnappversion_types.go
@@ -311,6 +311,7 @@ func (a KeptnAppVersion) GetMetricsAttributes() []attribute.KeyValue {
 func (a KeptnAppVersion) GetDurationMetricsAttributes() []attribute.KeyValue {
 	return []attribute.KeyValue{
 		common.AppName.String(a.Spec.AppName),
+		common.AppNamespace.String(a.Namespace),
 		common.AppVersion.String(a.Spec.Version),
 		common.AppPreviousVersion.String(a.Spec.PreviousVersion),
 	}

--- a/lifecycle-operator/apis/lifecycle/v1beta1/keptnappversion_types_test.go
+++ b/lifecycle-operator/apis/lifecycle/v1beta1/keptnappversion_types_test.go
@@ -151,6 +151,7 @@ func TestKeptnAppVersion(t *testing.T) {
 
 	require.Equal(t, []attribute.KeyValue{
 		common.AppName.String("appname"),
+		common.AppNamespace.String("namespace"),
 		common.AppVersion.String("version"),
 		common.AppPreviousVersion.String("prev"),
 	}, app.GetDurationMetricsAttributes())

--- a/lifecycle-operator/apis/lifecycle/v1beta1/keptnworkloadversion_types.go
+++ b/lifecycle-operator/apis/lifecycle/v1beta1/keptnworkloadversion_types.go
@@ -311,6 +311,7 @@ func (w KeptnWorkloadVersion) GetDurationMetricsAttributes() []attribute.KeyValu
 	return []attribute.KeyValue{
 		common.AppName.String(w.Spec.AppName),
 		common.WorkloadName.String(w.Spec.WorkloadName),
+		common.WorkloadNamespace.String(w.Namespace),
 		common.WorkloadVersion.String(w.Spec.Version),
 		common.WorkloadPreviousVersion.String(w.Spec.PreviousVersion),
 	}

--- a/lifecycle-operator/apis/lifecycle/v1beta1/keptnworkloadversion_types_test.go
+++ b/lifecycle-operator/apis/lifecycle/v1beta1/keptnworkloadversion_types_test.go
@@ -141,6 +141,7 @@ func TestKeptnWorkloadVersion(t *testing.T) {
 	require.Equal(t, []attribute.KeyValue{
 		common.AppName.String("appname"),
 		common.WorkloadName.String("workloadname"),
+		common.WorkloadNamespace.String("namespace"),
 		common.WorkloadVersion.String("version"),
 		common.WorkloadPreviousVersion.String("prev"),
 	}, workload.GetDurationMetricsAttributes())


### PR DESCRIPTION
# Description

This PR adds namespace attributes to both `keptn_app_deploymentduration` and `keptn_deployment_deploymentduration` metrics.

All other DORA specific metrics include either the `keptn_deployment_app_namespace` or the `keptn_deployment_workload_namespace`, except for the `_deploymentduration`. This PR fixes that.

This is useful for our usecase where we want to filter deploymentduration per namespace instead of per app.

# How to test

Unit tests have been updated, manual verification was done to check if these namespace attributes are present on the exported metrics at `localhost:2222/metrics`.

# Checklist

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [x] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [x] New and existing unit and integration tests pass locally with my changes
