### PR TITLE
fix: fix an issue with elastic when we try to pull multiple metrics 

### DIFF
--- a/metrics-operator/controllers/common/providers/elastic/elastic.go
+++ b/metrics-operator/controllers/common/providers/elastic/elastic.go
@@ -159,7 +159,7 @@ func (r *KeptnElasticProvider) extractMetric(result map[string]interface{}, metr
 			}
 		}
 	}
-	return "", nil
+	return "0", nil
 }
 
 // convertResultTOMap recursively converts map[string]interface{} to map[string]float64

--- a/metrics-operator/controllers/common/providers/elastic/elastic_test.go
+++ b/metrics-operator/controllers/common/providers/elastic/elastic_test.go
@@ -201,7 +201,7 @@ func TestExtractMetric(t *testing.T) {
 				},
 			},
 			metricPath:    "metrics.cpu",
-			expectedValue: "",
+			expectedValue: "0",
 		},
 		{
 			name: "Success - Comma Separated Paths",
@@ -223,7 +223,7 @@ func TestExtractMetric(t *testing.T) {
 				},
 			},
 			metricPath:    "metrics.cpu",
-			expectedValue: "",
+			expectedValue: "0",
 		},
 	}
 


### PR DESCRIPTION
fixes a bug for https://github.com/keptn/lifecycle-toolkit/issues/3727

This PR addresses an issue with Elastic as a provider. Previously, we encountered difficulties in retrieving metrics from multiple aggregations. However, this PR has resolved the issue, and we can now provide multiple metric paths. Additionally, I have updated the unit tests to reflect these code changes.

CC:- @mowies @odubajDT