### PR TITLE
feat: Integrating ELK provider

### DIFF
--- a/metrics-operator/controllers/common/providers/elk/elk.go
+++ b/metrics-operator/controllers/common/providers/elk/elk.go
@@ -1,0 +1,121 @@
+package elasticsearch
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "strings"
+    "time"
+
+    "github.com/go-logr/logr"
+    metricsapi "github.com/keptn/lifecycle-toolkit/metrics-operator/api/v1"
+    elastic "github.com/elastic/go-elasticsearch/v8"
+    "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+    warningLogStringElastic = "%s API returned warnings: %s"
+)
+
+type KeptnElasticProvider struct {
+    Log       logr.Logger
+    K8sClient client.Client
+    Elastic   *elastic.Client
+}
+
+func NewElasticProvider(log logr.Logger, k8sClient client.Client, elasticURL string) (*KeptnElasticProvider, error) {
+    cfg := elastic.Config{
+        Addresses: []string{
+            elasticURL,
+        },
+    }
+    es, err := elastic.NewClient(cfg)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create elasticsearch client: %w", err)
+    }
+
+    return &KeptnElasticProvider{
+        Log:       log,
+        K8sClient: k8sClient,
+        Elastic:   es,
+    }, nil
+}
+
+func (r *KeptnElasticProvider) FetchAnalysisValue(ctx context.Context, query string, analysis metricsapi.Analysis, provider *metricsapi.KeptnMetricsProvider) (string, error) {
+    ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+    defer cancel()
+
+    result, err := r.runElasticQuery(ctx, query, analysis.GetFrom(), analysis.GetTo())
+    if err != nil {
+        return "", err
+    }
+
+    r.Log.Info(fmt.Sprintf("Elasticsearch query result: %v", result))
+    return r.extractMetric(result)
+}
+
+func (r *KeptnElasticProvider) EvaluateQuery(ctx context.Context, metric metricsapi.KeptnMetric, provider metricsapi.KeptnMetricsProvider) (string, []byte, error) {
+    ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+    defer cancel()
+
+    result, err := r.runElasticQuery(ctx, metric.Spec.Query, time.Now().Add(-30*time.Minute), time.Now())
+    if err != nil {
+        return "", nil, err
+    }
+
+    metricValue, err := r.extractMetric(result)
+    if err != nil {
+        return "", nil, err
+    }
+
+    return metricValue, []byte{}, nil
+}
+
+func (r *KeptnElasticProvider) runElasticQuery(ctx context.Context, query string, from, to time.Time) (map[string]interface{}, error) {
+    queryBody := fmt.Sprintf(`
+    {
+        "query": {
+            "range": {
+                "@timestamp": {
+                    "gte": "%s",
+                    "lte": "%s"
+                }
+            }
+        }
+    }`, from.Format(time.RFC3339), to.Format(time.RFC3339))
+
+    res, err := r.Elastic.Search(
+        r.Elastic.Search.WithContext(ctx),
+        r.Elastic.Search.WithBody(strings.NewReader(queryBody)),
+    )
+    if err != nil {
+        return nil, fmt.Errorf("failed to execute Elasticsearch query: %w", err)
+    }
+    defer res.Body.Close()
+
+    if warnings, ok := res.Header["Warning"]; ok {
+        r.Log.Info(fmt.Sprintf(warningLogStringElastic, "Elasticsearch", warnings))
+    }
+
+    var result map[string]interface{}
+    if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
+        return nil, fmt.Errorf("failed to parse Elasticsearch response: %w", err)
+    }
+    return result, nil
+}
+
+func (r *KeptnElasticProvider) extractMetric(result map[string]interface{}) (string, error) {
+    hits, ok := result["hits"].(map[string]interface{})
+    if !ok {
+        return "", fmt.Errorf("invalid result format: missing 'hits' field")
+    }
+
+    totalHits, ok := hits["total"].(map[string]interface{})
+    if !ok {
+        return "", fmt.Errorf("invalid result format: missing 'total' field in 'hits'")
+    }
+
+    value := fmt.Sprintf("%v", totalHits["value"])
+
+    return value, nil
+}

--- a/metrics-operator/go.mod
+++ b/metrics-operator/go.mod
@@ -31,6 +31,8 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+require github.com/elastic/elastic-transport-go/v8 v8.6.0 // indirect
+
 require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
@@ -43,6 +45,8 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/elastic/go-elasticsearch/v7 v7.17.10
+	github.com/elastic/go-elasticsearch/v8 v8.15.0
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect

--- a/metrics-operator/go.sum
+++ b/metrics-operator/go.sum
@@ -29,6 +29,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/elastic/elastic-transport-go/v8 v8.6.0 h1:Y2S/FBjx1LlCv5m6pWAF2kDJAHoSjSRSJCApolgfthA=
+github.com/elastic/elastic-transport-go/v8 v8.6.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
+github.com/elastic/go-elasticsearch/v7 v7.17.10 h1:TCQ8i4PmIJuBunvBS6bwT2ybzVFxxUhhltAs3Gyu1yo=
+github.com/elastic/go-elasticsearch/v7 v7.17.10/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v8 v8.15.0 h1:IZyJhe7t7WI3NEFdcHnf6IJXqpRf+8S8QWLtZYYyBYk=
+github.com/elastic/go-elasticsearch/v8 v8.15.0/go.mod h1:HCON3zj4btpqs2N1jjsAy4a/fiAul+YBP00mBH4xik8=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=


### PR DESCRIPTION
Fixes #3727 

# Description
I have started creating custom KeptnMetricsProvider for Elastic and now I have integrated some methods.

For now the methods purpose are-
- NewElasticProvider: Creates a new KeptnElasticProvider with an Elasticsearch client.
- FetchAnalysisValue: Runs a query to get analysis results and returns the metric value.
- EvaluateQuery: Runs a metric query for the last 30 minutes and returns the metric value.
- runElasticQuery: Executes a query on Elasticsearch and returns the result.
- extractMetric: Gets the metric value from the Elasticsearch result.