### PR TITLE
fix(examples): fix KeptnMetric in metrics example

### DIFF
--- a/examples/support/metrics/metric.yaml
+++ b/examples/support/metrics/metric.yaml
@@ -15,7 +15,5 @@ metadata:
 spec:
   provider:
     name: my-provider
-  query: 'avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-metrics"}))'
+  query: 'avg(rate(container_cpu_cfs_throttled_seconds_total{container="server", namespace="podtato-metrics"}[1m:10s]))'
   fetchIntervalSeconds: 10
-  range:
-    interval: "1m"


### PR DESCRIPTION
for some reason, the keptnmetric doesn't work with the keptn provided range options