### PR TITLE
feat(metrics-operator): support Cortex metrics provider

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -104,6 +104,7 @@ controlleroptions
 controllerutil
 coredns
 CORS
+cortex
 coverpkg
 coverprofile
 cowsay

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -13614,8 +13614,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -13614,8 +13614,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -13750,8 +13750,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -13750,8 +13750,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
@@ -2589,8 +2589,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only-with-apiservice-disabled/result.yaml
@@ -2589,8 +2589,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -2589,8 +2589,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/metrics-only/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-only/result.yaml
@@ -2589,8 +2589,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -2604,8 +2604,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/metrics-with-certs/result.yaml
@@ -2604,8 +2604,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/docs/docs/assets/crd/examples/yaml-synopsis.yaml
+++ b/docs/docs/assets/crd/examples/yaml-synopsis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: <data-source-instance-name>
   namespace: <namespace>
 spec:
-  type: prometheus | thanos | dynatrace | dql | datadog
+  type: prometheus | thanos | cortex | dynatrace | dql | datadog
   targetServer: "<data-source-url>"
   secretKeyRef:
     name: <secret-name>

--- a/docs/docs/assets/crd/examples/yaml-synopsis.yaml
+++ b/docs/docs/assets/crd/examples/yaml-synopsis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: <data-source-instance-name>
   namespace: <namespace>
 spec:
-  type: prometheus | thanos | cortex | dynatrace | dql | datadog
+  type: cortex | datadog | dql | dynatrace | prometheus | thanos
   targetServer: "<data-source-url>"
   secretKeyRef:
     name: <secret-name>

--- a/docs/docs/components/metrics-operator.md
+++ b/docs/docs/components/metrics-operator.md
@@ -13,7 +13,7 @@ of the application and infrastructure.
 
 While Kubernetes has ways to extend its metrics APIs, there are limitations,
 especially that they allow you to use only a single observability platform
-such as Prometheus, Thanos, Dynatrace or Datadog.
+such as Prometheus, Thanos, Cortex, Dynatrace or Datadog.
 The Keptn Metrics Operator solves this problem
 by providing a single entry point for
 all your metrics data, regardless of its source.

--- a/docs/docs/contribute/software/add-new-metric-provider.md
+++ b/docs/docs/contribute/software/add-new-metric-provider.md
@@ -95,7 +95,7 @@ The steps to create your own metrics provider are:
    [line](https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/api/v1/keptnmetricsprovider_types.go#L29)
    to look like this
 
-    `// +kubebuilder:validation:Pattern:=prometheus|thanos|cortex|dynatrace|datadog|dql|placeholder`.
+    `// +kubebuilder:validation:Pattern:=cortex|datadog|dql|dynatrace|prometheus|thanos|placeholder`.
 
      In the metric-operator directory run `make generate manifests` to update the metrics-operator crd config
      Then modify the helm chart and the helm chart crd validation to match the update in the metrics-operator crd config

--- a/docs/docs/contribute/software/add-new-metric-provider.md
+++ b/docs/docs/contribute/software/add-new-metric-provider.md
@@ -95,7 +95,7 @@ The steps to create your own metrics provider are:
    [line](https://github.com/keptn/lifecycle-toolkit/blob/main/metrics-operator/api/v1/keptnmetricsprovider_types.go#L29)
    to look like this
 
-    `// +kubebuilder:validation:Pattern:=prometheus|thanos|dynatrace|datadog|dql|placeholder`.
+    `// +kubebuilder:validation:Pattern:=prometheus|thanos|cortex|dynatrace|datadog|dql|placeholder`.
 
      In the metric-operator directory run `make generate manifests` to update the metrics-operator crd config
      Then modify the helm chart and the helm chart crd validation to match the update in the metrics-operator crd config

--- a/docs/docs/core-concepts/index.md
+++ b/docs/docs/core-concepts/index.md
@@ -33,7 +33,7 @@ The Keptn metrics feature extends the functionality of
 
 * Handles observability data from multiple instances
   of multiple observability solutions
-  – Prometheus, Thanos, Dynatrace, Datadog and others –
+  – Prometheus, Thanos, Cortex, Dynatrace, Datadog and others –
   as well as data that comes directly from your cloud provider
   such as AWS, Google, or Azure.
 

--- a/docs/docs/getting-started/metrics.md
+++ b/docs/docs/getting-started/metrics.md
@@ -14,7 +14,7 @@ such as whether a rollout is good, or whether to scale up or down.
 
 Your observability data may come
 from multiple observability solutions --
-Prometheus, Thanos, Dynatrace, Datadog and others --
+Prometheus, Thanos, Cortex, Dynatrace, Datadog and others --
 or may be data that comes directly
 from your cloud provider such as AWS, Google, or Azure.
 The Keptn Metrics Server unifies and standardizes access to all this data.

--- a/docs/docs/installation/k8s.md
+++ b/docs/docs/installation/k8s.md
@@ -79,6 +79,7 @@ Your cluster should include the following:
 * At least one observability data provider such as
   [Prometheus](https://prometheus.io/),
   [Thanos](https://thanos.io/),
+  [Cortex](https://cortexmetrics.io/),
   [Dynatrace](https://www.dynatrace.com/),
   or [Datadog](https://www.datadoghq.com/);
   you can use multiple instances of different data providers.

--- a/docs/docs/migrate/keptn/strategy.md
+++ b/docs/docs/migrate/keptn/strategy.md
@@ -269,7 +269,7 @@ Keptn v1
 [SLIs](https://v1.keptn.sh/docs/1.0.x/reference/files/sli/)
 (Service Level Indicators)
 represent queries from the data provider
-such as Prometheus, Thanos, Dynatrace, or Datadog,
+such as Prometheus, Thanos, Cortex, Dynatrace, or Datadog,
 which is configured as a Keptn integration.
 
 When migrating to Keptn, you need to define a

--- a/docs/docs/reference/api-reference/metrics/v1/index.md
+++ b/docs/docs/reference/api-reference/metrics/v1/index.md
@@ -373,7 +373,7 @@ _Appears in:_
 
 | Field | Description | Default | Optional |Validation |
 | --- | --- | --- | --- | --- |
-| `type` _string_ | Type represents the provider type. This can be one of prometheus, thanos, dynatrace, datadog, dql. || x | Optional: {} <br />Pattern: `prometheus|thanos|dynatrace|datadog|dql` <br /> |
+| `type` _string_ | Type represents the provider type. This can be one of prometheus, thanos, cortex, dynatrace, datadog, dql. || x | Optional: {} <br />Pattern: `prometheus|thanos|cortex|dynatrace|datadog|dql` <br /> |
 | `targetServer` _string_ | TargetServer defines URL (including port and protocol) at which the metrics provider is reachable. || x |  |
 | `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SecretKeyRef defines an optional secret for access credentials to the metrics provider. || ✓ | Optional: {} <br /> |
 

--- a/docs/docs/reference/api-reference/metrics/v1/index.md
+++ b/docs/docs/reference/api-reference/metrics/v1/index.md
@@ -373,7 +373,7 @@ _Appears in:_
 
 | Field | Description | Default | Optional |Validation |
 | --- | --- | --- | --- | --- |
-| `type` _string_ | Type represents the provider type. This can be one of prometheus, thanos, cortex, dynatrace, datadog, dql. || x | Optional: {} <br />Pattern: `prometheus|thanos|cortex|dynatrace|datadog|dql` <br /> |
+| `type` _string_ | Type represents the provider type. This can be one of cortex, datadog, dql, dynatrace, prometheus or thanos. || x | Optional: {} <br />Pattern: `cortex|datadog|dql|dynatrace|prometheus|thanos` <br /> |
 | `targetServer` _string_ | TargetServer defines URL (including port and protocol) at which the metrics provider is reachable. || x |  |
 | `secretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SecretKeyRef defines an optional secret for access credentials to the metrics provider. || ✓ | Optional: {} <br /> |
 

--- a/docs/docs/reference/crd-reference/analysisvaluetemplate.md
+++ b/docs/docs/reference/crd-reference/analysisvaluetemplate.md
@@ -20,7 +20,7 @@ metadata:
   namespace: <namespace-where-this-resource-resides>
 spec:
   provider:
-    name: prometheus | thanos | dynatrace | dql | datadog
+    name: prometheus | thanos | cortex | dynatrace | dql | datadog
   query: <query>
 ```
 

--- a/docs/docs/reference/crd-reference/analysisvaluetemplate.md
+++ b/docs/docs/reference/crd-reference/analysisvaluetemplate.md
@@ -20,7 +20,7 @@ metadata:
   namespace: <namespace-where-this-resource-resides>
 spec:
   provider:
-    name: prometheus | thanos | cortex | dynatrace | dql | datadog
+    name: cortex | datadog | dql | dynatrace | prometheus | thanos
   query: <query>
 ```
 

--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -121,7 +121,7 @@ kind: KeptnEvaluationDefinition
 metadata:
   name: <evaluation-name>
 spec:
-  source: prometheus | dynatrace | datadog
+  source: datadog | dynatrace | prometheus 
   objectives:
     - name: query-1
       query: "xxxx"

--- a/docs/docs/reference/crd-reference/evaluationdefinition.md
+++ b/docs/docs/reference/crd-reference/evaluationdefinition.md
@@ -116,12 +116,12 @@ that are now taken from the specified [KeptnMetric](metric.md) CRD.
 The synopsis was:
 
 ```yaml
-apiVersion: lifecycle.keptn.sh/v1
+apiVersion: lifecycle.keptn.sh/v1alpha2
 kind: KeptnEvaluationDefinition
 metadata:
   name: <evaluation-name>
 spec:
-  source: prometheus | dynatrace | datadog | thanos
+  source: prometheus | dynatrace | datadog
   objectives:
     - name: query-1
       query: "xxxx"

--- a/docs/docs/reference/crd-reference/metricsprovider.md
+++ b/docs/docs/reference/crd-reference/metricsprovider.md
@@ -5,7 +5,7 @@ comments: true
 # KeptnMetricsProvider
 
 A `KeptnMetricsProvider` resource defines an instance of a data provider
-(such as Prometheus, Thanos, Dynatrace, or Datadog)
+(such as Prometheus, Thanos, Cortex, Dynatrace, or Datadog)
 that is used by one or more [KeptnMetric](metric.md) resources.
 
 One Keptn application can perform
@@ -90,9 +90,9 @@ For detailed information please look at the [Examples section](#examples).
 
 <!-- markdownlint-disable MD046 -->
 
-=== "Prometheus and Thanos"
+=== "Prometheus, Cortex and Thanos"
 
-    An example of Prometheus as a metrics provider with a Secret holding
+    An example of Prometheus, Thanos or Cortex as a metrics provider with a Secret holding
     the authentication data looks like the following:
 
     ```yaml
@@ -129,7 +129,7 @@ For detailed information please look at the [Examples section](#examples).
     > **Note**
     When using Dynatrace as metrics provider you can
     define the key name of your DT token stored in a secret,
-    which is not possible for Datadog, Prometheus or Thanos.
+    which is not possible for Datadog, Prometheus, Cortex or Thanos.
     For this example `myCustomTokenKey` was used.
 
 <!-- markdownlint-enable MD046 -->

--- a/docs/docs/use-cases/non-k8s.md
+++ b/docs/docs/use-cases/non-k8s.md
@@ -179,13 +179,13 @@ similar to what the metrics evaluations of the
 Keptn v1 quality gates feature provided.
 The data used can come from multiple instances
 of multiple data providers
-(such as Prometheus, Thanos, Dynatrace, and DataDog).
+(such as Prometheus, Thanos, Cortex, Dynatrace, and DataDog).
 
 A Keptn analysis can be run for any application running anywhere
 as long Keptn can access a monitoring provider endpoint
 that serves metrics for the application.
 You can point to multiple instances of the supported monitoring providers
-(Prometheus, Thanos, Dynatrace, Datadog, and dql)
+(Prometheus, Thanos, Cortex, Dynatrace, Datadog, and dql)
 so the application itself can run anywhere.
 
 To implement a Keptn analysis for your deployment:

--- a/metrics-operator/api/v1/keptnmetricsprovider_types.go
+++ b/metrics-operator/api/v1/keptnmetricsprovider_types.go
@@ -26,8 +26,8 @@ import (
 // KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
 type KeptnMetricsProviderSpec struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Pattern:=prometheus|thanos|cortex|dynatrace|datadog|dql
-	// Type represents the provider type. This can be one of prometheus, thanos, cortex, dynatrace, datadog, dql.
+	// +kubebuilder:validation:Pattern:=cortex|datadog|dql|dynatrace|prometheus|thanos
+	// Type represents the provider type. This can be one of cortex, datadog, dql, dynatrace, prometheus or thanos.
 	Type string `json:"type"`
 	// TargetServer defines URL (including port and protocol) at which the metrics provider is reachable.
 	TargetServer string `json:"targetServer"`

--- a/metrics-operator/api/v1/keptnmetricsprovider_types.go
+++ b/metrics-operator/api/v1/keptnmetricsprovider_types.go
@@ -26,8 +26,8 @@ import (
 // KeptnMetricsProviderSpec defines the desired state of KeptnMetricsProvider
 type KeptnMetricsProviderSpec struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Pattern:=prometheus|thanos|dynatrace|datadog|dql
-	// Type represents the provider type. This can be one of prometheus, thanos, dynatrace, datadog, dql.
+	// +kubebuilder:validation:Pattern:=prometheus|thanos|cortex|dynatrace|datadog|dql
+	// Type represents the provider type. This can be one of prometheus, thanos, cortex, dynatrace, datadog, dql.
 	Type string `json:"type"`
 	// TargetServer defines URL (including port and protocol) at which the metrics provider is reachable.
 	TargetServer string `json:"targetServer"`

--- a/metrics-operator/api/v1/keptnmetricsprovider_types_test.go
+++ b/metrics-operator/api/v1/keptnmetricsprovider_types_test.go
@@ -45,6 +45,19 @@ func TestKeptnMetricsProvider_GetType(t *testing.T) {
 			want: "thanos",
 		},
 		{
+			name: "cortex provider type set",
+			fields: fields{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "provider1",
+				},
+				Spec: KeptnMetricsProviderSpec{
+					Type:         "cortex",
+					TargetServer: "",
+				},
+			},
+			want: "cortex",
+		},
+		{
 			name: "provider type not set, should return name",
 			fields: fields{
 				ObjectMeta: metav1.ObjectMeta{

--- a/metrics-operator/chart/templates/keptnmetricsprovider-crd.yaml
+++ b/metrics-operator/chart/templates/keptnmetricsprovider-crd.yaml
@@ -77,8 +77,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/metrics-operator/chart/templates/keptnmetricsprovider-crd.yaml
+++ b/metrics-operator/chart/templates/keptnmetricsprovider-crd.yaml
@@ -77,8 +77,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetricsproviders.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetricsproviders.yaml
@@ -69,8 +69,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, cortex, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
+                  cortex, datadog, dql, dynatrace, prometheus or thanos.
+                pattern: cortex|datadog|dql|dynatrace|prometheus|thanos
                 type: string
             required:
             - targetServer

--- a/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetricsproviders.yaml
+++ b/metrics-operator/config/crd/bases/metrics.keptn.sh_keptnmetricsproviders.yaml
@@ -69,8 +69,8 @@ spec:
                 type: string
               type:
                 description: Type represents the provider type. This can be one of
-                  prometheus, thanos, dynatrace, datadog, dql.
-                pattern: prometheus|thanos|dynatrace|datadog|dql
+                  prometheus, thanos, cortex, dynatrace, datadog, dql.
+                pattern: prometheus|thanos|cortex|dynatrace|datadog|dql
                 type: string
             required:
             - targetServer

--- a/metrics-operator/controllers/analysis/provider_selector_test.go
+++ b/metrics-operator/controllers/analysis/provider_selector_test.go
@@ -246,7 +246,7 @@ func TestProvidersPool(t *testing.T) {
 
 func TestProvidersPool_StartProviders(t *testing.T) {
 
-	numJobs := 4
+	numJobs := 6
 	ctx, cancel := context.WithCancel(context.Background())
 	resChan := make(chan metricsapi.ProviderResult)
 	// Create a mock IObjectivesEvaluator, Client, and Logger for testing
@@ -273,7 +273,7 @@ func TestProvidersPool_StartProviders(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	// Assert the expected number of workers (goroutines) were started
-	require.Equal(t, 4, len(pool.providers))
+	require.Equal(t, 6, len(pool.providers))
 	require.Equal(t, numJobs, cap(pool.providers["prometheus"]))
 	// Stop the providers after testing
 	pool.StopProviders()

--- a/metrics-operator/controllers/common/providers/common.go
+++ b/metrics-operator/controllers/common/providers/common.go
@@ -12,4 +12,6 @@ var SupportedProviders = []string{
 	DynatraceDQLProviderType,
 	PrometheusProviderType,
 	DataDogProviderType,
+	CortexProviderType,
+	ThanosProviderType,
 }

--- a/metrics-operator/controllers/common/providers/common.go
+++ b/metrics-operator/controllers/common/providers/common.go
@@ -4,6 +4,7 @@ const DynatraceProviderType = "dynatrace"
 const DynatraceDQLProviderType = "dql"
 const PrometheusProviderType = "prometheus"
 const ThanosProviderType = "thanos"
+const CortexProviderType = "cortex"
 const DataDogProviderType = "datadog"
 
 var SupportedProviders = []string{

--- a/metrics-operator/controllers/common/providers/provider.go
+++ b/metrics-operator/controllers/common/providers/provider.go
@@ -29,7 +29,7 @@ type ProviderFactory func(providerType string, log logr.Logger, k8sClient client
 func NewProvider(providerType string, log logr.Logger, k8sClient client.Client) (KeptnSLIProvider, error) {
 
 	switch strings.ToLower(providerType) {
-	case PrometheusProviderType, ThanosProviderType:
+	case PrometheusProviderType, ThanosProviderType, CortexProviderType:
 		return prometheus.NewPrometheusProvider(log, k8sClient), nil
 	case DynatraceProviderType:
 		return &dynatrace.KeptnDynatraceProvider{

--- a/metrics-operator/controllers/common/providers/provider_test.go
+++ b/metrics-operator/controllers/common/providers/provider_test.go
@@ -28,6 +28,11 @@ func TestFactory(t *testing.T) {
 			err:          false,
 		},
 		{
+			providerType: CortexProviderType,
+			provider:     &prometheus.KeptnPrometheusProvider{},
+			err:          false,
+		},
+		{
 			providerType: DynatraceProviderType,
 			provider:     &dynatrace.KeptnDynatraceProvider{},
 			err:          false,


### PR DESCRIPTION
Fixes: #2903 

Prometheus and Cortrex metrics providers have 100% compatible API, see [here](https://cortexmetrics.io/docs/configuration/v1guarantees/#api-compatibility)

metrics provider uses only single [api endpoint](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries), which is same for Cortex as well, see [here](https://cortexmetrics.io/docs/api/#range-query)