### PR TITLE
chore: introduce unit test for non-blocking lifecycle operator mode

### DIFF
--- a/lifecycle-operator/controllers/lifecycle/keptnappversion/controller_test.go
+++ b/lifecycle-operator/controllers/lifecycle/keptnappversion/controller_test.go
@@ -159,7 +159,8 @@ func TestKeptnAppVersionNonBlockingReconciler_Reconcile(t *testing.T) {
 	// set up a non blocking deployment
 	r.Config.SetBlockDeployment(false)
 	r.PhaseHandler = &phasefake.MockHandler{HandlePhaseFunc: func(ctx context.Context, ctxTrace context.Context, tracer telemetry.ITracer, reconcileObject client.Object, phaseMoqParam apicommon.KeptnPhaseType, reconcilePhase func(phaseCtx context.Context) (apicommon.KeptnState, error)) (phase.PhaseResult, error) {
-		reconcilePhase(ctx)
+		_, err := reconcilePhase(ctx)
+		require.Nil(t, err)
 		return phase.PhaseResult{Continue: true, Result: ctrl.Result{}}, nil
 	}}
 


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

Added a unit test for the non-blocking lifecycle operator mode. 

I used the manifest provided in the [docs](https://keptn.sh/stable/docs/components/lifecycle-operator/keptn-non-blocking/) as the template for the unit test. 

Since the non-blocking mode does not introduce any errors in the controller, we can write a unit test with a mock handler that does not return any errors when using the manifest provided in the docs. 
Partially Fixes # (#3121)

# How to test

Please describe how to run the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also provide information about any automatic tests that you added.

I use the run test option in VSCode to verify that my tests works. 
- [ ] Manual Test A
- [x] Unit Test B
- [ ] Integration Test C

# Checklist

- [x] My PR fulfills the Definition of Done of the corresponding issue and not more (or parts if the issue is separated
  into multiple PRs)
- [x] I used descriptive commit messages to help reviewers understand my thought process
- [x] I signed off all my commits according to the Developer Certificate of Origin (DCO)
  see [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [x] My PR title is formatted according to the semantic PR conventions described in
  the [Contribution Guide](https://lifecycle.keptn.sh/contribute/docs/contribution-guidelines)
- [ ] My code follows the style guidelines of this project (golangci-lint passes, YAMLLint passes)
- [ ] I regenerated the auto-generated docs for Helm and the CRD documentation (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (if needed)
- [ ] My changes result in all-green PR checks (first-time contributors need to ask a maintainer to approve their test runs)
- [x] New and existing unit and integration tests pass locally with my changes
