### PR TITLE
chore: remove waiting after KEDA integration test cleanup

### DIFF
--- a/test/chainsaw/testmetrics/metrics-keda/chainsaw-test.yaml
+++ b/test/chainsaw/testmetrics/metrics-keda/chainsaw-test.yaml
@@ -66,11 +66,3 @@ spec:
         - script:
             content: |
               kubectl delete -f https://github.com/kedacore/keda/releases/download/v2.13.1/keda-2.13.1.yaml
-        - wait:
-            timeout: 3m
-            apiVersion: v1
-            kind: Pod
-            namespace: keda
-            selector: name=keda-operator
-            for:
-              deletion: {}


### PR DESCRIPTION
## Description

There is no need to wait for cleanup of KEDA resources (which takes time+resources and often times out) after KEDA integration test as the cluster will be deleted after the test is finished even if the uninstallation is not done yet.