### PR TITLE
docs: add use case page for KEDA

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -229,6 +229,7 @@ GSo
 gstatic
 gtm
 GVK
+GVKR
 healthz
 hellopy
 helloworldtask

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,6 +5,8 @@ config:
     line_length: 120
     tables: false
     code_blocks: false
+  code-block-style:
+    style: fenced
   no-inline-html:
     allowed_elements:
       - details

--- a/docs/docs/use-cases/assets/keda/k-describe-metric.txt
+++ b/docs/docs/use-cases/assets/keda/k-describe-metric.txt
@@ -1,0 +1,13 @@
+$ kubectl describe keptnmetrics.metrics.keptn.sh cpu-throttling -n podtato-kubectl
+Name:         cpu-throttling
+Namespace:    podtato-kubectl
+API Version:  metrics.keptn.sh/v1
+Kind:         KeptnMetric
+Spec:
+  Fetch Interval Seconds:  60
+  Provider:
+    Name:  prometheus-provider
+  Query:  avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-kubectl"}))
+Status:
+  Raw Value: <omitted for readability>
+  Value:         4.53

--- a/docs/docs/use-cases/assets/keda/k-describe-scaledobject.txt
+++ b/docs/docs/use-cases/assets/keda/k-describe-scaledobject.txt
@@ -1,0 +1,56 @@
+$ kubectl describe scaledobject -n podtato-kubectl my-scaledobject
+Name:         my-scaledobject
+Namespace:    podtato-kubectl
+Labels:       deploymentName=podtato-head-entry
+              scaledobject.keda.sh/name=my-scaledobject
+API Version:  keda.sh/v1alpha1
+Kind:         ScaledObject
+Spec:
+  Max Replica Count:  3
+  Scale Target Ref:
+    Name:  podtato-head-entry
+  Triggers:
+    Metadata:
+      Target Value:    1
+      Unsafe Ssl:      true
+      URL:             http://metrics-operator-service.keptn-system.svc.cluster.local:9999/api/v1/metrics/chainsaw-proud-wallaby/test
+      Value Location:  value
+    Type:              metrics-api
+Status:
+  Conditions:
+    Message:  ScaledObject is defined correctly and is ready for scaling
+    Reason:   ScaledObjectReady
+    Status:   True
+    Type:     Ready
+    Message:  Scaling is not performed because triggers are not active
+    Reason:   ScalerNotActive
+    Status:   False
+    Type:     Active
+    Message:  No fallbacks are active on this scaled object
+    Reason:   NoFallbackFound
+    Status:   False
+    Type:     Fallback
+    Status:   Unknown
+    Type:     Paused
+  External Metric Names:
+    s0-metric-api-value
+  Health:
+    s0-metric-api-value:
+      Number Of Failures:  0
+      Status:              Happy
+  Hpa Name:                keda-hpa-test-scaledobject
+  Last Active Time:        2024-03-26T09:36:36Z
+  Original Replica Count:  1
+  Scale Target GVKR:
+    Group:            apps
+    Kind:             Deployment
+    Resource:         deployments
+    Version:          v1
+  Scale Target Kind:  apps/v1.Deployment
+Events:
+  Type     Reason              Age                From           Message
+  ----     ------              ----               ----           -------
+  Normal   KEDAScalersStarted  63s                keda-operator  Started scalers watch
+  Normal   ScaledObjectReady   63s                keda-operator  ScaledObject is ready for scaling
+  Warning  KEDAScalerFailed    33s (x2 over 63s)  keda-operator  error requesting metrics endpoint: valueLocation must point to value of type number or a string representing a Quantity got: ''
+  Normal   KEDAScalersStarted  18s (x5 over 63s)  keda-operator  Scaler metrics-api is built.

--- a/docs/docs/use-cases/assets/keda/k-get-pods-result.txt
+++ b/docs/docs/use-cases/assets/keda/k-get-pods-result.txt
@@ -1,0 +1,5 @@
+$ kubectl get pods -n podtato-kubectl
+NAME                                  READY   STATUS    RESTARTS   AGE
+podtato-head-entry-7796c8f786-4cdtc   1/1     Running   0          3m29s
+podtato-head-entry-7796c8f786-nsk2c   1/1     Running   0          2m41s
+podtato-head-entry-7796c8f786-qj85h   1/1     Running   0          2m41s

--- a/docs/docs/use-cases/assets/keda/keptnmetric.yaml
+++ b/docs/docs/use-cases/assets/keda/keptnmetric.yaml
@@ -1,0 +1,20 @@
+apiVersion: metrics.keptn.sh/v1
+kind: KeptnMetricsProvider
+metadata:
+  name: prometheus-provider
+  namespace: podtato-kubectl
+spec:
+  type: prometheus
+  targetServer: <your-metrics-provider-server>
+---
+apiVersion: metrics.keptn.sh/v1
+kind: KeptnMetric
+metadata:
+  name: cpu-throttling
+spec:
+  provider:
+    name: prometheus-provider
+  query: 'avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-kubectl"}))'
+  fetchIntervalSeconds: 10
+  range:
+    interval: "30s"

--- a/docs/docs/use-cases/assets/keda/keptnmetric.yaml
+++ b/docs/docs/use-cases/assets/keda/keptnmetric.yaml
@@ -1,13 +1,4 @@
 apiVersion: metrics.keptn.sh/v1
-kind: KeptnMetricsProvider
-metadata:
-  name: prometheus-provider
-  namespace: podtato-kubectl
-spec:
-  type: prometheus
-  targetServer: <your-metrics-provider-server>
----
-apiVersion: metrics.keptn.sh/v1
 kind: KeptnMetric
 metadata:
   name: cpu-throttling

--- a/docs/docs/use-cases/assets/keda/keptnmetric.yaml
+++ b/docs/docs/use-cases/assets/keda/keptnmetric.yaml
@@ -2,6 +2,7 @@ apiVersion: metrics.keptn.sh/v1
 kind: KeptnMetric
 metadata:
   name: cpu-throttling
+  namespace: podtato-kubectl
 spec:
   provider:
     name: prometheus-provider

--- a/docs/docs/use-cases/assets/keda/keptnmetricsprovider.yaml
+++ b/docs/docs/use-cases/assets/keda/keptnmetricsprovider.yaml
@@ -1,0 +1,8 @@
+apiVersion: metrics.keptn.sh/v1
+kind: KeptnMetricsProvider
+metadata:
+  name: prometheus-provider
+  namespace: podtato-kubectl
+spec:
+  type: prometheus
+  targetServer: <your-metrics-provider-server>

--- a/docs/docs/use-cases/assets/keda/sample-app.yaml
+++ b/docs/docs/use-cases/assets/keda/sample-app.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    matchLabels:
+      component: podtato-head-entry
+  template:
+    metadata:
+      labels:
+        component: podtato-head-entry
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: server
+          image: ghcr.io/podtato-head/entry:0.2.7
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 5m
+              memory: 128Mi
+            requests:
+              cpu: 1m
+              memory: 64Mi
+          ports:
+            - containerPort: 9000
+          env:
+            - name: PODTATO_PORT
+              value: "9000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-entry
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      nodePort: 30900
+      targetPort: 9000
+  type: NodePort

--- a/docs/docs/use-cases/assets/keda/sample-app.yaml
+++ b/docs/docs/use-cases/assets/keda/sample-app.yaml
@@ -31,21 +31,3 @@ spec:
           env:
             - name: PODTATO_PORT
               value: "9000"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: podtato-head-entry
-  namespace: podtato-kubectl
-  labels:
-    app: podtato-head
-spec:
-  selector:
-    component: podtato-head-entry
-  ports:
-    - name: http
-      port: 9000
-      protocol: TCP
-      nodePort: 30900
-      targetPort: 9000
-  type: NodePort

--- a/docs/docs/use-cases/assets/keda/sample-service.yaml
+++ b/docs/docs/use-cases/assets/keda/sample-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: podtato-head-entry
+  namespace: podtato-kubectl
+  labels:
+    app: podtato-head
+spec:
+  selector:
+    component: podtato-head-entry
+  ports:
+    - name: http
+      port: 9000
+      protocol: TCP
+      nodePort: 30900
+      targetPort: 9000
+  type: NodePort

--- a/docs/docs/use-cases/assets/keda/scaledobject.yaml
+++ b/docs/docs/use-cases/assets/keda/scaledobject.yaml
@@ -1,0 +1,17 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: my-scaledobject
+  labels:
+    deploymentName: podtato-head-entry
+spec:
+  maxReplicaCount: 3
+  scaleTargetRef:
+    name: podtato-head-entry
+  triggers:
+    - type: metrics-api
+      metadata:
+        targetValue: "1"
+        valueLocation: 'value'
+        url: 'http://metrics-operator-service.keptn-system.svc.cluster.local:9999/api/v1/metrics/podtato-kubectl/cpu-throttling'
+        unsafeSsl: "true"

--- a/docs/docs/use-cases/assets/keda/scaledobject.yaml
+++ b/docs/docs/use-cases/assets/keda/scaledobject.yaml
@@ -2,6 +2,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: my-scaledobject
+  namespace: podtato-kubectl
   labels:
     deploymentName: podtato-head-entry
 spec:

--- a/docs/docs/use-cases/hpa.md
+++ b/docs/docs/use-cases/hpa.md
@@ -54,10 +54,11 @@ $ kubectl get pods -n podtato-kubectl
 podtato-head-entry-58d6485d9b-ld9x2         1/1     Running     (2m ago)
 ```
 
-## Create KeptnMetric and KeptnMetricsProvider custom resources
+## Create KeptnMetric and KeptnMetricsProvider resources
 
 To be able to react on the metrics of our application, we need to create
-`KeptnMetrics` and `KeptnMetricsProvider` custom resources.
+[KeptnMetrics](../reference/crd-reference/metric.md) and
+[KeptnMetricsProvider](../reference/crd-reference/metricsprovider.md) resources.
 These metrics are
 exposed via the custom metrics API, which gives us the possibility to configure
 the HPA to react on the values of these metrics:
@@ -66,7 +67,7 @@ the HPA to react on the values of these metrics:
 {% include "./assets/hpa/keptnmetric.yaml" %}
 ```
 
-For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
+For more information about the `KeptnMetric` and `KeptnMetricsProvider` resources,
 please refer to the [CRD documentation](../reference/api-reference/metrics/v1/index.md).
 
 After a few seconds we should be able to see values for the `cpu-throttling` metric:
@@ -92,7 +93,7 @@ Here we can see that the value of the `cpu-throttling` metric is `1.63`
 ## Set up the HorizontalPodAutoscaler
 
 Now that we are able to retrieve the value of our metric, and have it stored in
-our cluster in the status of our `KeptnMetric` custom resource, we can configure
+our cluster in the status of our `KeptnMetric` resource, we can configure
 a `HorizontalPodAutoscaler` to make use of this information and therefore scale
 our application automatically:
 

--- a/docs/docs/use-cases/hpa.md
+++ b/docs/docs/use-cases/hpa.md
@@ -2,9 +2,7 @@
 comments: true
 ---
 
-# Keptn + HorizontalPodAutoscaler
-
-## Scaling Workloads based on Keptn metrics
+# Scaling Workloads with HPA based on Keptn metrics
 
 Kubernetes provides many built-in capabilities to ensure
 that enough replicas are running in order to meet the current demand of

--- a/docs/docs/use-cases/hpa.md
+++ b/docs/docs/use-cases/hpa.md
@@ -17,7 +17,7 @@ to scale the number of replicas of [workloads](https://kubernetes.io/docs/concep
 load.
 It does this by using metrics such as CPU throttling, memory consumption, or response time.
 
-### Installation of Keptn Metrics Operator
+## Installation of Keptn Metrics Operator
 
 To use an HPA with the custom metrics API, the
 Keptn Metrics Operator must be installed on the cluster.
@@ -27,7 +27,7 @@ For more information about installation please refer to the
 > **Note**
   The Keptn Lifecycle Operator does not need to be installed for this use-case.
 
-### Installation of metrics provider (optional)
+## Installation of metrics provider (optional)
 
 If you do not have a metrics provider installed on your cluster yet, please do so.
 
@@ -35,7 +35,7 @@ For this tutorial we are going to use [Prometheus](https://prometheus.io/).
 For more information about how to install Prometheus into your cluster, please
 refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
 
-### Deploy sample application
+## Deploy sample application
 
 First, we need to deploy our application to the cluster.
 For this we are going to
@@ -54,7 +54,7 @@ $ kubectl get pods -n podtato-kubectl
 podtato-head-entry-58d6485d9b-ld9x2         1/1     Running     (2m ago)
 ```
 
-### Create KeptnMetric and KeptnMetricsProvider custom resources
+## Create KeptnMetric and KeptnMetricsProvider custom resources
 
 To be able to react on the metrics of our application, we need to create
 `KeptnMetrics` and `KeptnMetricsProvider` custom resources.
@@ -89,7 +89,7 @@ Status:
 
 Here we can see that the value of the `cpu-throttling` metric is `1.63`
 
-### Set up the HorizontalPodAutoscaler
+## Set up the HorizontalPodAutoscaler
 
 Now that we are able to retrieve the value of our metric, and have it stored in
 our cluster in the status of our `KeptnMetric` custom resource, we can configure

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -124,7 +124,7 @@ our application automatically:
 As we can see in this example, by setting the `url` field,
 we are now referring to the `KeptnMetric` and fetch it from the
 Keptn Metrics Operator.
-KEDA will scale up our application, until our target value or `1` is reached,
+KEDA will scale up our application, until our target value of `1` is reached,
 or we hit the maximum number of replicas which is `3` in this example.
 
 If the load of the application is high enough, we will be able to see

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -42,15 +42,15 @@ use a single service `podtato-head` application.
 
 === "deployment.yaml"
 
-    ```yaml
-    {% include "./assets/keda/sample-app.yaml" %}
-    ```
+```yaml
+{% include "./assets/keda/sample-app.yaml" %}
+```
 
 === "service.yaml"
 
-    ```yaml
-    {% include "./assets/keda/sample-service.yaml" %}
-    ```
+```yaml
+{% include "./assets/keda/sample-service.yaml" %}
+```
 
 <!-- markdownlint-enable MD046 -->
 
@@ -75,15 +75,15 @@ KEDA to react on the values of these metrics:
 
 === "KeptnMetric"
 
-    ```yaml
-    {% include "./assets/keda/keptnmetric.yaml" %}
-    ```
+```yaml
+{% include "./assets/keda/keptnmetric.yaml" %}
+```
 
 === "KeptnMetricsProvider"
 
-    ```yaml
-    {% include "./assets/keda/keptnmetricsprovider.yaml" %}
-    ```
+```yaml
+{% include "./assets/keda/keptnmetricsprovider.yaml" %}
+```
 
 <!-- markdownlint-enable MD046 -->
 
@@ -126,7 +126,6 @@ we are now referring to the `KeptnMetric` and fetch it from the
 Keptn Metrics Operator.
 KEDA will scale up our application, until our target value or `1` is reached,
 or we hit the maximum number of replicas which is `3` in this example.
-
 
 If the load of the application is high enough, we will be able to see
 the automatic scaling of our application:

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -2,34 +2,28 @@
 comments: true
 ---
 
-# Keptn + KEDA
+# Scaling Workloads with KEDA based on Keptn metrics
 
-## Scaling Workloads based on Keptn metrics
+If you want to use KEDA to scale your workloads, you can set it up
+to consume metrics from Keptn.
+This gives you great flexibility for your setup since Keptn can
+consolidate different observability providers for you and KEDA
+will simplify the scaling operations for you.
 
-Kubernetes provides many built-in capabilities to ensure
-that enough replicas are running in order to meet the current demand of
-your [workloads](https://kubernetes.io/docs/concepts/workloads/).
-One of these is the
-[HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-(HPA).
-
-An HPA can make use of the Keptn Metrics
+This use case is enabled by the Keptn Metrics
 [custom API](https://kubernetes.io/docs/reference/external-api/custom-metrics.v1beta2/)
-to scale the number of replicas of [workloads](https://kubernetes.io/docs/concepts/workloads/) based on the current
-load.
-It does this by using metrics such as CPU throttling, memory consumption, or response time.
+that the Keptn Metrics Operator provides.
 
-### Installation of Keptn Metrics Operator
+## Installation of Keptn Metrics Operator
 
-To use an HPA with the custom metrics API, the
+To use KEDA with Keptn, the
 Keptn Metrics Operator must be installed on the cluster.
 For more information about installation please refer to the
 [installation guide](../installation/index.md).
 
-> **Note**
-  The Keptn Lifecycle Operator does not need to be installed for this use-case.
+> The Keptn Lifecycle Operator does not need to be installed for this use-case.
 
-### Installation of metrics provider (optional)
+## Installation of metrics provider (optional)
 
 If you do not have a metrics provider installed on your cluster yet, please do so.
 
@@ -37,14 +31,14 @@ For this tutorial we are going to use [Prometheus](https://prometheus.io/).
 For more information about how to install Prometheus into your cluster, please
 refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
 
-### Deploy sample application
+## Deploy sample application
 
 First, we need to deploy our application to the cluster.
 For this we are going to
 use a single service `podtato-head` application.
 
 ```yaml
-{% include "./assets/hpa/sample-app.yaml" %}
+{% include "./assets/keda/sample-app.yaml" %}
 ```
 
 Please create a `podtato-kubectl` namespace and apply the above manifest
@@ -56,7 +50,7 @@ $ kubectl get pods -n podtato-kubectl
 podtato-head-entry-58d6485d9b-ld9x2         1/1     Running     (2m ago)
 ```
 
-### Create KeptnMetric and KeptnMetricsProvider custom resources
+## Create KeptnMetric and KeptnMetricsProvider custom resources
 
 To be able to react on the metrics of our application, we need to create
 `KeptnMetrics` and `KeptnMetricsProvider` custom resources.
@@ -65,7 +59,7 @@ exposed via the custom metrics API, which gives us the possibility to configure
 the HPA to react on the values of these metrics:
 
 ```yaml
-{% include "./assets/hpa/keptnmetric.yaml" %}
+{% include "./assets/keda/keptnmetric.yaml" %}
 ```
 
 For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
@@ -91,7 +85,7 @@ Status:
 
 Here we can see that the value of the `cpu-throttling` metric is `1.63`
 
-### Set up the HorizontalPodAutoscaler
+## Set up the HorizontalPodAutoscaler
 
 Now that we are able to retrieve the value of our metric, and have it stored in
 our cluster in the status of our `KeptnMetric` custom resource, we can configure
@@ -99,7 +93,7 @@ a `HorizontalPodAutoscaler` to make use of this information and therefore scale
 our application automatically:
 
 ```yaml
-{% include "./assets/hpa/hpa.yaml" %}
+{% include "./assets/keda/hpa.yaml" %}
 ```
 
 As we can see in this example, we are now referring to the `KeptnMetric`

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -4,7 +4,7 @@ comments: true
 
 # Scaling Workloads with KEDA based on Keptn metrics
 
-If you want to use KEDA to scale your workloads, you can set it up
+If you want to use [KEDA](https://keda.sh/) to scale your workloads, you can set it up
 to consume metrics from Keptn.
 This gives you great flexibility for your setup since Keptn can
 consolidate different observability providers for you and KEDA
@@ -14,22 +14,24 @@ This use case is enabled by the Keptn Metrics
 [custom API](https://kubernetes.io/docs/reference/external-api/custom-metrics.v1beta2/)
 that the Keptn Metrics Operator provides.
 
-## Installation of Keptn Metrics Operator
+## Before you begin
 
-To use KEDA with Keptn, the
-Keptn Metrics Operator must be installed on the cluster.
-For more information about installation please refer to the
-[installation guide](../installation/index.md).
+For this use case presentation, a few components need to be deployed to the
+cluster in order to have a full setup:
 
-> The Keptn Lifecycle Operator does not need to be installed for this use-case.
+- Keptn Metrics Operator: Will be used for metrics consolidation.
 
-## Installation of metrics provider (optional)
+    For more information about installation please refer to the
+    [installation guide](../installation/index.md).
 
-If you do not have a metrics provider installed on your cluster yet, please do so.
+    > The Keptn Lifecycle Operator does not need to be installed for this use-case.
 
-For this tutorial we are going to use [Prometheus](https://prometheus.io/).
-For more information about how to install Prometheus into your cluster, please
-refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
+- [KEDA](https://keda.sh/): Will be used for scaling.
+- [Prometheus](https://prometheus.io/): Will be used as metrics provider.
+  
+    For more information about how to install Prometheus into your cluster, please
+    refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
+
 
 ## Deploy sample application
 
@@ -37,11 +39,19 @@ First, we need to deploy our application to the cluster.
 For this we are going to
 use a single service `podtato-head` application.
 
-```yaml
-{% include "./assets/keda/sample-app.yaml" %}
-```
+=== "deployment.yaml"
 
-Please create a `podtato-kubectl` namespace and apply the above manifest
+    ```yaml
+    {% include "./assets/keda/sample-app.yaml" %}
+    ```
+
+=== "service.yaml"
+
+    ```yaml
+    {% include "./assets/keda/sample-service.yaml" %}
+    ```
+
+Please create a `podtato-kubectl` namespace and apply the above manifests
 to your cluster and continue with the next steps.
 After applying, please make sure that the application is up and running:
 
@@ -55,12 +65,20 @@ podtato-head-entry-58d6485d9b-ld9x2         1/1     Running     (2m ago)
 To be able to react on the metrics of our application, we need to create
 `KeptnMetrics` and `KeptnMetricsProvider` custom resources.
 These metrics are
-exposed via the custom metrics API, which gives us the possibility to configure
-the HPA to react on the values of these metrics:
+exposed via the Keptn Metrics Operator, which gives us the possibility to configure
+KEDA to react on the values of these metrics:
 
-```yaml
-{% include "./assets/keda/keptnmetric.yaml" %}
-```
+=== "KeptnMetric"
+
+    ```yaml
+    {% include "./assets/keda/keptnmetric.yaml" %}
+    ```
+
+=== "KeptnMetricsProvider"
+
+    ```yaml
+    {% include "./assets/keda/keptnmetricsprovider.yaml" %}
+    ```
 
 For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
 please refer to the [CRD documentation](../reference/api-reference/metrics/v1/index.md).
@@ -85,7 +103,7 @@ Status:
 
 Here we can see that the value of the `cpu-throttling` metric is `1.63`
 
-## Set up the HorizontalPodAutoscaler
+## Set up the KEDA ScaledObject
 
 Now that we are able to retrieve the value of our metric, and have it stored in
 our cluster in the status of our `KeptnMetric` custom resource, we can configure
@@ -93,7 +111,7 @@ a `HorizontalPodAutoscaler` to make use of this information and therefore scale
 our application automatically:
 
 ```yaml
-{% include "./assets/keda/hpa.yaml" %}
+{% include "./assets/keda/scaledobject.yaml" %}
 ```
 
 As we can see in this example, we are now referring to the `KeptnMetric`

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -1,0 +1,153 @@
+---
+comments: true
+---
+
+# Keptn + KEDA
+
+## Scaling Workloads based on Keptn metrics
+
+Kubernetes provides many built-in capabilities to ensure
+that enough replicas are running in order to meet the current demand of
+your [workloads](https://kubernetes.io/docs/concepts/workloads/).
+One of these is the
+[HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+(HPA).
+
+An HPA can make use of the Keptn Metrics
+[custom API](https://kubernetes.io/docs/reference/external-api/custom-metrics.v1beta2/)
+to scale the number of replicas of [workloads](https://kubernetes.io/docs/concepts/workloads/) based on the current
+load.
+It does this by using metrics such as CPU throttling, memory consumption, or response time.
+
+### Installation of Keptn Metrics Operator
+
+To use an HPA with the custom metrics API, the
+Keptn Metrics Operator must be installed on the cluster.
+For more information about installation please refer to the
+[installation guide](../installation/index.md).
+
+> **Note**
+  The Keptn Lifecycle Operator does not need to be installed for this use-case.
+
+### Installation of metrics provider (optional)
+
+If you do not have a metrics provider installed on your cluster yet, please do so.
+
+For this tutorial we are going to use [Prometheus](https://prometheus.io/).
+For more information about how to install Prometheus into your cluster, please
+refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
+
+### Deploy sample application
+
+First, we need to deploy our application to the cluster.
+For this we are going to
+use a single service `podtato-head` application.
+
+```yaml
+{% include "./assets/hpa/sample-app.yaml" %}
+```
+
+Please create a `podtato-kubectl` namespace and apply the above manifest
+to your cluster and continue with the next steps.
+After applying, please make sure that the application is up and running:
+
+```shell
+$ kubectl get pods -n podtato-kubectl
+podtato-head-entry-58d6485d9b-ld9x2         1/1     Running     (2m ago)
+```
+
+### Create KeptnMetric and KeptnMetricsProvider custom resources
+
+To be able to react on the metrics of our application, we need to create
+`KeptnMetrics` and `KeptnMetricsProvider` custom resources.
+These metrics are
+exposed via the custom metrics API, which gives us the possibility to configure
+the HPA to react on the values of these metrics:
+
+```yaml
+{% include "./assets/hpa/keptnmetric.yaml" %}
+```
+
+For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
+please refer to the [CRD documentation](../reference/api-reference/metrics/v1/index.md).
+
+After a few seconds we should be able to see values for the `cpu-throttling` metric:
+
+```shell
+$ kubectl describe  keptnmetrics.metrics.keptn.sh cpu-throttling -n podtato-kubectl
+Name:         cpu-throttling
+Namespace:    podtato-kubectl
+API Version:  metrics.keptn.sh/v1
+Kind:         KeptnMetric
+Spec:
+  Fetch Interval Seconds:  60
+  Provider:
+    Name:  prometheus-provider
+  Query:  avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-kubectl"}))
+Status:
+  Raw Value: <omitted for readability>
+  Value:         1.63
+```
+
+Here we can see that the value of the `cpu-throttling` metric is `1.63`
+
+### Set up the HorizontalPodAutoscaler
+
+Now that we are able to retrieve the value of our metric, and have it stored in
+our cluster in the status of our `KeptnMetric` custom resource, we can configure
+a `HorizontalPodAutoscaler` to make use of this information and therefore scale
+our application automatically:
+
+```yaml
+{% include "./assets/hpa/hpa.yaml" %}
+```
+
+As we can see in this example, we are now referring to the `KeptnMetric`
+we applied earlier, and tell the HPA to scale up our application, until our
+target value of `5` for this metric is reached, or the number of replicas
+has reached a maximum of `10`.
+
+If the load of the application is high enough, we will be able to see
+the automatic scaling of our application:
+
+```shell
+$ kubectl describe  horizontalpodautoscalers.autoscaling -n podtato-kubectl podtato-hpa
+Name:                                                             podtato-hpa
+Namespace:                                                        podtato-kubectl
+Reference:                                                        Deployment/podtato-head-entry
+Metrics:                                                          ( current / target )
+  "cpu-throttling" on KeptnMetric/cpu-throttling (target value):  30.5 / 5
+Min replicas:                                                     1
+Max replicas:                                                     10
+Deployment pods:                                                  10 current / 10 desired
+Conditions:
+  Type            Status  Reason               Message
+  ----            ------  ------               -------
+  AbleToScale     True    ScaleDownStabilized  recent recommendations were higher than current one, applying the highest recent recommendation
+  ScalingActive   True    ValidMetricFound     the HPA was able to successfully calculate a replica count from KeptnMetric metric cpu-throttling
+  ScalingLimited  True    TooManyReplicas      the desired replica count is more than the maximum replica count
+Events:
+  Type    Reason             Age                  From                       Message
+  ----    ------             ----                 ----                       -------
+  Normal  SuccessfulRescale  7m18s (x5 over 16h)  horizontal-pod-autoscaler  New size: 4; reason: KeptnMetric metric cpu-throttling above target
+  Normal  SuccessfulRescale  6m18s                horizontal-pod-autoscaler  New size: 7; reason: KeptnMetric metric cpu-throttling above target
+  Normal  SuccessfulRescale  6m3s (x4 over 16h)   horizontal-pod-autoscaler  New size: 10; reason: KeptnMetric metric cpu-throttling above target
+```
+
+If we retrieve the pods of our application, we can see that, instead of
+a single instance at the beginning, there are currently 10 instances running:
+
+```shell
+$ kubectl get pods -n podtato-kubectl
+NAME                                      READY   STATUS    RESTARTS   AGE
+podtato-head-entry-795b4bf76c-22vl8       1/1     Running   0          4m50s
+podtato-head-entry-795b4bf76c-4mqz5       1/1     Running   0          4m50s
+podtato-head-entry-795b4bf76c-g5bcr       1/1     Running   0          5m5s
+podtato-head-entry-795b4bf76c-h22pq       1/1     Running   0          6m5s
+podtato-head-entry-795b4bf76c-kgcgb       1/1     Running   0          4m50s
+podtato-head-entry-795b4bf76c-kkt82       1/1     Running   0          5m5s
+podtato-head-entry-795b4bf76c-lmfnx       1/1     Running   0          6m5s
+podtato-head-entry-795b4bf76c-pnq2f       1/1     Running   0          15m
+podtato-head-entry-795b4bf76c-r5dx4       1/1     Running   0          5m5s
+podtato-head-entry-795b4bf76c-vwdj7       1/1     Running   0          6m5s
+```

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -125,43 +125,71 @@ If the load of the application is high enough, we will be able to see
 the automatic scaling of our application:
 
 ```shell
-$ kubectl describe  horizontalpodautoscalers.autoscaling -n podtato-kubectl podtato-hpa
-Name:                                                             podtato-hpa
-Namespace:                                                        podtato-kubectl
-Reference:                                                        Deployment/podtato-head-entry
-Metrics:                                                          ( current / target )
-  "cpu-throttling" on KeptnMetric/cpu-throttling (target value):  30.5 / 5
-Min replicas:                                                     1
-Max replicas:                                                     10
-Deployment pods:                                                  10 current / 10 desired
-Conditions:
-  Type            Status  Reason               Message
-  ----            ------  ------               -------
-  AbleToScale     True    ScaleDownStabilized  recent recommendations were higher than current one, applying the highest recent recommendation
-  ScalingActive   True    ValidMetricFound     the HPA was able to successfully calculate a replica count from KeptnMetric metric cpu-throttling
-  ScalingLimited  True    TooManyReplicas      the desired replica count is more than the maximum replica count
+$ kubectl describe scaledobject -n podtato-kubectl my-scaledobject
+Name:         my-scaledobject
+Namespace:    podtato-kubectl
+Labels:       deploymentName=podtato-head-entry
+              scaledobject.keda.sh/name=my-scaledobject
+API Version:  keda.sh/v1alpha1
+Kind:         ScaledObject
+Spec:
+  Max Replica Count:  3
+  Scale Target Ref:
+    Name:  podtato-head-entry
+  Triggers:
+    Metadata:
+      Target Value:    1
+      Unsafe Ssl:      true
+      URL:             http://metrics-operator-service.keptn-system.svc.cluster.local:9999/api/v1/metrics/chainsaw-proud-wallaby/test
+      Value Location:  value
+    Type:              metrics-api
+Status:
+  Conditions:
+    Message:  ScaledObject is defined correctly and is ready for scaling
+    Reason:   ScaledObjectReady
+    Status:   True
+    Type:     Ready
+    Message:  Scaling is not performed because triggers are not active
+    Reason:   ScalerNotActive
+    Status:   False
+    Type:     Active
+    Message:  No fallbacks are active on this scaled object
+    Reason:   NoFallbackFound
+    Status:   False
+    Type:     Fallback
+    Status:   Unknown
+    Type:     Paused
+  External Metric Names:
+    s0-metric-api-value
+  Health:
+    s0-metric-api-value:
+      Number Of Failures:  0
+      Status:              Happy
+  Hpa Name:                keda-hpa-test-scaledobject
+  Last Active Time:        2024-03-26T09:36:36Z
+  Original Replica Count:  1
+  Scale Target GVKR:
+    Group:            apps
+    Kind:             Deployment
+    Resource:         deployments
+    Version:          v1
+  Scale Target Kind:  apps/v1.Deployment
 Events:
-  Type    Reason             Age                  From                       Message
-  ----    ------             ----                 ----                       -------
-  Normal  SuccessfulRescale  7m18s (x5 over 16h)  horizontal-pod-autoscaler  New size: 4; reason: KeptnMetric metric cpu-throttling above target
-  Normal  SuccessfulRescale  6m18s                horizontal-pod-autoscaler  New size: 7; reason: KeptnMetric metric cpu-throttling above target
-  Normal  SuccessfulRescale  6m3s (x4 over 16h)   horizontal-pod-autoscaler  New size: 10; reason: KeptnMetric metric cpu-throttling above target
+  Type     Reason              Age                From           Message
+  ----     ------              ----               ----           -------
+  Normal   KEDAScalersStarted  63s                keda-operator  Started scalers watch
+  Normal   ScaledObjectReady   63s                keda-operator  ScaledObject is ready for scaling
+  Warning  KEDAScalerFailed    33s (x2 over 63s)  keda-operator  error requesting metrics endpoint: valueLocation must point to value of type number or a string representing a Quantity got: ''
+  Normal   KEDAScalersStarted  18s (x5 over 63s)  keda-operator  Scaler metrics-api is built.
 ```
 
 If we retrieve the pods of our application, we can see that, instead of
-a single instance at the beginning, there are currently 10 instances running:
+a single instance at the beginning, there are currently 3 instances running:
 
 ```shell
 $ kubectl get pods -n podtato-kubectl
-NAME                                      READY   STATUS    RESTARTS   AGE
-podtato-head-entry-795b4bf76c-22vl8       1/1     Running   0          4m50s
-podtato-head-entry-795b4bf76c-4mqz5       1/1     Running   0          4m50s
-podtato-head-entry-795b4bf76c-g5bcr       1/1     Running   0          5m5s
-podtato-head-entry-795b4bf76c-h22pq       1/1     Running   0          6m5s
-podtato-head-entry-795b4bf76c-kgcgb       1/1     Running   0          4m50s
-podtato-head-entry-795b4bf76c-kkt82       1/1     Running   0          5m5s
-podtato-head-entry-795b4bf76c-lmfnx       1/1     Running   0          6m5s
-podtato-head-entry-795b4bf76c-pnq2f       1/1     Running   0          15m
-podtato-head-entry-795b4bf76c-r5dx4       1/1     Running   0          5m5s
-podtato-head-entry-795b4bf76c-vwdj7       1/1     Running   0          6m5s
+NAME                                  READY   STATUS    RESTARTS   AGE
+podtato-head-entry-7796c8f786-4cdtc   1/1     Running   0          3m29s
+podtato-head-entry-7796c8f786-nsk2c   1/1     Running   0          2m41s
+podtato-head-entry-7796c8f786-qj85h   1/1     Running   0          2m41s
 ```

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -93,19 +93,7 @@ please refer to the [CRD documentation](../reference/api-reference/metrics/v1/in
 After a few seconds we should be able to see values for the `cpu-throttling` metric:
 
 ```shell
-$ kubectl describe  keptnmetrics.metrics.keptn.sh cpu-throttling -n podtato-kubectl
-Name:         cpu-throttling
-Namespace:    podtato-kubectl
-API Version:  metrics.keptn.sh/v1
-Kind:         KeptnMetric
-Spec:
-  Fetch Interval Seconds:  60
-  Provider:
-    Name:  prometheus-provider
-  Query:  avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-kubectl"}))
-Status:
-  Raw Value: <omitted for readability>
-  Value:         4.53
+{% include "./assets/keda/k-describe-metric.txt" %}
 ```
 
 Here we can see that the value of the `cpu-throttling` metric is `4.53`
@@ -131,71 +119,12 @@ If the load of the application is high enough, we will be able to see
 the automatic scaling of our application:
 
 ```shell
-$ kubectl describe scaledobject -n podtato-kubectl my-scaledobject
-Name:         my-scaledobject
-Namespace:    podtato-kubectl
-Labels:       deploymentName=podtato-head-entry
-              scaledobject.keda.sh/name=my-scaledobject
-API Version:  keda.sh/v1alpha1
-Kind:         ScaledObject
-Spec:
-  Max Replica Count:  3
-  Scale Target Ref:
-    Name:  podtato-head-entry
-  Triggers:
-    Metadata:
-      Target Value:    1
-      Unsafe Ssl:      true
-      URL:             http://metrics-operator-service.keptn-system.svc.cluster.local:9999/api/v1/metrics/chainsaw-proud-wallaby/test
-      Value Location:  value
-    Type:              metrics-api
-Status:
-  Conditions:
-    Message:  ScaledObject is defined correctly and is ready for scaling
-    Reason:   ScaledObjectReady
-    Status:   True
-    Type:     Ready
-    Message:  Scaling is not performed because triggers are not active
-    Reason:   ScalerNotActive
-    Status:   False
-    Type:     Active
-    Message:  No fallbacks are active on this scaled object
-    Reason:   NoFallbackFound
-    Status:   False
-    Type:     Fallback
-    Status:   Unknown
-    Type:     Paused
-  External Metric Names:
-    s0-metric-api-value
-  Health:
-    s0-metric-api-value:
-      Number Of Failures:  0
-      Status:              Happy
-  Hpa Name:                keda-hpa-test-scaledobject
-  Last Active Time:        2024-03-26T09:36:36Z
-  Original Replica Count:  1
-  Scale Target GVKR:
-    Group:            apps
-    Kind:             Deployment
-    Resource:         deployments
-    Version:          v1
-  Scale Target Kind:  apps/v1.Deployment
-Events:
-  Type     Reason              Age                From           Message
-  ----     ------              ----               ----           -------
-  Normal   KEDAScalersStarted  63s                keda-operator  Started scalers watch
-  Normal   ScaledObjectReady   63s                keda-operator  ScaledObject is ready for scaling
-  Warning  KEDAScalerFailed    33s (x2 over 63s)  keda-operator  error requesting metrics endpoint: valueLocation must point to value of type number or a string representing a Quantity got: ''
-  Normal   KEDAScalersStarted  18s (x5 over 63s)  keda-operator  Scaler metrics-api is built.
+{% include "./assets/keda/k-describe-scaledobject.txt" %}
 ```
 
 If we retrieve the pods of our application, we can see that, instead of
 a single instance at the beginning, there are currently 3 instances running:
 
 ```shell
-$ kubectl get pods -n podtato-kubectl
-NAME                                  READY   STATUS    RESTARTS   AGE
-podtato-head-entry-7796c8f786-4cdtc   1/1     Running   0          3m29s
-podtato-head-entry-7796c8f786-nsk2c   1/1     Running   0          2m41s
-podtato-head-entry-7796c8f786-qj85h   1/1     Running   0          2m41s
+{% include "./assets/keda/k-get-pods-result.txt" %}
 ```

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -10,9 +10,9 @@ This gives you great flexibility for your setup since Keptn can
 consolidate different observability providers for you and KEDA
 will simplify the scaling operations for you.
 
-This use case is enabled by the Keptn Metrics
-[custom API](https://kubernetes.io/docs/reference/external-api/custom-metrics.v1beta2/)
-that the Keptn Metrics Operator provides.
+This use case is enabled by the
+[Custom Metrics API](https://kubernetes.io/docs/reference/external-api/custom-metrics.v1beta2/)
+that the [Keptn Metrics Operator](../components/metrics-operator.md) provides.
 
 ## Before you begin
 
@@ -28,7 +28,7 @@ cluster in order to have a full setup:
 
 - [KEDA](https://keda.sh/): Will be used for scaling.
 - [Prometheus](https://prometheus.io/): Will be used as metrics provider.
-  
+
     For more information about how to install Prometheus into your cluster, please
     refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
 
@@ -56,7 +56,7 @@ use a single service `podtato-head` application.
 
 Please create a `podtato-kubectl` namespace and apply the above manifests
 to your cluster and continue with the next steps.
-After applying, please make sure that the application is up and running:
+After applying, use the following command to ensure that the application is up and running:
 
 ```shell
 $ kubectl get pods -n podtato-kubectl

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -52,8 +52,6 @@ use a single service `podtato-head` application.
     {% include "./assets/keda/sample-service.yaml" %}
     ```
 
-<!-- markdownlint-enable MD046 -->
-
 Please create a `podtato-kubectl` namespace and apply the above manifests
 to your cluster and continue with the next steps.
 After applying, please make sure that the application is up and running:
@@ -71,8 +69,6 @@ These metrics are
 exposed via the Keptn Metrics Operator, which gives us the possibility to configure
 KEDA to react on the values of these metrics:
 
-<!-- markdownlint-disable MD046 -->
-
 === "KeptnMetric"
 
     ```yaml
@@ -84,8 +80,6 @@ KEDA to react on the values of these metrics:
     ```yaml
     {% include "./assets/keda/keptnmetricsprovider.yaml" %}
     ```
-
-<!-- markdownlint-enable MD046 -->
 
 For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
 please refer to the [CRD documentation](../reference/api-reference/metrics/v1/index.md).
@@ -199,3 +193,5 @@ podtato-head-entry-7796c8f786-4cdtc   1/1     Running   0          3m29s
 podtato-head-entry-7796c8f786-nsk2c   1/1     Running   0          2m41s
 podtato-head-entry-7796c8f786-qj85h   1/1     Running   0          2m41s
 ```
+
+<!-- markdownlint-enable MD046 -->

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -10,8 +10,7 @@ This gives you great flexibility for your setup since Keptn can
 consolidate different observability providers for you and KEDA
 will simplify the scaling operations for you.
 
-This use case is enabled by the
-[Custom Metrics API](https://kubernetes.io/docs/reference/external-api/custom-metrics.v1beta2/)
+This use case is enabled by the metrics endpoint
 that the [Keptn Metrics Operator](../components/metrics-operator.md) provides.
 
 ## Before you begin

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -107,17 +107,19 @@ Here we can see that the value of the `cpu-throttling` metric is `1.63`
 
 Now that we are able to retrieve the value of our metric, and have it stored in
 our cluster in the status of our `KeptnMetric` custom resource, we can configure
-a `HorizontalPodAutoscaler` to make use of this information and therefore scale
+a `ScaledObject` to make use of this information in KEDA and therefore scale
 our application automatically:
 
 ```yaml
 {% include "./assets/keda/scaledobject.yaml" %}
 ```
 
-As we can see in this example, we are now referring to the `KeptnMetric`
-we applied earlier, and tell the HPA to scale up our application, until our
-target value of `5` for this metric is reached, or the number of replicas
-has reached a maximum of `10`.
+As we can see in this example, by setting the `url` field,
+we are now referring to the `KeptnMetric` and fetching it from the
+Keptn Metrics Operator.
+KEDA will scale up our application, until our target value or `1` is reached,
+or we hit the maximum number of replicas which is `3` in this example.
+
 
 If the load of the application is high enough, we will be able to see
 the automatic scaling of our application:

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -32,12 +32,13 @@ cluster in order to have a full setup:
     For more information about how to install Prometheus into your cluster, please
     refer to the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/installation/).
 
-
 ## Deploy sample application
 
 First, we need to deploy our application to the cluster.
 For this we are going to
 use a single service `podtato-head` application.
+
+<!-- markdownlint-disable MD046 -->
 
 === "deployment.yaml"
 
@@ -50,6 +51,8 @@ use a single service `podtato-head` application.
     ```yaml
     {% include "./assets/keda/sample-service.yaml" %}
     ```
+
+<!-- markdownlint-enable MD046 -->
 
 Please create a `podtato-kubectl` namespace and apply the above manifests
 to your cluster and continue with the next steps.
@@ -68,6 +71,8 @@ These metrics are
 exposed via the Keptn Metrics Operator, which gives us the possibility to configure
 KEDA to react on the values of these metrics:
 
+<!-- markdownlint-disable MD046 -->
+
 === "KeptnMetric"
 
     ```yaml
@@ -79,6 +84,8 @@ KEDA to react on the values of these metrics:
     ```yaml
     {% include "./assets/keda/keptnmetricsprovider.yaml" %}
     ```
+
+<!-- markdownlint-enable MD046 -->
 
 For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
 please refer to the [CRD documentation](../reference/api-reference/metrics/v1/index.md).
@@ -98,10 +105,10 @@ Spec:
   Query:  avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-kubectl"}))
 Status:
   Raw Value: <omitted for readability>
-  Value:         1.63
+  Value:         4.53
 ```
 
-Here we can see that the value of the `cpu-throttling` metric is `1.63`
+Here we can see that the value of the `cpu-throttling` metric is `4.53`
 
 ## Set up the KEDA ScaledObject
 
@@ -115,7 +122,7 @@ our application automatically:
 ```
 
 As we can see in this example, by setting the `url` field,
-we are now referring to the `KeptnMetric` and fetching it from the
+we are now referring to the `KeptnMetric` and fetch it from the
 Keptn Metrics Operator.
 KEDA will scale up our application, until our target value or `1` is reached,
 or we hit the maximum number of replicas which is `3` in this example.

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -42,15 +42,15 @@ use a single service `podtato-head` application.
 
 === "deployment.yaml"
 
-```yaml
-{% include "./assets/keda/sample-app.yaml" %}
-```
+    ```yaml
+    {% include "./assets/keda/sample-app.yaml" %}
+    ```
 
 === "service.yaml"
 
-```yaml
-{% include "./assets/keda/sample-service.yaml" %}
-```
+    ```yaml
+    {% include "./assets/keda/sample-service.yaml" %}
+    ```
 
 <!-- markdownlint-enable MD046 -->
 
@@ -75,15 +75,15 @@ KEDA to react on the values of these metrics:
 
 === "KeptnMetric"
 
-```yaml
-{% include "./assets/keda/keptnmetric.yaml" %}
-```
+    ```yaml
+    {% include "./assets/keda/keptnmetric.yaml" %}
+    ```
 
 === "KeptnMetricsProvider"
 
-```yaml
-{% include "./assets/keda/keptnmetricsprovider.yaml" %}
-```
+    ```yaml
+    {% include "./assets/keda/keptnmetricsprovider.yaml" %}
+    ```
 
 <!-- markdownlint-enable MD046 -->
 

--- a/docs/docs/use-cases/keda.md
+++ b/docs/docs/use-cases/keda.md
@@ -52,6 +52,8 @@ use a single service `podtato-head` application.
     {% include "./assets/keda/sample-service.yaml" %}
     ```
 
+<!-- markdownlint-enable MD046 -->
+
 Please create a `podtato-kubectl` namespace and apply the above manifests
 to your cluster and continue with the next steps.
 After applying, please make sure that the application is up and running:
@@ -69,6 +71,8 @@ These metrics are
 exposed via the Keptn Metrics Operator, which gives us the possibility to configure
 KEDA to react on the values of these metrics:
 
+<!-- markdownlint-disable MD046 -->
+
 === "KeptnMetric"
 
     ```yaml
@@ -80,6 +84,8 @@ KEDA to react on the values of these metrics:
     ```yaml
     {% include "./assets/keda/keptnmetricsprovider.yaml" %}
     ```
+
+<!-- markdownlint-enable MD046 -->
 
 For more information about the `KeptnMetric` and `KeptnMetricsProvider` custom resources,
 please refer to the [CRD documentation](../reference/api-reference/metrics/v1/index.md).
@@ -193,5 +199,3 @@ podtato-head-entry-7796c8f786-4cdtc   1/1     Running   0          3m29s
 podtato-head-entry-7796c8f786-nsk2c   1/1     Running   0          2m41s
 podtato-head-entry-7796c8f786-qj85h   1/1     Running   0          2m41s
 ```
-
-<!-- markdownlint-enable MD046 -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
           - docs/use-cases/index.md
           - Day 2 Operations: docs/use-cases/day-2-operations.md
           - Keptn + HorizontalPodAutoscaler: docs/use-cases/hpa.md
+          - Keptn + KEDA: docs/use-cases/keda.md
           - Keptn for non-Kubernetes deployments: docs/use-cases/non-k8s.md
       - Components:
           - docs/components/index.md


### PR DESCRIPTION
### This PR
- fixes #2899 
- sets up a use case page on how to set up KEDA to consume keptn metrics