### PR TITLE
fix(examples): helm values overide format and dashboard fix

### DIFF
--- a/docs/docs/getting-started/observability.md
+++ b/docs/docs/getting-started/observability.md
@@ -407,7 +407,9 @@ Save this file as `values.yaml`:
 ```yaml
 grafana:
   adminPassword: admin
-  sidecar.datasources.defaultDatasourceEnabled: false
+  sidecar:
+    datasources:
+      defaultDatasourceEnabled: false
 prometheus:
   prometheusSpec:
     additionalScrapeConfigs:

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-applications.yaml
@@ -805,4 +805,4 @@ metadata:
   name: grafana-dashboard-keptn-applications
   namespace: monitoring
   labels:
-    grafana_dashboard: "0"
+    grafana_dashboard: "1"

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-overview.yaml
@@ -891,4 +891,4 @@ metadata:
   name: grafana-dashboard-keptn-overview
   namespace: monitoring
   labels:
-    grafana_dashboard: "0"
+    grafana_dashboard: "1"

--- a/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
+++ b/examples/support/observability/config/prometheus/grafana-dashboard-keptn-workloads.yaml
@@ -639,4 +639,4 @@ metadata:
   name: grafana-dashboard-keptn-workloads-dora
   namespace: monitoring
   labels:
-    grafana_dashboard: "0"
+    grafana_dashboard: "1"


### PR DESCRIPTION
1. helm value overide:
`sidecar.datasources.defaultDatasourceEnabled: false`
this format has no effect, should be like 
```
  sidecar:
    datasources:
      defaultDatasourceEnabled: false
```

2. dashboard label 
grafana_dashboard should be "1"

grafana-sc-dashboard containers watch 
            - name: LABEL
              value: "grafana_dashboard"
            - name: LABEL_VALUE
              value: "1"
              
with lable=0 currently, follow the document example deployment, Grafana will not have the corresponding Dashboard.