### PR TITLE
fix(lifecycle-operator): update ownerReference when updating KeptnWorkload

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -539,6 +539,7 @@ remediations
 replicasets
 replicationcontrollers
 resourcereference
+revisionhistorylimit
 Rexed
 rgb
 RLock

--- a/lifecycle-operator/config/crd/bases/lifecycle.keptn.sh_keptntaskdefinitions.yaml
+++ b/lifecycle-operator/config/crd/bases/lifecycle.keptn.sh_keptntaskdefinitions.yaml
@@ -331,6 +331,17 @@ spec:
                             required:
                             - port
                             type: object
+                          sleep:
+                            description: Sleep represents the duration that the container
+                              should sleep before being terminated.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
                           tcpSocket:
                             description: |-
                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
@@ -427,6 +438,17 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
+                          sleep:
+                            description: Sleep represents the duration that the container
+                              should sleep before being terminated.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
                             type: object
                           tcpSocket:
                             description: |-
@@ -2040,6 +2062,17 @@ spec:
                             required:
                             - port
                             type: object
+                          sleep:
+                            description: Sleep represents the duration that the container
+                              should sleep before being terminated.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
                           tcpSocket:
                             description: |-
                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
@@ -2136,6 +2169,17 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
+                          sleep:
+                            description: Sleep represents the duration that the container
+                              should sleep before being terminated.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
                             type: object
                           tcpSocket:
                             description: |-
@@ -3671,6 +3715,17 @@ spec:
                             required:
                             - port
                             type: object
+                          sleep:
+                            description: Sleep represents the duration that the container
+                              should sleep before being terminated.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
                           tcpSocket:
                             description: |-
                               Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
@@ -3767,6 +3822,17 @@ spec:
                                 type: string
                             required:
                             - port
+                            type: object
+                          sleep:
+                            description: Sleep represents the duration that the container
+                              should sleep before being terminated.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
                             type: object
                           tcpSocket:
                             description: |-

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/workload.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/workload.go
@@ -52,6 +52,7 @@ func (a *WorkloadHandler) updateWorkload(ctx context.Context, workload *apilifec
 
 	a.Log.Info("Pod changed, updating workload")
 	workload.Spec = newWorkload.Spec
+	workload.OwnerReferences = newWorkload.OwnerReferences
 
 	err := a.Client.Update(ctx, workload)
 	if err != nil {

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/workload.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/workload.go
@@ -45,7 +45,7 @@ func (a *WorkloadHandler) Handle(ctx context.Context, pod *corev1.Pod, namespace
 }
 
 func (a *WorkloadHandler) updateWorkload(ctx context.Context, workload *apilifecycle.KeptnWorkload, newWorkload *apilifecycle.KeptnWorkload) error {
-	if reflect.DeepEqual(workload.Spec, newWorkload.Spec) {
+	if reflect.DeepEqual(workload.Spec, newWorkload.Spec) && reflect.DeepEqual(workload.OwnerReferences, newWorkload.OwnerReferences) {
 		a.Log.Info("Pod not changed, not updating anything")
 		return nil
 	}

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/workload_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/workload_test.go
@@ -126,12 +126,12 @@ func TestHandle(t *testing.T) {
 		wanterr      error
 		wantWorkload *apilifecycle.KeptnWorkload
 	}{
-		// {
-		// 	name:         "Create Workload",
-		// 	pod:          pod,
-		// 	client:       testcommon.NewTestClient(),
-		// 	wantWorkload: wantWorkload,
-		// },
+		{
+			name:         "Create Workload",
+			pod:          pod,
+			client:       testcommon.NewTestClient(),
+			wantWorkload: wantWorkload,
+		},
 		{
 			name:         "Update Workload",
 			pod:          pod2,

--- a/lifecycle-operator/webhooks/pod_mutator/handlers/workload_test.go
+++ b/lifecycle-operator/webhooks/pod_mutator/handlers/workload_test.go
@@ -58,6 +58,35 @@ func TestHandle(t *testing.T) {
 			},
 		},
 	}
+	wantWorkload2 := &apilifecycle.KeptnWorkload{
+		TypeMeta: metav1.TypeMeta{Kind: "KeptnWorkload", APIVersion: "lifecycle.keptn.sh/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testAppWorkload,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID:        "owner-uid",
+					Kind:       "Deployment",
+					Name:       "deployment-1",
+					APIVersion: "apps/v1",
+				},
+			},
+			ResourceVersion: "2",
+		},
+		Spec: apilifecycle.KeptnWorkloadSpec{
+			AppName: TestWorkload,
+			Version: "0.2",
+			Metadata: map[string]string{
+				"foo": "bar",
+				"bar": "foo",
+			},
+			ResourceReference: apilifecycle.ResourceReference{
+				UID:  "owner-uid",
+				Kind: "Deployment",
+				Name: "deployment-1",
+			},
+		},
+	}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -68,7 +97,27 @@ func TestHandle(t *testing.T) {
 				apicommon.VersionAnnotation:  "0.1",
 				apicommon.MetadataAnnotation: "foo=bar,bar=foo",
 			},
-		}}
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-pod",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				apicommon.WorkloadAnnotation: TestWorkload,
+				apicommon.VersionAnnotation:  "0.2",
+				apicommon.MetadataAnnotation: "foo=bar,bar=foo",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					UID:        "owner-uid",
+					Kind:       "Deployment",
+					Name:       "deployment-1",
+					APIVersion: "apps/v1",
+				},
+			},
+		},
+	}
 	// Define test cases
 	tests := []struct {
 		name         string
@@ -77,17 +126,17 @@ func TestHandle(t *testing.T) {
 		wanterr      error
 		wantWorkload *apilifecycle.KeptnWorkload
 	}{
-		{
-			name:         "Create Workload",
-			pod:          pod,
-			client:       testcommon.NewTestClient(),
-			wantWorkload: wantWorkload,
-		},
+		// {
+		// 	name:         "Create Workload",
+		// 	pod:          pod,
+		// 	client:       testcommon.NewTestClient(),
+		// 	wantWorkload: wantWorkload,
+		// },
 		{
 			name:         "Update Workload",
-			pod:          pod,
+			pod:          pod2,
 			client:       testcommon.NewTestClient(wantWorkload),
-			wantWorkload: wantWorkload,
+			wantWorkload: wantWorkload2,
 		},
 		{
 			name: "Error Fetching Workload",

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/00-assert.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/00-assert.yaml
@@ -38,7 +38,7 @@ spec:
   revision: 1
   version: "0.1"
   workloads:
-  - name: waiter
-    version: "0.1"
+    - name: waiter
+      version: "0.1"
 status:
   currentPhase: Completed

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/00-assert.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/00-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+status:
+  readyReplicas: 2
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnWorkload
+metadata:
+  name: waiter-waiter
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnWorkloadVersion
+metadata:
+  name: waiter-waiter-0.1
+status:
+  currentPhase: Completed
+  deploymentStatus: Succeeded
+  postDeploymentEvaluationStatus: Succeeded
+  postDeploymentStatus: Succeeded
+  preDeploymentEvaluationStatus: Succeeded
+  preDeploymentStatus: Succeeded
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnApp
+metadata:
+  name: waiter
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnAppVersion
+metadata:
+  name: waiter-0.1-6b86b273
+spec:
+  appName: waiter
+  revision: 1
+  version: "0.1"
+  workloads:
+  - name: waiter
+    version: "0.1"
+status:
+  currentPhase: Completed

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/00-install.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/00-install.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+spec:
+  replicas: 2
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: test
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: test
+      annotations:
+        keptn.sh/workload: waiter
+        keptn.sh/version: "0.1"
+    spec:
+      containers:
+        - image: busybox
+          name: busybox
+          command: ['sh', '-c', 'echo The app is running! && sleep infinity']

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/01-assert.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/01-assert.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+status:
+  readyReplicas: 2
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnWorkload
+metadata:
+  name: waiter-waiter
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnWorkloadVersion
+metadata:
+  name: waiter-waiter-0.2
+status:
+  currentPhase: Completed
+  deploymentStatus: Succeeded
+  postDeploymentEvaluationStatus: Succeeded
+  postDeploymentStatus: Succeeded
+  preDeploymentEvaluationStatus: Succeeded
+  preDeploymentStatus: Succeeded
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnApp
+metadata:
+  name: waiter
+---
+apiVersion: lifecycle.keptn.sh/v1
+kind: KeptnAppVersion
+metadata:
+  name: waiter-0.2-d4735e3a
+spec:
+  appName: waiter
+  revision: 1
+  version: "0.2"
+  workloads:
+  - name: waiter
+    version: "0.2"
+status:
+  currentPhase: Completed

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/01-assert.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/01-assert.yaml
@@ -38,7 +38,7 @@ spec:
   revision: 1
   version: "0.2"
   workloads:
-  - name: waiter
-    version: "0.2"
+    - name: waiter
+      version: "0.2"
 status:
   currentPhase: Completed

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/01-install.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/01-install.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test
+  name: test
+spec:
+  replicas: 2
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: test
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: test
+      annotations:
+        keptn.sh/workload: waiter
+        keptn.sh/version: "0.2"
+    spec:
+      containers:
+        - image: busybox
+          name: busybox
+          command: ['sh', '-c', 'echo The app is running! && sleep infinity']

--- a/test/chainsaw/integration/simple-deployment-revisionhistorylimit/chainsaw-test.yaml
+++ b/test/chainsaw/integration/simple-deployment-revisionhistorylimit/chainsaw-test.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: simple-deployment-revisionhistorylimit
+spec:
+  namespaceTemplate:
+    metadata:
+      annotations:
+        keptn.sh/lifecycle-toolkit: enabled
+  steps:
+    - name: step-00
+      try:
+        - apply:
+            file: 00-install.yaml
+        - assert:
+            file: 00-assert.yaml
+    - name: step-01
+      try:
+        - apply:
+            file: 01-install.yaml
+        - assert:
+            file: 01-assert.yaml


### PR DESCRIPTION
<!-- PLEASE USE THE TEMPLATE SECTION THAT IS APPLICABLE FOR YOUR CONTRIBUTION -->

<!-- CODE SECTION -->
<!-- USE THIS FOR CODE CONTRIBUTIONS -->

# Description

When updating KeptnWorkload after an update of the workload, ownerReference should be updated as well

Fixes #3680 
