### PR TITLE
feat(helm-chart): ability to set hostNetwork for lifecycle operator deployment

### DIFF
--- a/.github/scripts/.helm-tests/Openshift/result.yaml
+++ b/.github/scripts/.helm-tests/Openshift/result.yaml
@@ -15419,6 +15419,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: false
       volumes:
       - name: keptn-certs
         secret:

--- a/.github/scripts/.helm-tests/default/result.yaml
+++ b/.github/scripts/.helm-tests/default/result.yaml
@@ -15423,6 +15423,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: false
       volumes:
       - name: keptn-certs
         secret:

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -11989,6 +11989,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: false
       volumes:
       - name: keptn-certs
         secret:

--- a/.github/scripts/.helm-tests/lifecycle-only/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/result.yaml
@@ -11989,7 +11989,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
-      hostNetwork: false
+      hostNetwork: true
       volumes:
       - name: keptn-certs
         secret:

--- a/.github/scripts/.helm-tests/lifecycle-only/values.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-only/values.yaml
@@ -9,6 +9,7 @@ lifecycleOperator:
       repository: busybox
       tag: 1.35
       imagePullPolicy: Always
+    hostNetwork: true
   scheduler:
     image:
       tag: v0.0.0

--- a/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
+++ b/.github/scripts/.helm-tests/lifecycle-with-certs/result.yaml
@@ -12290,6 +12290,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: false
       volumes:
       - name: keptn-certs
         secret:

--- a/.github/scripts/.helm-tests/local-global-precedence/result.yaml
+++ b/.github/scripts/.helm-tests/local-global-precedence/result.yaml
@@ -15751,6 +15751,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: false
       volumes:
       - name: keptn-certs
         secret:

--- a/lifecycle-operator/chart/README.md
+++ b/lifecycle-operator/chart/README.md
@@ -67,6 +67,7 @@ and application health checks
 | `lifecycleOperator.replicas`                                          | customize number of installed lifecycle operator replicas                      | `1`                                   |
 | `lifecycleOperator.tolerations`                                       | add custom tolerations to lifecycle operator                                   | `[]`                                  |
 | `lifecycleOperator.topologySpreadConstraints`                         | add custom topology constraints to lifecycle operator                          | `[]`                                  |
+| `lifecycleOperator.hostNetwork`                                       | Sets hostNetwork option for lifecycle operator                                 | `false`                               |
 | `lifecycleOperatorMetricsService`                                     | Adjust settings here to change the k8s service for scraping Prometheus metrics |                                       |
 
 ### Global

--- a/lifecycle-operator/chart/templates/deployment.yaml
+++ b/lifecycle-operator/chart/templates/deployment.yaml
@@ -165,6 +165,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: {{ .Values.lifecycleOperator.hostNetwork }}
       volumes:
       - name: keptn-certs
         secret:

--- a/lifecycle-operator/chart/values.yaml
+++ b/lifecycle-operator/chart/values.yaml
@@ -154,6 +154,8 @@ lifecycleOperator:
   tolerations: []
 ## @param   lifecycleOperator.topologySpreadConstraints add custom topology constraints to lifecycle operator
   topologySpreadConstraints: []
+## @param   lifecycleOperator.hostNetwork Sets hostNetwork option for lifecycle operator
+  hostNetwork: false
 ## @extra   lifecycleOperatorMetricsService Adjust settings here to change the k8s service for scraping Prometheus metrics
 ## @skip    lifecycleOperatorMetricsService.ports[0].name
 ## @skip    lifecycleOperatorMetricsService.ports[0].port

--- a/lifecycle-operator/config/manager/manager.yaml
+++ b/lifecycle-operator/config/manager/manager.yaml
@@ -122,6 +122,7 @@ spec:
               memory: 64Mi
       serviceAccountName: lifecycle-operator
       terminationGracePeriodSeconds: 10
+      hostNetwork: false
       volumes:
         - name: keptn-certs
           secret:


### PR DESCRIPTION
# Description
This PR adds the ability to set the .spec.template.spec.hostNetwork value for the lifecycle-operator deployment in the helm-chart values. By default it will be set to `false`.

This is required due to the webhook being blocked while using Cilium on managed Amazon EKS clusters. This makes it so other deployments won't be able to deploy on our clusters.

# How to test
Added the default values to `.github/scripts/.helm-tests`.

# Checklist

- [ ] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [ ] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [x] New and existing unit and integration tests pass locally with my changes