### PR TITLE
docs: reduce blogpost title length to fit into social card

### DIFF
--- a/docs/blog/posts/stable-release-announcement.md
+++ b/docs/blog/posts/stable-release-announcement.md
@@ -8,7 +8,7 @@ categories:
 comments: true
 ---
 
-# Announcing the Official Release Candidate for Keptn v2
+# Announcing the Release Candidate for Keptn v2
 
 The Keptn project is proud to announce a release candidate for what will become Keptn v2.
 User feedback to the Keptn project has been clear, and we’ve listened.

--- a/docs/blog/posts/stable-release-announcement.md
+++ b/docs/blog/posts/stable-release-announcement.md
@@ -6,6 +6,7 @@ description: >
 categories:
   - Announcement
 comments: true
+slug: announcing-the-official-release-candidate-for-keptn-v2
 ---
 
 # Announcing the Release Candidate for Keptn v2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,9 @@ extra_css:
   - assets/stylesheets/mermaid.css
 plugins:
   - search
-  - social
+  - social:
+      cards_layout_options:
+        background_color: "#006bba"
   - include-markdown:
       trailing_newlines: false
   - git-revision-date-localized:


### PR DESCRIPTION
### This PR
- adjusts the release candidate blogpost title so that it fits into the social card while sharing (see screenshot)
- set the post slug to the old one so that the URL that is already released stays the same as before
- adjusts the social card background color to use the default Keptn color


### Before
![Screenshot 2024-03-19 at 11 51 38](https://github.com/keptn/lifecycle-toolkit/assets/6901203/8817809b-74b9-4fef-89d4-a44dfb5ad84d)

### After
![Screenshot 2024-03-19 at 11 51 10](https://github.com/keptn/lifecycle-toolkit/assets/6901203/91bd7941-5b2b-48e8-a609-2afb50497c50)
