### PR TITLE
fix: fix a bug when elastic as a provider 

### DIFF
--- a/metrics-operator/controllers/common/providers/elastic/elastic.go
+++ b/metrics-operator/controllers/common/providers/elastic/elastic.go
@@ -84,7 +84,7 @@ func (r *KeptnElasticProvider) FetchAnalysisValue(ctx context.Context, query str
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	result, err := r.runElasticQuery(ctx, query)
+	result, err := r.runElasticQuery(ctx, *provider, query)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +98,7 @@ func (r *KeptnElasticProvider) EvaluateQuery(ctx context.Context, metric metrics
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	result, err := r.runElasticQuery(ctx, metric.Spec.Query)
+	result, err := r.runElasticQuery(ctx, provider, metric.Spec.Query)
 	if err != nil {
 		return "", nil, err
 	}
@@ -117,7 +117,13 @@ func (r *KeptnElasticProvider) EvaluateQueryForStep(ctx context.Context, metric 
 }
 
 // runElasticQuery runs query on elastic search to get output from elasticsearch
-func (r *KeptnElasticProvider) runElasticQuery(ctx context.Context, query string) (map[string]interface{}, error) {
+func (r *KeptnElasticProvider) runElasticQuery(ctx context.Context, provider metricsapi.KeptnMetricsProvider, query string) (map[string]interface{}, error) {
+	var err error
+	r.Log.Info("Running Elasticsearch query", "query", query)
+	r.Elastic, err = GetElasticClient(provider)
+	if err != nil {
+		return nil, err
+	}
 
 	res, err := r.Elastic.Search(
 		r.Elastic.Search.WithContext(ctx),

--- a/metrics-operator/controllers/common/providers/elastic/elastic_test.go
+++ b/metrics-operator/controllers/common/providers/elastic/elastic_test.go
@@ -152,7 +152,7 @@ func TestRunElasticQuery(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			result, err := provider.runElasticQuery(ctx, tt.query)
+			result, err := provider.runElasticQuery(ctx, metricsapi.KeptnMetricsProvider{}, tt.query)
 
 			if tt.expectedError {
 				assert.Error(t, err)


### PR DESCRIPTION
fixes a bug for  https://github.com/keptn/lifecycle-toolkit/issues/3727

Hey @mowies @odubajDT  there is a small bug when using elastic as a provider. Previously we have not included the provider info now I have modified to include it. Can you please have a look at this? It is a continuation of the PR https://github.com/keptn/lifecycle-toolkit/pull/3890